### PR TITLE
Upsert dataframe - support non-async option

### DIFF
--- a/pinecone/core/grpc/index_grpc.py
+++ b/pinecone/core/grpc/index_grpc.py
@@ -415,7 +415,7 @@ class GRPCIndex(GRPCIndexBase):
         request = UpsertRequest(vectors=vectors, **args_dict)
         return self._wrap_grpc_call(self.stub.Upsert, request, timeout=timeout, **kwargs)
 
-    def upsert_dataframe(self,
+    def upsert_from_dataframe(self,
                          df,
                          namespace: str = None,
                          batch_size: int = 500,

--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -214,11 +214,15 @@ class Index(ApiClient):
         if not isinstance(df, pd.DataFrame):
             raise ValueError(f"Only pandas dataframes are supported. Found: {type(df)}")
 
+        upserted_count = 0
         pbar = tqdm(total=len(df), disable=not show_progress)
         for i in range(0, len(df), batch_size):
             batch = df.iloc[i:i + batch_size].to_dict(orient="records")
-            self.upsert(batch, namespace=namespace)
+            res = self.upsert(batch, namespace=namespace)
+            upserted_count += res.upserted_count
             pbar.update(len(batch))
+
+        return UpsertResponse(upserted_count=upserted_count)
 
     @validate_and_convert_errors
     def delete(self,

--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -195,7 +195,7 @@ class Index(ApiClient):
 
     def upsert_dataframe(self,
                          df,
-                         namespase: str = None,
+                         namespace: str = None,
                          batch_size: int = 500,
                          show_progress: bool = True) -> None:
         """Upserts a dataframe into the index.
@@ -206,13 +206,18 @@ class Index(ApiClient):
             batch_size: The number of rows to upsert in a single batch.
             show_progress: Whether to show a progress bar.
         """
-        if find_spec("pandas") is None:
-            raise ImportError("pandas not found. Please install pandas to use this method.")
+        try:
+            import pandas as pd
+        except ImportError:
+            raise RuntimeError("The `pandas` package is not installed. Please install pandas to use `upsert_from_dataframe()`")
+
+        if not isinstance(df, pd.DataFrame):
+            raise ValueError(f"Only pandas dataframes are supported. Found: {type(df)}")
 
         pbar = tqdm(total=len(df), disable=not show_progress)
         for i in range(0, len(df), batch_size):
             batch = df.iloc[i:i + batch_size].to_dict(orient="records")
-            self.upsert(batch, namespace=namespase)
+            self.upsert(batch, namespace=namespace)
             pbar.update(len(batch))
 
     @validate_and_convert_errors

--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -193,7 +193,7 @@ class Index(ApiClient):
             **{k: v for k, v in kwargs.items() if k in _OPENAPI_ENDPOINT_PARAMS}
         )
 
-    def upsert_dataframe(self,
+    def upsert_from_dataframe(self,
                          df,
                          namespace: str = None,
                          batch_size: int = 500,


### PR DESCRIPTION
1. Added verification that the input is `pd.Dataframe`
1. Return the proper result type (`UpsertResponse`) with the total upserted number.
2. For gRPC - support both async and non-async modes
3. Renamed to `upsert_from_dataframe()`