### PR TITLE
Index.upsert() now accepts List[dict]

### DIFF
--- a/pinecone/core/grpc/index_grpc.py
+++ b/pinecone/core/grpc/index_grpc.py
@@ -3,7 +3,6 @@
 #
 import logging
 import numbers
-import warnings
 from abc import ABC, abstractmethod
 from functools import wraps
 from typing import NamedTuple, Optional, Dict, Iterable, Union, List, Tuple, Any
@@ -340,8 +339,8 @@ class GRPCIndex(GRPCIndexBase):
 
             excessive_keys = item_keys - (REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)
             if len(excessive_keys) > 0:
-                warnings.warn(f"Found excessive keys in the vector dictionary: {list(excessive_keys)}. "
-                              f"These keys will be ignored. The allowed keys are: {list(REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)}")
+                raise ValueError(f"Found excess keys in the vector dictionary: {list(excessive_keys)}. "
+                                 f"The allowed keys are: {list(REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)}")
 
             sparse_values = None
             if 'sparse_values' in item:
@@ -377,7 +376,7 @@ class GRPCIndex(GRPCIndexBase):
                 if len(item) > 3:
                     raise ValueError(f"Found a tuple of length {len(item)} which is not supported. " 
                                      f"Vectors can be represented as tuples either the form (id, values, metadata) or (id, values). "
-                                     f"To pass sparse values please use either dicts or a GRPCVector objects as inputs.")
+                                     f"To pass sparse values please use either dicts or GRPCVector objects as inputs.")
                 id, values, metadata = fix_tuple_length(item, 3)
                 return GRPCVector(id=id, values=values, metadata=dict_to_proto_struct(metadata) or {})
             elif isinstance(item, Mapping):

--- a/pinecone/core/grpc/index_grpc.py
+++ b/pinecone/core/grpc/index_grpc.py
@@ -5,6 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from functools import wraps
 from typing import NamedTuple, Optional, Dict, Iterable, Union, List, Tuple, Any
+from collections.abc import Mapping
 
 import certifi
 import grpc
@@ -263,7 +264,7 @@ class GRPCIndex(GRPCIndexBase):
         return VectorServiceStub
 
     def upsert(self,
-               vectors: Union[List[GRPCVector], List[Tuple]],
+               vectors: Union[List[GRPCVector], List[tuple], List[dict]],
                async_req: bool = False,
                namespace: Optional[str] = None,
                batch_size: Optional[int] = None,
@@ -274,18 +275,25 @@ class GRPCIndex(GRPCIndexBase):
         If a new value is upserted for an existing vector id, it will overwrite the previous value.
 
         Examples:
-            >>> index.upsert([('id1', [1.0, 2.0, 3.0], {'key': 'value'}), ('id2', [1.0, 2.0, 3.0])],
-            >>>               namespace='ns1', async_req=True)
+            >>> index.upsert([('id1', [1.0, 2.0, 3.0], {'key': 'value'}),
+                              ('id2', [1.0, 2.0, 3.0])
+                              ],
+                              namespace='ns1', async_req=True)
+            >>> index.upsert([{'id': 'id1', 'values': [1.0, 2.0, 3.0], 'metadata': {'key': 'value'}},
+                              {'id': 'id2',
+                                        'values': [1.0, 2.0, 3.0],
+                                        'sprase_values': {'indices': [1, 8], 'values': [0.2, 0.4]},
+                              ])
             >>> index.upsert([GRPCVector(id='id1', values=[1.0, 2.0, 3.0], metadata={'key': 'value'}),
-            >>>               GRPCVector(id='id2', values=[1.0, 2.0, 3.0]),
-            >>>               GRPCVector(id='id3',
-            >>>                          values=[1.0, 2.0, 3.0],
-            >>>                          sparse_values=GRPCSparseValues(indices=[1, 2], values=[0.2, 0.4]))])
+                              GRPCVector(id='id2', values=[1.0, 2.0, 3.0]),
+                              GRPCVector(id='id3',
+                                         values=[1.0, 2.0, 3.0],
+                                         sparse_values=GRPCSparseValues(indices=[1, 2], values=[0.2, 0.4]))])
 
         Args:
             vectors (Union[List[Vector], List[Tuple]]): A list of vectors to upsert.
 
-                     A vector can be represented by a 1) GRPCVector object or a 2) tuple.
+                     A vector can be represented by a 1) GRPCVector object, a 2) tuple or 3) a dictionary
                      1) if a tuple is used, it must be of the form (id, values, metadata) or (id, values).
                         where id is a string, vector is a list of floats, and metadata is a dict.
                         Examples: ('id1', [1.0, 2.0, 3.0], {'key': 'value'}), ('id2', [1.0, 2.0, 3.0])
@@ -298,6 +306,10 @@ class GRPCIndex(GRPCIndexBase):
                                  GRPCVector(id='id3',
                                             values=[1.0, 2.0, 3.0],
                                             sparse_values=GRPCSparseValues(indices=[1, 2], values=[0.2, 0.4]))
+
+                    3) if a dictionary is used, it must be in the form
+                       {'id': str, 'values': List[float], 'sparse_values': {'indices': List[int], 'values': List[float]},
+                        'metadata': dict}
 
                     Note: the dimension of each vector must match the dimension of the index.
             async_req (bool): If True, the upsert operation will be performed asynchronously.
@@ -320,9 +332,20 @@ class GRPCIndex(GRPCIndexBase):
         def _vector_transform(item):
             if isinstance(item, GRPCVector):
                 return item
-            if isinstance(item, tuple):
+            elif isinstance(item, tuple):
+                if len(item) > 3:
+                    raise ValueError(f"Found a tuple of length {len(item)} which is not supported. " 
+                                     f"Vectors can be represented as tuples either the form (id, values, metadata) or (id, values). "
+                                     f"To pass sparse values please use either dicts or a GRPCVector objects as inputs.")
                 id, values, metadata = fix_tuple_length(item, 3)
                 return GRPCVector(id=id, values=values, metadata=dict_to_proto_struct(metadata) or {})
+            elif isinstance(item, Mapping):
+                sparse_values = None
+                if 'sparse_values' in item:
+                    indices = item['sparse_values'].get('indices', None)
+                    values = item['sparse_values'].get('values', None)
+                    sparse_values = GRPCSparseValues(indices=indices, values=values)
+                return GRPCVector(id=item['id'], values=item['values'], sparse_values=sparse_values, metadata=dict_to_proto_struct(item.get('metadata', None)))
             raise ValueError(f"Invalid vector value passed: cannot interpret type {type(item)}")
 
         timeout = kwargs.pop('timeout', None)

--- a/pinecone/core/utils/constants.py
+++ b/pinecone/core/utils/constants.py
@@ -37,3 +37,6 @@ CLIENT_ID = f'python-client-{CLIENT_VERSION}'
 TCP_KEEPINTVL = 60   # Sec
 TCP_KEEPIDLE = 300   # Sec
 TCP_KEEPCNT = 4
+
+REQUIRED_VECTOR_FIELDS = {'id', 'values'}
+OPTIONAL_VECTOR_FIELDS = {'sparse_values', 'metadata'}

--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -1,6 +1,9 @@
 #
 # Copyright (c) 2020-2021 Pinecone Systems Inc. All right reserved.
 #
+import numbers
+import warnings
+
 from tqdm import tqdm
 from collections.abc import Iterable, Mapping
 from typing import Union, List, Tuple, Optional, Dict, Any
@@ -21,6 +24,7 @@ __all__ = [
     "UpdateRequest", "Vector", "DeleteRequest", "UpdateRequest", "DescribeIndexStatsRequest", "SparseValues"
 ]
 
+from .core.utils.constants import REQUIRED_VECTOR_FIELDS, OPTIONAL_VECTOR_FIELDS
 from .core.utils.error_handling import validate_and_convert_errors
 
 _OPENAPI_ENDPOINT_PARAMS = (
@@ -162,6 +166,45 @@ class Index(ApiClient):
 
         args_dict = self._parse_non_empty_args([('namespace', namespace)])
 
+        def _dict_to_vector(item):
+            item_keys = set(item.keys())
+            if not item_keys.issuperset(REQUIRED_VECTOR_FIELDS):
+                raise ValueError(
+                    f"Vector dictionary is missing required fields: {list(REQUIRED_VECTOR_FIELDS - item_keys)}")
+
+            excessive_keys = item_keys - (REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)
+            if len(excessive_keys) > 0:
+                warnings.warn(f"Found excessive keys in the vector dictionary: {list(excessive_keys)}. "
+                              f"These keys will be ignored. The allowed keys are: {list(REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)}")
+
+            sparse_values = None
+            if 'sparse_values' in item:
+                if not isinstance(item['sparse_values'], Mapping):
+                    raise ValueError(
+                        f"Column `sparse_values` is expected to be a dictionary, found {type(item['sparse_values'])}")
+                indices = item['sparse_values'].get('indices', None)
+                values = item['sparse_values'].get('values', None)
+                try:
+                    sparse_values = SparseValues(indices=indices, values=values)
+                except TypeError as e:
+                    raise ValueError("Found unexpected data in column `sparse_values`. "
+                                     "Expected format is `'sparse_values': {'indices': List[int], 'values': List[float]}`."
+                                     ) from e
+
+                metadata = item.get('metadata') or {}
+                if not isinstance(metadata, Mapping):
+                    raise TypeError(f"Column `metadata` is expected to be a dictionary, found {type(metadata)}")
+
+            try:
+                return Vector(id=item['id'], values=item['values'], sparse_values=sparse_values, metadata=metadata)
+
+            except TypeError as e:
+                # if not isinstance(item['values'], Iterable) or not isinstance(item['values'][0], numbers.Real):
+                #     raise TypeError(f"Column `values` is expected to be a list of floats")
+                if not isinstance(item['values'], Iterable) or not isinstance(item['values'][0], numbers.Real):
+                    raise TypeError(f"Column `values` is expected to be a list of floats")
+                raise
+
         def _vector_transform(item: Union[Vector, Tuple]):
             if isinstance(item, Vector):
                 return item
@@ -173,13 +216,7 @@ class Index(ApiClient):
                 id, values, metadata = fix_tuple_length(item, 3)
                 return Vector(id=id, values=values, metadata=metadata or {}, _check_type=_check_type)
             elif isinstance(item, Mapping):
-                sparse_values = None
-                if 'sparse_values' in item:
-                    indices = item['sparse_values'].get('indices', [])
-                    values = item['sparse_values'].get('values', [])
-                    sparse_values = SparseValues(indices=indices, values=values)
-                return Vector(id=item['id'], values=item['values'], sparse_values=sparse_values, metadata=item.get('metadata', {}), _check_type=_check_type)
-
+                return _dict_to_vector(item)
             raise ValueError(f"Invalid vector value passed: cannot interpret type {type(item)}")
 
         return self._vector_api.upsert(

--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2020-2021 Pinecone Systems Inc. All right reserved.
 #
 import numbers
-import warnings
 
 from tqdm import tqdm
 from collections.abc import Iterable, Mapping
@@ -174,8 +173,8 @@ class Index(ApiClient):
 
             excessive_keys = item_keys - (REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)
             if len(excessive_keys) > 0:
-                warnings.warn(f"Found excessive keys in the vector dictionary: {list(excessive_keys)}. "
-                              f"These keys will be ignored. The allowed keys are: {list(REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)}")
+                raise ValueError(f"Found excess keys in the vector dictionary: {list(excessive_keys)}. "
+                                 f"The allowed keys are: {list(REQUIRED_VECTOR_FIELDS | OPTIONAL_VECTOR_FIELDS)}")
 
             sparse_values = None
             if 'sparse_values' in item:


### PR DESCRIPTION
Upsert will now accept vectors represented as dicts. This provides a nice way to pass vectors with sparse values, rather than isntantiating `Vector()` objects

Also, this will allow us to represent entire datasets in the future as dataframes, where each vector is a dictionary (one row of the dataframe).