### PR TITLE
Bump protobuf dependency

### DIFF
--- a/requirements-grpc.txt
+++ b/requirements-grpc.txt
@@ -2,4 +2,4 @@ grpcio>=1.44.0
 grpc-gateway-protoc-gen-openapiv2==0.1.0
 googleapis-common-protos>=1.53.0
 lz4>=3.1.3
-protobuf~=3.19.5
+protobuf~=3.20.0


### PR DESCRIPTION
## Problem

Users have requested we bump our protobuf dependency version to a more modern release for compatibility with their other dependencies.

## Solution

Attempt going from 3.19.x to 3.20.x.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue): Dependency update.

## Test Plan

GRPC tests should continue to run successfully.