### PR TITLE
Fix prod pypi release by adjusting shared publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -25,7 +25,7 @@ on:
         default: true
       prereleaseSuffix:
         description: 'Suffix to add onto the new version number in order to mark it as a prerelease. Value ignored when shipping a release that is not a prerelease.'
-        required: true
+        required: false
         type: string
         default: 'rc1'
       TWINE_REPOSITORY:


### PR DESCRIPTION
## Problem

Prod release builds currently fail because the required prereleaseSuffix input is not being passed to the shared workflow `publish-to-pypi.yaml`

This is a follow up to #178 Release from CI

## Solution

There's no reason for this property to be required; the bump version action correctly handles the scenario where that value is not passed.

This issue causes failures like [this one](https://github.com/pinecone-io/pinecone-python-client/actions/runs/5195718175).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure change (CI configs, etc)

## Test Plan

Land and try shipping again 🤣 