### PR TITLE
Update numpy dependency version

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,6 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, '3.10', 3.11]
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, '3.10', 3.11]
 

--- a/pinecone/core/utils/__init__.py
+++ b/pinecone/core/utils/__init__.py
@@ -26,7 +26,7 @@ def dump_numpy_public(np_array: 'np.ndarray', compressed: bool = False) -> 'vect
     """
     Dump numpy array to vector_column_service_pb2.NdArray
     """
-    warn_deprecated('dump_numpy_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
+    warn_deprecated('dump_numpy_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.1', removal_in='3.0.0')
     protobuf_arr = vector_column_service_pb2.NdArray()
     protobuf_arr.dtype = str(np_array.dtype)
     protobuf_arr.shape.extend(np_array.shape)
@@ -39,7 +39,7 @@ def dump_numpy_public(np_array: 'np.ndarray', compressed: bool = False) -> 'vect
 
 
 def dump_strings_public(strs: List[str], compressed: bool = False) -> 'vector_column_service_pb2.NdArray':
-    warn_deprecated('dump_strings_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
+    warn_deprecated('dump_strings_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.1', removal_in='3.0.0')
     return dump_numpy_public(np.array(strs, dtype='S'), compressed=compressed)
 
 
@@ -92,7 +92,7 @@ def load_numpy_public(proto_arr: 'vector_column_service_pb2.NdArray') -> 'np.nda
     :param proto_arr:
     :return:
     """
-    warn_deprecated('load_numpy_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
+    warn_deprecated('load_numpy_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.1', removal_in='3.0.0')
     if len(proto_arr.shape) == 0:
         return np.array([])
     if proto_arr.compressed:
@@ -103,7 +103,7 @@ def load_numpy_public(proto_arr: 'vector_column_service_pb2.NdArray') -> 'np.nda
 
 
 def load_strings_public(proto_arr: 'vector_column_service_pb2.NdArray') -> List[str]:
-    warn_deprecated('load_strings_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
+    warn_deprecated('load_strings_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.1', removal_in='3.0.0')
     return [str(item, 'utf-8') for item in load_numpy_public(proto_arr)]
 
 def warn_deprecated(description: str = '', deprecated_in: str = None, removal_in: str = None):

--- a/pinecone/core/utils/__init__.py
+++ b/pinecone/core/utils/__init__.py
@@ -26,6 +26,7 @@ def dump_numpy_public(np_array: 'np.ndarray', compressed: bool = False) -> 'vect
     """
     Dump numpy array to vector_column_service_pb2.NdArray
     """
+    warn_deprecated('dump_numpy_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
     protobuf_arr = vector_column_service_pb2.NdArray()
     protobuf_arr.dtype = str(np_array.dtype)
     protobuf_arr.shape.extend(np_array.shape)
@@ -38,6 +39,7 @@ def dump_numpy_public(np_array: 'np.ndarray', compressed: bool = False) -> 'vect
 
 
 def dump_strings_public(strs: List[str], compressed: bool = False) -> 'vector_column_service_pb2.NdArray':
+    warn_deprecated('dump_strings_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
     return dump_numpy_public(np.array(strs, dtype='S'), compressed=compressed)
 
 
@@ -90,6 +92,7 @@ def load_numpy_public(proto_arr: 'vector_column_service_pb2.NdArray') -> 'np.nda
     :param proto_arr:
     :return:
     """
+    warn_deprecated('load_numpy_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
     if len(proto_arr.shape) == 0:
         return np.array([])
     if proto_arr.compressed:
@@ -100,9 +103,9 @@ def load_numpy_public(proto_arr: 'vector_column_service_pb2.NdArray') -> 'np.nda
 
 
 def load_strings_public(proto_arr: 'vector_column_service_pb2.NdArray') -> List[str]:
+    warn_deprecated('load_strings_public and all numpy-related features will be removed in a future version', deprecated_in='2.2.0', removal_in='3.0.0')
     return [str(item, 'utf-8') for item in load_numpy_public(proto_arr)]
-
 
 def warn_deprecated(description: str = '', deprecated_in: str = None, removal_in: str = None):
     message = f'DEPRECATED since v{deprecated_in} [Will be removed in v{removal_in}]: {description}'
-    warnings.warn(message, DeprecationWarning)
+    warnings.warn(message, FutureWarning)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ dnspython>=2.0.0
 python_dateutil >= 2.5.3
 urllib3 >= 1.21.1
 tqdm >= 4.64.1
-numpy
+numpy >= 1.22.0

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -1,5 +1,7 @@
 import pandas as pd
+import numpy as np
 import pytest
+import warnings
 
 from pinecone.core.client.api_client import Endpoint
 
@@ -34,8 +36,15 @@ class TestRestIndex:
 
         pinecone.init(api_key='example-key')
         self.index = pinecone.Index('example-name')
-
-    # region: upsert tests
+    
+    def test_upsert_numpy_deprecation_warning(self, mocker):
+        mocker.patch.object(self.index._vector_api, 'upsert', autospec=True)
+        with pytest.warns(FutureWarning):
+            # numpy used in dictionary values
+            self.index.upsert([{'id': '2', 'values': np.array([3.0, 3.2, 4.2])}])
+        with pytest.warns(FutureWarning):
+            # numpy used in dictionary sparse_values
+            self.index.upsert([{'id': '3', 'values': [0.5,0.5,0.5], 'sparse_values': { 'indices': np.array([0, 1]), 'values': np.array([3.0, 3.2])}}])
 
     def test_upsert_tuplesOfIdVec_UpserWithoutMD(self, mocker):
         mocker.patch.object(self.index._vector_api, 'upsert', autospec=True)


### PR DESCRIPTION
## Problem

Need to update numpy dependency version to pull in recent security updates. In the future we plan to remove our direct dependency on numpy.

## Solution

- Update numpy to >= 1.22.0
- Add deprecation notices where numpy is currently being used. Notices are emitted using the `warnings` [package from the Python standard library](https://docs.python.org/3.8/library/warnings.html) which will only display the message one time.
- Adjust our deprecation utility to emit warning type `FutureWarning` because `DeprecationWarning` is suppressed by default and almost nobody will see it. 

## Other notes
- The deprecation warning messages give guidance on how to fix usage, but if anyone wants to suppress the messages without making a change right now, they should add this to their code.

```py
import warnings
warnings.filterwarnings(action="ignore", category=FutureWarning, module="pinecone")
```

- I don't have a good understanding of how people might be using the numpy util functions:`dump_strings_public`, `dump_numpy_public`, `load_numpy_public`, `load_strings_public`. Seems like they have been in the module for a long time but are not documented anywhere and are not used internally. If anyone cares about them, I'm hoping they will speak up after seeing the deprecation notice to let us know. 

## Type of Change

- [x] None of the above: Dependency update

## Test Plan

Added a new test case asserting the deprecation warning is emitted when expected (when numpy ndarray values are passed in as part of a dictionary value to `upsert()`.

Also did some manual testing with a small (dimension: 3) index I have. The purpose here is to verify how the error messages look and make sure they are not spamming when upsert is called multiple times.

```py
import pinecone
import numpy as np

pinecone.init(api_key="REDACTED", environment="us-east1-gcp")
index = pinecone.Index('jen-numpy-test')

print('About to call without numpy')
index.upsert([{'id': '2', 'values': [3.0, 3.2, 4.2]}])
print('Finished call without numpy. No error should be shown.')

# This should print a deprecation notice, but only the first time a numpy value is used
index.upsert([{'id': '2', 'values': np.array([3.0, 3.2, 4.2])}])
index.upsert([{'id': '3', 'values': np.array([3.0, 3.2, 4.2])}])
index.upsert([{'id': '4', 'values': np.array([3.0, 3.2, 4.2])}])
print('Should only see one deprecation notice up to this point.')

# This is a different code path, so it should print an additional deprecation notice for each sparse_values field using np
index.upsert([{'id': '5', 'values': [0.0,0.0,0.0], 'sparse_values': { 'indices': np.array([0, 1]), 'values': np.array([3.0, 3.2])}}])
index.upsert([{'id': '6', 'values': [0.0,0.0,0.0], 'sparse_values': { 'indices': np.array([0, 1]), 'values': np.array([3.0, 3.2])}}])
index.upsert([{'id': '7', 'values': [0.0,0.0,0.0], 'sparse_values': { 'indices': np.array([0, 1]), 'values': np.array([3.0, 3.2])}}])
index.upsert([{'id': '8', 'values': [0.0,0.0,0.0], 'sparse_values': { 'indices': np.array([0, 1]), 'values': np.array([3.0, 3.2])}}])
print('Should see a total of 3 deprecated notices up to this point despite many calls.')
```

This gave the following output:

```
About to call without numpy
Finished call without numpy. No error should be shown.
/Users/jhamon/workspace/pinecone-python-client/pinecone/core/utils/__init__.py:111: FutureWarning: DEPRECATED since v2.2.1 [Will be removed in v3.0.0]: Deprecated type passed in 'values'. The ability to pass a numpy ndarray as part of a dictionary argument to upsert() will be removed in a future version of the pinecone client. To remove this warning, use the numpy.ndarray.tolist method to convert your ndarray into a python list before calling upsert().
  warnings.warn(message, FutureWarning)
Should only see one deprecation notice up to this point.
/Users/jhamon/workspace/pinecone-python-client/pinecone/core/utils/__init__.py:111: FutureWarning: DEPRECATED since v2.2.1 [Will be removed in v3.0.0]: Deprecated type passed in sparse_values['values']. The ability to pass a numpy ndarray as part of a dictionary argument to upsert() will be removed in a future version of the pinecone client. To remove this warning, use the numpy.ndarray.tolist method to convert your ndarray into a python list before calling upsert().
  warnings.warn(message, FutureWarning)
/Users/jhamon/workspace/pinecone-python-client/pinecone/core/utils/__init__.py:111: FutureWarning: DEPRECATED since v2.2.1 [Will be removed in v3.0.0]: Deprecated type passed in sparse_values['indices']. The ability to pass a numpy ndarray as part of a dictionary argument to upsert() will be removed in a future version of the pinecone client. To remove this warning, use the numpy.ndarray.tolist method to convert your ndarray into a python list before calling upsert().
  warnings.warn(message, FutureWarning)
Should see a total of 3 deprecated notices up to this point despite many calls.
```
