### PR TITLE
chore (core): add comments to WhoAmIResponse fields

### DIFF
--- a/pinecone/core/api_action.py
+++ b/pinecone/core/api_action.py
@@ -11,9 +11,20 @@ from pinecone.core.utils import get_version
 
 
 class WhoAmIResponse(NamedTuple):
-    username: str = 'UNKNOWN'
+    """
+    Represents the response returned by the Pinecone WhoAmI API.
+
+    Example response:
+        {"project_name":"5d54712","user_label":"default","user_name":"18bd872"}
+
+    Fields:
+        - username: the user ID of the Pinecone account, rather than username
+        - user_label: the label of the user in the Pinecone account
+        - projectname: the project ID of the Pinecone account, rather projectname
+    """
+    username: str = 'UNKNOWN'  # TODO:  should be named as user_id
     user_label: str = 'UNKNOWN'
-    projectname: str = 'UNKNOWN'
+    projectname: str = 'UNKNOWN'  # TODO:  should be named as project_id
 
 
 class VersionResponse(NamedTuple):


### PR DESCRIPTION
Add comments to the `WhoAmIResponse` fields to better describe their meaning, as they can be ambiguous. The `username` field should be named `user_id` to better reflect its meaning, and `projectname` should be named `project_id` for consistency. No functional changes were made.

So, it can be merged as is. I hope it will help to fix any bugs with naming and prevent new bugs from arising in the future.

Take a look https://github.com/pinecone-io/pinecone-python-client/issues/154#issuecomment-1486775026
