### PR TITLE
Nightly python builds

### DIFF
--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -1,4 +1,4 @@
-name: PyPI Prerelease
+name: 'PyPI Release: Pre-Release (pinecone-client)'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -32,7 +32,7 @@ jobs:
         id: version
         run: |
             versionFile="pinecone/__version__"
-            currentDate=$(date +%Y%m%d)
+            currentDate=$(date +%Y%m%d.%s)
             versionNumber=$(cat $versionFile)
             devVersion="${versionNumber}.dev${currentDate}"
             echo "$devVersion" > $versionFile

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -32,7 +32,7 @@ jobs:
         id: version
         run: |
             versionFile="pinecone/__version__"
-            currentDate=$(date +%Y%m%d.%s)
+            currentDate=$(date +%Y%m%d-%M%S)
             versionNumber=$(cat $versionFile)
             devVersion="${versionNumber}.dev${currentDate}"
             echo "$devVersion" > $versionFile

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -6,11 +6,11 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-#   run-tests:
-#     uses: './.github/workflows/testing.yaml'
+  run-tests:
+    uses: './.github/workflows/testing.yaml'
 
   pypi-nightly:
-    # needs: run-tests
+    needs: run-tests
     timeout-minutes: 30
     name: pypi-nightly
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
       - name: Upload Python client to PyPI
         id: pypi_upload
         env:
-          TWINE_REPOSITORY: testpypi
-          PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+          TWINE_REPOSITORY: pypi
+          PYPI_USERNAME: ${{ secrets.PROD_PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.PROD_PYPI_PASSWORD }}
         run: make upload

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -13,26 +13,25 @@ jobs:
     name: pypi-nightly
     runs-on: ubuntu-latest
     steps:
-        - name: Checkout
-          uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+    
+      - name: List recent changes
+        id: list-commits
+        run: |
+          recentCommits=$(git log --since=yesterday --oneline)
+          echo "commits=$recentCommits" >> "$GITHUB_OUTPUT"
+
+      - name: Show commits
+        run: echo "${{ steps.list-commits.outputs.commits }}"
+
+      - name: Abort release if no changes since yesterday
+        if: steps.list-commits.outputs.commits == ''
+        uses: andymckay/cancel-action@0.3
         
-        - name: List recent changes
-          id: list-commits
-          run: |
-            recentCommits=$(git log --since=yesterday --oneline)
-            echo "commits=$recentCommits" >> "$GITHUB_OUTPUT"
-
-        - name: Show commits
-          run: |
-            echo "commits=${{ steps.list-commits.outputs.commits }}"
-
-        - name: Abort release if no changes since yesterday
-          if: steps.list-commits.outputs.commits == ''
-          uses: andymckay/cancel-action@0.3
-          
-        - uses: actions/setup-python@v4
-          with:
-            python-version: 3.x
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
 
         # - name: Build Python client
         #   run: make package

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -2,6 +2,8 @@ name: 'PyPI Release: Nightly (pinecone-client-nightly)'
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
 #   run-tests:
@@ -38,6 +40,10 @@ jobs:
       - name: Adjust module name
         run: |
             sed -i 's/pinecone-client/pinecone-client-nightly/g' setup.py
+    
+      - name: Update README
+        run: |
+            echo "This is a nightly developer build of the Pinecone Python client. It is not intended for production use." > README.md
 
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-tests:
-    uses: './.github/workflows/testing.yaml'
+#   run-tests:
+#     uses: './.github/workflows/testing.yaml'
 
   pypi-nightly:
-    needs: run-tests
+    # needs: run-tests
     timeout-minutes: 30
     name: pypi-nightly
     runs-on: ubuntu-latest
@@ -25,21 +25,34 @@ jobs:
       - name: Show commits
         run: echo "${{ steps.list-commits.outputs.commits }}"
 
-      - name: Abort release if no changes since yesterday
+      - name: Abort if no recent changes
         if: steps.list-commits.outputs.commits == ''
         uses: andymckay/cancel-action@0.3
-        
+
+      - name: Set dev version
+        id: version
+        run: |
+            versionFile="pinecone/__version__"
+            currentDate=$(date +%Y%m%d)
+            versionNumber=$(cat $versionFile)
+            devVersion="${versionNumber}.dev${currentDate}"
+            echo "$devVersion" > $versionFile
+
+      - name: Adjust module name
+        run: |
+            sed -i 's/pinecone-client/pinecone-client-nightly/g' setup.py
+
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
-        # - name: Build Python client
-        #   run: make package
+      - name: Build Python client
+        run: make package
 
-        # - name: Upload Python client to PyPI
-        #   id: pypi_upload
-        #   env:
-        #     TWINE_REPOSITORY: testpypy
-        #     PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-        #     PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
-        #   run: make upload
+      - name: Upload Python client to PyPI
+        id: pypi_upload
+        env:
+          TWINE_REPOSITORY: testpypy
+          PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        run: make upload

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -13,5 +13,34 @@ jobs:
     name: pypi-nightly
     runs-on: ubuntu-latest
     steps:
-      - name: greeting
-        run: echo "Hello World"
+        - name: Checkout
+          uses: actions/checkout@v3
+        
+        - name: List recent changes
+          id: list-commits
+          run: |
+            recentCommits=$(git log --since=yesterday --oneline)
+            echo "commits=$recentCommits" >> "$GITHUB_OUTPUT"
+
+        - name: Show commits
+          run: |
+            echo "commits=${{ steps.list-commits.outputs.commits }}"
+
+        - name: Abort release if no changes since yesterday
+          if: steps.list-commits.outputs.commits == ''
+          uses: andymckay/cancel-action@0.3
+          
+        - uses: actions/setup-python@v4
+          with:
+            python-version: 3.x
+
+        # - name: Build Python client
+        #   run: make package
+
+        # - name: Upload Python client to PyPI
+        #   id: pypi_upload
+        #   env:
+        #     TWINE_REPOSITORY: testpypy
+        #     PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+        #     PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        #   run: make upload

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -32,7 +32,7 @@ jobs:
         id: version
         run: |
             versionFile="pinecone/__version__"
-            currentDate=$(date +%Y%m%d-%M%S)
+            currentDate=$(date +%Y%m%d%M%S)
             versionNumber=$(cat $versionFile)
             devVersion="${versionNumber}.dev${currentDate}"
             echo "$devVersion" > $versionFile

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -32,7 +32,7 @@ jobs:
         id: version
         run: |
             versionFile="pinecone/__version__"
-            currentDate=$(date +%Y%m%d%M%S)
+            currentDate=$(date +%Y%m%d%H%M%S)
             versionNumber=$(cat $versionFile)
             devVersion="${versionNumber}.dev${currentDate}"
             echo "$devVersion" > $versionFile

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -16,14 +16,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
     
-      - name: List recent changes
+      - name: Get recent changes
         id: list-commits
         run: |
           recentCommits=$(git log --since=yesterday --oneline)
           echo "commits=$recentCommits" >> "$GITHUB_OUTPUT"
-
-      - name: Show commits
-        run: echo "${{ steps.list-commits.outputs.commits }}"
 
       - name: Abort if no recent changes
         if: steps.list-commits.outputs.commits == ''

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Upload Python client to PyPI
         id: pypi_upload
         env:
-          TWINE_REPOSITORY: testpypy
+          TWINE_REPOSITORY: testpypi
           PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
           PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
         run: make upload

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -1,4 +1,4 @@
-name: PyPI Prerelease
+name: Publish to PyPI
 
 on:
   workflow_call:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: PyPI Release
+name: 'PyPI Release: Production (pinecone-client)'
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Problem

We need a way to consume unreleased changes for integration testing purposes.

## Solution

Publish each night, if there are new changes, using the package name `python-client-nightly`. This follows the practice of other large projects such as `tensorflow` which publishes nightlies under the `tf-nightly` name. PyPI does have some limited support for prereleases but releasing a lot of them under our normal package name will make the release history page on pypi look quite cluttered.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

I successfully used this to publish to testpypi. Just changed a few variables to point at the public index.