### PR TITLE
use getenv instead of accessing environ obj

### DIFF
--- a/pinecone/core/utils/constants.py
+++ b/pinecone/core/utils/constants.py
@@ -12,7 +12,7 @@ DEFAULT_PARENT_LOGGER_LEVEL = 'ERROR'
 
 MAX_MSG_SIZE = 128 * 1024 * 1024
 
-MAX_ID_LENGTH = int(os.environ.get("PINECONE_MAX_ID_LENGTH", default="64"))
+MAX_ID_LENGTH = int(os.getenv("PINECONE_MAX_ID_LENGTH", default="64"))
 
 REQUEST_ID: str = "request_id"
 CLIENT_VERSION_HEADER = 'X-Pinecone-Client-Version'


### PR DESCRIPTION
I had problems importing the package after manipulating the environ object, so the "default" keyword argument was not available anymore. In this case getenv will still work.
The module using  getenv in all other occurences, so it also good to keep it consistent.