### PR TITLE
V2.2.1

### DIFF
--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -202,8 +202,8 @@ class Index(ApiClient):
                 if not isinstance(metadata, Mapping):
                     raise TypeError(f"Column `metadata` is expected to be a dictionary, found {type(metadata)}")
     
-                if isinstance(item['values'], np.ndarray):
-                    item['values'] = item['values'].tolist()
+            if isinstance(item['values'], np.ndarray):
+                item['values'] = item['values'].tolist()
 
             try:
                 return Vector(**item)

--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -248,7 +248,7 @@ class Index(ApiClient):
                          df,
                          namespace: str = None,
                          batch_size: int = 500,
-                         show_progress: bool = True) -> None:
+                         show_progress: bool = True) -> UpsertResponse:
         """Upserts a dataframe into the index.
 
         Args:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ tox==3.27.0
 pytest-timeout==1.4.2
 urllib3_mock==0.3.3
 responses>0.9.0
+pandas>1.5.0

--- a/tests/unit/test_grpc_index.py
+++ b/tests/unit/test_grpc_index.py
@@ -67,7 +67,6 @@ class TestGrpcIndex:
                     self.expected_vec_md2],
         )
 
-
     def test_upsert_vectors_upsertInputVectors(self, mocker):
         mocker.patch.object(self.index, '_wrap_grpc_call', autospec=True)
         self.index.upsert([self.expected_vec_md1,
@@ -208,7 +207,7 @@ class TestGrpcIndex:
         assert 'sparse' in str(e.value)
         assert key in str(e.value)
 
-    def test_updsert_dataframe(self, mocker):
+    def test_upsert_dataframe(self, mocker):
         mocker.patch.object(self.index, '_wrap_grpc_call', autospec=True,
                             side_effect=lambda stub, upsert_request, timeout: MockUpsertDelegate(UpsertResponse(
                                 upserted_count=len(upsert_request.vectors))))
@@ -226,7 +225,7 @@ class TestGrpcIndex:
         )
 
 
-    def test_updsert_dataframe_sync(self, mocker):
+    def test_upsert_dataframe_sync(self, mocker):
         mocker.patch.object(self.index, '_wrap_grpc_call', autospec=True,
                             side_effect=lambda stub, upsert_request, timeout: UpsertResponse(
                                 upserted_count=len(upsert_request.vectors)))

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from pinecone.core.client.api_client import Endpoint
@@ -56,6 +57,7 @@ class TestRestIndex:
                 pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)
             ])
         )
+
     def test_upsert_dictOfIdVecMD_UpsertVectorsWithMD(self, mocker):
         mocker.patch.object(self.index._vector_api, 'upsert', autospec=True)
         self.index.upsert([{'id': self.id1, 'values': self.vals1, 'metadata': self.md1},
@@ -77,6 +79,7 @@ class TestRestIndex:
                 pinecone.Vector(id='vec2', values=self.vals2)
             ])
         )
+
     def test_upsert_dictOfIdVecMD_UpsertVectorsWithSparseValues(self, mocker):
         mocker.patch.object(self.index._vector_api, 'upsert', autospec=True)
         self.index.upsert([{'id': self.id1, 'values': self.vals1, 'sparse_values': self.sv1},
@@ -91,8 +94,8 @@ class TestRestIndex:
     def test_upsert_vectors_upsertInputVectors(self, mocker):
         mocker.patch.object(self.index._vector_api, 'upsert', autospec=True)
         self.index.upsert(vectors=[
-                pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
-                pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)],
+            pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
+            pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)],
             namespace='ns')
         self.index._vector_api.upsert.assert_called_once_with(
             pinecone.UpsertRequest(vectors=[
@@ -140,8 +143,8 @@ class TestRestIndex:
                                 upserted_count=len(upsert_request.vectors)))
 
         result = self.index.upsert(vectors=[
-                pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
-                pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)],
+            pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
+            pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)],
             namespace='ns',
             batch_size=1,
             show_progress=False)
@@ -168,9 +171,9 @@ class TestRestIndex:
                                 upserted_count=len(upsert_request.vectors)))
 
         result = self.index.upsert(vectors=[
-                pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
-                pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2),
-                pinecone.Vector(id='vec3', values=self.vals1, metadata=self.md1)],
+            pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
+            pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2),
+            pinecone.Vector(id='vec3', values=self.vals1, metadata=self.md1)],
             namespace='ns',
             batch_size=2)
 
@@ -197,9 +200,9 @@ class TestRestIndex:
                                 upserted_count=len(upsert_request.vectors)))
 
         result = self.index.upsert(vectors=[
-                pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
-                pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2),
-                pinecone.Vector(id='vec3', values=self.vals1, metadata=self.md1)],
+            pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
+            pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2),
+            pinecone.Vector(id='vec3', values=self.vals1, metadata=self.md1)],
             namespace='ns',
             batch_size=5)
 
@@ -241,6 +244,21 @@ class TestRestIndex:
         )
 
         assert result.upserted_count == 3
+
+    def test_upsert_dataframe(self, mocker):
+        mocker.patch.object(self.index._vector_api, 'upsert', autospec=True, return_value=UpsertResponse(upserted_count=2))
+        df = pd.DataFrame([
+            {'id': self.id1, 'values': self.vals1, 'metadata': self.md1},
+            {'id': self.id2, 'values': self.vals2, 'metadata': self.md2}
+        ])
+        self.index.upsert_from_dataframe(df)
+
+        self.index._vector_api.upsert.assert_called_once_with(
+            pinecone.UpsertRequest(vectors=[
+                pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
+                pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)
+            ])
+        )
 
     def test_upsert_batchSizeIsNotPositive_errorIsRaised(self):
         with pytest.raises(ValueError, match='batch_size must be a positive integer'):

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -18,22 +18,18 @@ class TestRestIndex:
         self.md2 = {'genre': 'documentary', 'year': 2020}
         self.filter1 = {'genre': {'$in': ['action']}}
         self.filter2 = {'year': {'$eq': 2020}}
-
-
         self.svi1 = [1, 3, 5]
         self.svv1 = [0.1, 0.2, 0.3]
         self.sv1 = {
             'indices': self.svi1,
             'values': self.svv1,
         }
-
         self.svi2 = [2, 4, 6]
         self.svv2 = [0.1, 0.2, 0.3]
         self.sv2 = {
             'indices': self.svi2,
             'values': self.svv2
         }
-
 
         pinecone.init(api_key='example-key')
         self.index = pinecone.Index('example-name')

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -10,6 +10,8 @@ class TestRestIndex:
 
     def setup_method(self):
         self.vector_dim = 8
+        self.id1 = 'vec1'
+        self.id2 = 'vec2'
         self.vals1 = [0.1] * self.vector_dim
         self.vals2 = [0.2] * self.vector_dim
         self.md1 = {'genre': 'action', 'year': 2021}
@@ -40,6 +42,27 @@ class TestRestIndex:
             pinecone.UpsertRequest(vectors=[
                 pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
                 pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)
+            ])
+        )
+    def test_upsert_dictOfIdVecMD_UpsertVectorsWithMD(self, mocker):
+        mocker.patch.object(self.index._vector_api, 'upsert', autospec=True)
+        self.index.upsert([{'id': self.id1, 'values': self.vals1, 'metadata': self.md1},
+                           {'id': self.id2, 'values': self.vals2, 'metadata': self.md2}])
+        self.index._vector_api.upsert.assert_called_once_with(
+            pinecone.UpsertRequest(vectors=[
+                pinecone.Vector(id='vec1', values=self.vals1, metadata=self.md1),
+                pinecone.Vector(id='vec2', values=self.vals2, metadata=self.md2)
+            ])
+        )
+
+    def test_upsert_dictOfIdVecMD_UpsertVectorsWithoutMD(self, mocker):
+        mocker.patch.object(self.index._vector_api, 'upsert', autospec=True)
+        self.index.upsert([{'id': self.id1, 'values': self.vals1},
+                           {'id': self.id2, 'values': self.vals2}])
+        self.index._vector_api.upsert.assert_called_once_with(
+            pinecone.UpsertRequest(vectors=[
+                pinecone.Vector(id='vec1', values=self.vals1),
+                pinecone.Vector(id='vec2', values=self.vals2)
             ])
         )
 


### PR DESCRIPTION
Fix issue where empty values for `sparse_values` and `metadata` being incorrectly passed to `Vector` in `_dict_to_vector`

Adds test coverage to cases where sparse_values and metadata included and excluded in dict upserts

Issue reported in https://community.pinecone.io/t/cannot-get-upsert-to-work-no-matter-what-i-am-trying/667