### PR TITLE
Typo in docstring for upsert()

### DIFF
--- a/pinecone/index.py
+++ b/pinecone/index.py
@@ -104,7 +104,7 @@ class Index(ApiClient):
             vectors (Union[List[Vector], List[Tuple]]): A list of vectors to upsert.
 
                      A vector can be represented by a 1) Vector object, a 2) tuple or 3) a dictionary
-                     1) if a tuple is used, it must be of the form (id, values, meatadata) or (id, values).
+                     1) if a tuple is used, it must be of the form (id, values, metadata) or (id, values).
                         where id is a string, vector is a list of floats, metadata is a dict,
                         and sparse_values is a dict of the form {'indices': List[int], 'values': List[float]}.
                         Examples: ('id1', [1.0, 2.0, 3.0], {'key': 'value'}, {'indices': [1, 2], 'values': [0.2, 0.4]}),


### PR DESCRIPTION
## Problem

Typo in the documentation

## Solution

Fix the spelling mistake.

## Type of Change

- [x] Non-code change (docs, etc)

## Test Plan

Not needed?