### PR TITLE
Fix tox configs for CI testing

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,6 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ pytest-mock==3.6.1
 tox==3.27.0
 pytest-timeout==1.4.2
 urllib3_mock==0.3.3
-responses>0.9.0
+responses>=0.8.1
 pandas>1.5.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,4 @@ tox==3.27.0
 pytest-timeout==1.4.2
 urllib3_mock==0.3.3
 responses>=0.8.1
-pandas>1.5.0
+pandas>=1.3.5

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,7 @@ import pinecone
 from pinecone.config import Config
 
 
-def test_multi_init():
+def _test_multi_init():
     env = 'test-env'
     api_key = 'foobar'
     # first init() sets api_key

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,7 @@ import pinecone
 from pinecone.config import Config
 
 
-def _test_multi_init():
+def test_multi_init():
     env = 'test-env'
     api_key = 'foobar'
     # first init() sets api_key

--- a/tests/unit/test_grpc_index.py
+++ b/tests/unit/test_grpc_index.py
@@ -164,8 +164,6 @@ class TestGrpcIndex:
             assert 'metadatta' in str(e.value)
 
     @pytest.mark.parametrize("key,new_val", [
-        ("id", 4.2),
-        ("id", ['vec1']),
         ("values", ['the', 'lazy', 'fox']),
         ("values", 'the lazy fox'),
         ("values", 0.5),
@@ -174,7 +172,24 @@ class TestGrpcIndex:
         ("sparse_values", 'cat'),
         ("sparse_values", []),
     ])
-    def test_upsert_dict_negative_types(self, mocker, key, new_val):
+    def test_upsert_dict_with_invalid_values(self, mocker, key, new_val):
+        mocker.patch.object(self.index, '_wrap_grpc_call', autospec=True)
+
+        full_dict1 = {'id': 'vec1', 'values': self.vals1,
+                      'sparse_values': {'indices': self.sparse_indices_1, 'values': self.sparse_values_1},
+                      'metadata': self.md1}
+
+        dict1 = deepcopy(full_dict1)
+        dict1[key] = new_val
+        with pytest.raises(TypeError) as e:
+            self.index.upsert([dict1])
+        assert key in str(e.value)
+    
+    @pytest.mark.parametrize("key,new_val", [
+        ("id", 4.2),
+        ("id", ['vec1']),
+    ])
+    def test_upsert_dict_with_invalid_ids(self, mocker, key, new_val):
         mocker.patch.object(self.index, '_wrap_grpc_call', autospec=True)
 
         full_dict1 = {'id': 'vec1', 'values': self.vals1,
@@ -193,7 +208,7 @@ class TestGrpcIndex:
         ("values", ['1', '4.4']),
         ("values", 0.5),
     ])
-    def test_upsert_dict_negative_types_sparse(self, mocker, key, new_val):
+    def test_upsert_dict_with_invalid_sparse_values(self, mocker, key, new_val):
         mocker.patch.object(self.index, '_wrap_grpc_call', autospec=True)
 
         full_dict1 = {'id': 'vec1', 'values': self.vals1,

--- a/tests/unit/test_grpc_index.py
+++ b/tests/unit/test_grpc_index.py
@@ -200,7 +200,7 @@ class TestGrpcIndex:
         dict1[key] = new_val
         with pytest.raises(TypeError) as e:
             self.index.upsert([dict1])
-        assert key in str(e.value)
+        assert str(new_val) in str(e.value)
 
     @pytest.mark.parametrize("key,new_val", [
         ("indices", 3),

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = py37, py38, py39, flake8, docs
+envlist = 
+  py37-old_deps_yes,
+  py{38,39},
+  flake8,
+  docs
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,15 @@ skip_missing_interpreters = true
 [testenv]
 setenv = HOSTNAME=hostname
 deps=
+  -r {toxinidir}/requirements.txt
+  -r {toxinidir}/test-requirements.txt
+  -r {toxinidir}/requirements-grpc.txt
+commands =
+  pytest --cov=pinecone --timeout=120 tests/unit {posargs}
+
+[testenv:py37-old_deps_yes]
+description = Run tests with old dependencies
+deps = 
   old_deps_yes: requests==2.19.0
   old_deps_yes: pyyaml==5.4
   old_deps_yes: loguru==0.5.0
@@ -17,18 +26,16 @@ deps=
   old_deps_yes: dnspython==2.0.0
   old_deps_yes: python_dateutil==2.5.3
   old_deps_yes: urllib3==1.21.1
-  -r {toxinidir}/requirements.txt
-  -r {toxinidir}/test-requirements.txt
-  -r {toxinidir}/requirements-grpc.txt
-commands =
-  pytest --cov=pinecone --timeout=120 tests/unit {posargs}
+  {[testenv]deps}
+commands = {[testenv]commands}
+
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
-    '3.10': py310
+    3.10: py310
     3.11: py311
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, flake8, docs
+envlist = py39, flake8, docs
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -9,15 +9,6 @@ skip_missing_interpreters = true
 [testenv]
 setenv = HOSTNAME=hostname
 deps=
-  -r {toxinidir}/requirements.txt
-  -r {toxinidir}/test-requirements.txt
-  -r {toxinidir}/requirements-grpc.txt
-commands =
-  pytest --cov=pinecone --timeout=120 tests/unit {posargs}
-
-[testenv:py37-old_deps_yes]
-description = Run tests with old dependencies
-deps = 
   old_deps_yes: requests==2.19.0
   old_deps_yes: pyyaml==5.4
   old_deps_yes: loguru==0.5.0
@@ -28,9 +19,11 @@ deps =
   old_deps_yes: urllib3==1.21.1
   old_deps_yes: pandas==1.3.5
   old_deps_yes: responses==0.8.1
-  {[testenv]deps}
-commands = {[testenv]commands}
-
+  -r {toxinidir}/requirements.txt
+  -r {toxinidir}/test-requirements.txt
+  -r {toxinidir}/requirements-grpc.txt
+commands =
+  pytest --cov=pinecone --timeout=120 tests/unit {posargs}
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-  py{36,37}-old_deps_yes,
+  py37-old_deps_yes,
   py{38,39,310,311},
   flake8,
   docs
@@ -27,7 +27,6 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist = 
-  py37-old_deps_yes,
+  py{36,37}-old_deps_yes,
   py{38,39,310,311},
   flake8,
   docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, flake8, docs
+envlist = py37, py38, py39, flake8, docs
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = 
   py37-old_deps_yes,
-  py{38,39},
+  py{38,39,310,311},
   flake8,
   docs
 skip_missing_interpreters = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, py311, flake8, docs
+envlist = py39, py310, py311, flake8, docs
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ deps =
   old_deps_yes: dnspython==2.0.0
   old_deps_yes: python_dateutil==2.5.3
   old_deps_yes: urllib3==1.21.1
+  old_deps_yes: pandas==1.3.5
+  old_deps_yes: responses==0.8.1
   {[testenv]deps}
 commands = {[testenv]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,docs
+envlist = py37, py38, py39, py310, py311, flake8, docs
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps=
   old_deps_yes: typing-extensions==3.7.4
   old_deps_yes: sentry-sdk==1.0.0
   old_deps_yes: dnspython==2.0.0
-  old_deps_yes: python_dateutil==2.5.3
+  old_deps_yes: python_dateutil==2.7.3
   old_deps_yes: urllib3==1.21.1
   old_deps_yes: pandas==1.3.5
   old_deps_yes: responses==0.8.1


### PR DESCRIPTION
## Problem

I discovered recently that tests have not been running in CI because some configuration for our test orchestrator [`tox`](https://tox.wiki/en/latest/config.html) were [accidentally removed](https://github.com/pinecone-io/pinecone-python-client/commit/10fb42c2983b731700ffe89183994cd4e1844020). This fact was obscured because the CI configuration specifying a matrix of python versions to test meant several versions of the workflow were kicking off, but if you look carefully you'd see no tests were actually executing.

## Solution

1. Add and iterate on configuration to `tox.ini`, the configuration for the tox test orchestrator. I'm new to this tool, but it seems that tox works in conjunction with [tox-gh-actions](https://github.com/ymyzk/tox-gh-actions) and the github matrix strategy to execute tests on multiple versions of python. We have to declare each test environment, and map those names to `gh-actions` names for these environments in an additional configuration section in the `tox.ini` file.

2. Make some adjustments to the "old deps" versions in order to get the python 3.7 installation & tests to run.

3. Fix tests that are revealed to be failing once all tests are running in CI. The changes are fairly minor, basically splitting up one of the parameterized tests so I could make a small adjustment to the assertion being made when invalid vector is are passed to upsert.

## Test Plan

Look closely at the checks that are running, and observe that test output shows the builds actually ran tests.

### Other changes and notes

- Bumped us up to `actions/setup-python@v4` from `actions/setup-python@v2` to fix a deprecation error message.
- I omitted Python 3.6 from the test matrix since it was end-of-life in 2021 and is no longer supported by github actions for testing on `ubuntu-latest`. A [relevant comment](https://github.com/actions/setup-python/issues/544#issuecomment-1332535877).