### PR TITLE
Fixing TqdmExperimentalWarning

### DIFF
--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2020-2021 Pinecone Systems Inc. All right reserved.
 #
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 from importlib.util import find_spec
 import numbers
 import numpy as np


### PR DESCRIPTION

Use of `tqdm.autonotebook` raises the following warning `TqdmExperimentalWarning` whenever pinecone is imported.

importing tqdm via `from tqdm.auto` removes the warning