### PR TITLE
Bug fix upsert(dict)

### DIFF
--- a/pinecone/core/grpc/index_grpc.py
+++ b/pinecone/core/grpc/index_grpc.py
@@ -345,19 +345,19 @@ class GRPCIndex(GRPCIndexBase):
             sparse_values = None
             if 'sparse_values' in item:
                 if not isinstance(item['sparse_values'], Mapping):
-                    raise ValueError(f"Column `sparse_values` is expected to be a dictionary, found {type(item['sparse_values'])}")
+                    raise TypeError(f"Column `sparse_values` is expected to be a dictionary, found {type(item['sparse_values'])}")
                 indices = item['sparse_values'].get('indices', None)
                 values = item['sparse_values'].get('values', None)
                 try:
                     sparse_values = GRPCSparseValues(indices=indices, values=values)
                 except TypeError as e:
-                    raise ValueError("Found unexpected data in column `sparse_values`. "
+                    raise TypeError("Found unexpected data in column `sparse_values`. "
                                      "Expected format is `'sparse_values': {'indices': List[int], 'values': List[float]}`."
                                      ) from e
 
-                metadata = item.get('metadata', None)
-                if metadata is not None and not isinstance(metadata, Mapping):
-                    raise TypeError(f"Column `metadata` is expected to be a dictionary, found {type(metadata)}")
+            metadata = item.get('metadata', None)
+            if metadata is not None and not isinstance(metadata, Mapping):
+                raise TypeError(f"Column `metadata` is expected to be a dictionary, found {type(metadata)}")
 
             try:
                 return GRPCVector(id=item['id'], values=item['values'], sparse_values=sparse_values,

--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -190,9 +190,9 @@ class Index(ApiClient):
                                      "Expected format is `'sparse_values': {'indices': List[int], 'values': List[float]}`."
                                      ) from e
 
-                metadata = item.get('metadata') or {}
-                if not isinstance(metadata, Mapping):
-                    raise TypeError(f"Column `metadata` is expected to be a dictionary, found {type(metadata)}")
+            metadata = item.get('metadata') or {}
+            if not isinstance(metadata, Mapping):
+                raise TypeError(f"Column `metadata` is expected to be a dictionary, found {type(metadata)}")
 
             try:
                 return Vector(id=item['id'], values=item['values'], sparse_values=sparse_values, metadata=metadata)


### PR DESCRIPTION
In case the user passed a vector with metadata but without sparse values, the metadata was simply ignored.  
(Caught by new UTs, which are coming in a separate PR).

The clause that parsed the `metadata` key was accidentally indented under the `if sparse_values` clause...