### PR TITLE
update urllib3_response.headers.get as getheader is deprecated

### DIFF
--- a/pinecone/core/client/rest.py
+++ b/pinecone/core/client/rest.py
@@ -42,7 +42,7 @@ class RESTResponse(io.IOBase):
 
     def getheader(self, name, default=None):
         """Returns a given response header."""
-        return self.urllib3_response.headers.getheader(name, default)
+        return self.urllib3_response.headers.get(name, default)
 
 
 class RESTClientObject(object):


### PR DESCRIPTION
## Problem

Follow up to #195, which updated to use `urllib.headers` -- there's also a deprecation for `getheader` coming: https://github.com/urllib3/urllib3/pull/2814

## Solution

Updated the call in `rest.py` to use `.get` instead of `.getheader`; based on the [code](https://github.com/urllib3/urllib3/blob/1.2.1/urllib3/response.py#L191C29-L191C32) this should be compatible with 1.2.1, [our current min version](https://github.com/pinecone-io/pinecone-python-client/blob/main/requirements.txt#L8)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

REST requests should work without a notice in URLLib3 2.0.4+