### PR TITLE
Update python_requires to 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         "grpc": read("requirements-grpc.txt"),
     },
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     entry_points={
         'console_scripts': ['pinecone=pinecone.cli:main'],
     },


### PR DESCRIPTION
## Problem

Recently removed code related to python 3.7 support because it is EOL, but forgot to include this change to setup.py where we declare what version of python is required.

## Solution

Adjust the setup.py configuration.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)