### PR TITLE
Add PR templated

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Problem
+
+Describe the purpose of this change. What problem is being solved and why?
+
+## Solution
+
+Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Non-code change (docs, CI config, etc)
+- [ ] None of the above: (explain here)
+
+## Test Plan
+
+Describe specific steps for validating this change.


### PR DESCRIPTION
## Problem

Some PRs would be easier to review with additional context shared in the description.

## Solution

Add a PR [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to guide people toward including more information about their changes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Non-code change (docs, CI config, etc)
- [ ] None of the above: (explain here)
