### PR TITLE
Fix typo in config.py

### DIFF
--- a/pinecone/config.py
+++ b/pinecone/config.py
@@ -37,7 +37,7 @@ class _CONFIG:
 
     Order of configs to load:
 
-    - configs specified explictly in reset
+    - configs specified explicitly in reset
     - environment variables
     - configs specified in the INI file
     - default configs


### PR DESCRIPTION
explictly -> explicitly