### PR TITLE
adds util for checking kwargs, and uses it to check init()

### DIFF
--- a/pinecone/config.py
+++ b/pinecone/config.py
@@ -15,7 +15,7 @@ from urllib3.connection import HTTPConnection
 
 from pinecone.core.client.exceptions import ApiKeyError
 from pinecone.core.api_action import ActionAPI, WhoAmIResponse
-from pinecone.core.utils import warn_deprecated
+from pinecone.core.utils import warn_deprecated, check_kwargs
 from pinecone.core.utils.constants import CLIENT_VERSION, PARENT_LOGGER_NAME, DEFAULT_PARENT_LOGGER_LEVEL, \
     TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
 from pinecone.core.client.configuration import Configuration as OpenApiConfiguration
@@ -245,6 +245,7 @@ def init(api_key: str = None, host: str = None, environment: str = None, project
     :param config: Optional. An INI configuration file.
     :param log_level: Deprecated since v2.0.2 [Will be removed in v3.0.0]; use the standard logging module to manage logger "pinecone" instead.
     """
+    check_kwargs.check_kwargs(init, kwargs)
     Config.reset(project_name=project_name, api_key=api_key, controller_host=host, environment=environment,
                  openapi_config=openapi_config, config_file=config, **kwargs)
     if log_level:

--- a/pinecone/config.py
+++ b/pinecone/config.py
@@ -245,7 +245,7 @@ def init(api_key: str = None, host: str = None, environment: str = None, project
     :param config: Optional. An INI configuration file.
     :param log_level: Deprecated since v2.0.2 [Will be removed in v3.0.0]; use the standard logging module to manage logger "pinecone" instead.
     """
-    check_kwargs.check_kwargs(init, kwargs)
+    check_kwargs(init, kwargs)
     Config.reset(project_name=project_name, api_key=api_key, controller_host=host, environment=environment,
                  openapi_config=openapi_config, config_file=config, **kwargs)
     if log_level:

--- a/pinecone/core/utils/__init__.py
+++ b/pinecone/core/utils/__init__.py
@@ -109,3 +109,10 @@ def load_strings_public(proto_arr: 'vector_column_service_pb2.NdArray') -> List[
 def warn_deprecated(description: str = '', deprecated_in: str = None, removal_in: str = None):
     message = f'DEPRECATED since v{deprecated_in} [Will be removed in v{removal_in}]: {description}'
     warnings.warn(message, FutureWarning)
+
+def check_kwargs(caller, given):
+    import inspect
+    argspec = inspect.getfullargspec(caller)
+    diff = set(given).difference(argspec.args)
+    if diff:
+        raise TypeError(caller.__name__ + ' had unexpected keyword argument(s): ' + ', '.join(diff))

--- a/pinecone/core/utils/__init__.py
+++ b/pinecone/core/utils/__init__.py
@@ -1,6 +1,8 @@
 #
 # Copyright (c) 2020-2021 Pinecone Systems Inc. All right reserved.
 #
+import inspect
+import logging
 import re
 import uuid
 import warnings
@@ -111,8 +113,7 @@ def warn_deprecated(description: str = '', deprecated_in: str = None, removal_in
     warnings.warn(message, FutureWarning)
 
 def check_kwargs(caller, given):
-    import inspect
     argspec = inspect.getfullargspec(caller)
     diff = set(given).difference(argspec.args)
     if diff:
-        raise TypeError(caller.__name__ + ' had unexpected keyword argument(s): ' + ', '.join(diff))
+        logging.exception(caller.__name__ + ' had unexpected keyword argument(s): ' + ', '.join(diff), exc_info=False)

--- a/pinecone/core/utils/check_kwargs.py
+++ b/pinecone/core/utils/check_kwargs.py
@@ -1,7 +1,0 @@
-
-def check_kwargs(caller, given):
-    import inspect
-    argspec = inspect.getfullargspec(caller)
-    diff = set(given).difference(argspec.args)
-    if diff:
-        raise TypeError(caller.__name__ + ' had unexpected keyword argument(s): ' + ', '.join(diff))

--- a/pinecone/core/utils/check_kwargs.py
+++ b/pinecone/core/utils/check_kwargs.py
@@ -1,0 +1,7 @@
+
+def check_kwargs(caller, given):
+    import inspect
+    argspec = inspect.getfullargspec(caller)
+    diff = set(given).difference(argspec.args)
+    if diff:
+        raise TypeError(caller.__name__ + ' had unexpected keyword argument(s): ' + ', '.join(diff))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -84,6 +84,10 @@ def test_init_with_kwargs():
     assert Config.CONTROLLER_HOST == controller_host
     assert Config.OPENAPI_CONFIG == openapi_config
 
+def test_init_with_mispelled_kwargs(caplog):
+    pinecone.init(invalid_kwarg="value")
+    assert 'init had unexpected keyword argument(s): invalid_kwarg' in caplog.text
+
 def test_init_with_file_based_configuration():
     """Test that config can be loaded from a file"""
     env = 'ini-test-env'


### PR DESCRIPTION
## Problem

Per #196 a typo in init's kwargs results in a default that might not be expected.

## Solution

Utils now includes check_kwargs, which takes a caller + the given kwargs, and fails with a traceback if they don't match.

## Open Questions
cc @jhamon @austin-denoble @rohanshah18 
1) Where else should we use check_kwargs?
2) Is the traceback useful? in this instance it risks leaking api keys into logs, so for `init` in particular i question its value.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

`pinecone.init(not_a_kwarg='foo')` should fail