### PR TITLE
Fix "Connection Reset by peer" error after long idle periods

### DIFF
--- a/pinecone/config.py
+++ b/pinecone/config.py
@@ -186,8 +186,11 @@ class _CONFIG:
             socket_params += [(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, keep_alive_tries)]
 
         # TCP Keep Alive Probes for Windows OS
-        elif platform == 'win32' and hasattr(socket, "SIO_KEEPALIVE_VALS"):
-            socket_params += [(socket.SIO_KEEPALIVE_VALS, (1, keep_alive_idle_sec * 1000, keep_alive_interval_sec * 1000))]
+        # NOTE: Changing TCP KA params on windows is done via a different mechanism which OpenAPI's Rest client doesn't expose.
+        # Since the default values work well, it seems setting `(socket.SO_KEEPALIVE, 1)` is sufficient.
+        # Leaving this code here for future reference.
+        # elif platform == 'win32' and hasattr(socket, "SIO_KEEPALIVE_VALS"):
+        #     socket.ioctl((socket.SIO_KEEPALIVE_VALS, (1, keep_alive_idle_sec * 1000, keep_alive_interval_sec * 1000)))
 
         # TCP Keep Alive Probes for Mac OS
         elif platform == 'darwin':

--- a/pinecone/config.py
+++ b/pinecone/config.py
@@ -2,17 +2,22 @@
 # Copyright (c) 2020-2021 Pinecone Systems Inc. All right reserved.
 #
 import logging
-from typing import NamedTuple
+import sys
+from typing import NamedTuple, List
 import os
 
 import certifi
 import requests
 import configparser
+import socket
+
+from urllib3.connection import HTTPConnection
 
 from pinecone.core.client.exceptions import ApiKeyError
 from pinecone.core.api_action import ActionAPI, WhoAmIResponse
 from pinecone.core.utils import warn_deprecated
-from pinecone.core.utils.constants import CLIENT_VERSION, PARENT_LOGGER_NAME, DEFAULT_PARENT_LOGGER_LEVEL
+from pinecone.core.utils.constants import CLIENT_VERSION, PARENT_LOGGER_NAME, DEFAULT_PARENT_LOGGER_LEVEL, \
+    TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
 from pinecone.core.client.configuration import Configuration as OpenApiConfiguration
 
 __all__ = [
@@ -109,6 +114,8 @@ class _CONFIG:
                 or default_openapi_config
         )
 
+        openapi_config.socket_options = self._get_socket_options()
+
         config = config._replace(openapi_config=openapi_config)
         self._config = config
 
@@ -143,6 +150,51 @@ class _CONFIG:
                 if "default" in parser.sections():
                     config_obj = {**parser["default"]}
         return config_obj
+
+    @staticmethod
+    def _get_socket_options(do_keep_alive: bool = True,
+                            keep_alive_idle_sec: int = TCP_KEEPIDLE,
+                            keep_alive_interval_sec: int = TCP_KEEPINTVL,
+                            keep_alive_tries: int = TCP_KEEPCNT
+                            ) -> List[tuple]:
+        """
+        Returns the socket options to pass to OpenAPI's Rest client
+        Args:
+            do_keep_alive: Whether to enable TCP keep alive mechanism
+            keep_alive_idle_sec: Time in seconds of connection idleness before starting to send keep alive probes
+            keep_alive_interval_sec: Interval time in seconds between keep alive probe messages
+            keep_alive_tries: Number of failed keep alive tries (unanswered KA messages) before terminating the connection
+
+        Returns:
+            A list of socket options for the Rest client's connection pool
+        """
+        # Source: https://www.finbourne.com/blog/the-mysterious-hanging-client-tcp-keep-alives
+
+        socket_params = HTTPConnection.default_socket_options
+        if not do_keep_alive:
+            return socket_params
+
+        socket_params += [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+        # TCP Keep Alive Probes for different platforms
+        platform = sys.platform
+        # TCP Keep Alive Probes for Linux
+        if platform == 'linux' and hasattr(socket, "TCP_KEEPIDLE") and hasattr(socket, "TCP_KEEPINTVL") \
+                and hasattr(socket, "TCP_KEEPCNT"):
+            socket_params += [(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, keep_alive_idle_sec)]
+            socket_params += [(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, keep_alive_interval_sec)]
+            socket_params += [(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, keep_alive_tries)]
+
+        # TCP Keep Alive Probes for Windows OS
+        elif platform == 'win32' and hasattr(socket, "SIO_KEEPALIVE_VALS"):
+            socket_params += [(socket.SIO_KEEPALIVE_VALS, (1, keep_alive_idle_sec * 1000, keep_alive_interval_sec * 1000))]
+
+        # TCP Keep Alive Probes for Mac OS
+        elif platform == 'darwin':
+            TCP_KEEPALIVE = 0x10
+            socket_params += [(socket.IPPROTO_TCP, TCP_KEEPALIVE, keep_alive_interval_sec)]
+
+        return socket_params
 
     @property
     def ENVIRONMENT(self):

--- a/pinecone/core/utils/constants.py
+++ b/pinecone/core/utils/constants.py
@@ -33,3 +33,7 @@ class NodeType(str, enum.Enum):
 PACKAGE_ENVIRONMENT = get_environment() or "development"
 CLIENT_VERSION = get_version()
 CLIENT_ID = f'python-client-{CLIENT_VERSION}'
+
+TCP_KEEPINTVL = 60   # Sec
+TCP_KEEPIDLE = 300   # Sec
+TCP_KEEPCNT = 4


### PR DESCRIPTION
It seems that OpenAPI's inherent Rest client uses connection pooling without a keep alive mechanism.  
In some cases, the client keeps holding an idle connection for long periods (>15 min), yet the server (Pinecone's load balancer) seem to be terminating the connection after ~10 minutes of idleness.  

I've configured OpenAPI's client to enable Keep Alive for all connections. Since the LB is configured to terminate the connection regardless of keep alive, this won't lead to having many dangling connections.  
The main benefit is having the client "finding out" early about the dropped connection, so it won't try to use it for the next user request.  

I've tested the solution (manually) on Both Mac OS, Linux and Windows Server OSes - and it seems to resolve the failure.