### PR TITLE
Fix depcrecation warning that interrupts users' testing/use flow

### DIFF
--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2020-2021 Pinecone Systems Inc. All right reserved.
 #
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from pinecone import Config
 from pinecone.core.client import ApiClient, Configuration


### PR DESCRIPTION
While running integration tests against pinecone, I got:

```
../related-content-api/lib/python3.8/site-packages/pinecone/index.py:5
  /Users/chelseatroy/workspace/related-content-api/related-content-api/lib/python3.8/site-packages/pinecone/index.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

This one-line change addresses that warning. 