### PR TITLE
Replace deprecated HTTPResponse.getheader()

### DIFF
--- a/pinecone/core/client/rest.py
+++ b/pinecone/core/client/rest.py
@@ -38,11 +38,11 @@ class RESTResponse(io.IOBase):
 
     def getheaders(self):
         """Returns a dictionary of the response headers."""
-        return self.urllib3_response.getheaders()
+        return self.urllib3_response.headers
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.getheader(name, default)
+        return self.urllib3_response.headers.getheader(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
## Problem

See gh-125

## Solution

This PR simply replaces the deprecated `HTTPResponse.getheader()` usages with the suggested `HTTResponse.headers`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [x] None of the above: Replacing deprecated usages

## Test Plan

Describe specific steps for validating this change.