### PR TITLE
Fix nightly-release workflow and tweak Poetry package naming

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-    
+
       - name: Get recent changes
         id: list-commits
         run: |
@@ -31,19 +31,19 @@ jobs:
       - name: Set dev version
         id: version
         run: |
-            versionFile="pinecone/__version__"
-            currentDate=$(date +%Y%m%d%H%M%S)
-            versionNumber=$(cat $versionFile)
-            devVersion="${versionNumber}.dev${currentDate}"
-            echo "$devVersion" > $versionFile
+          versionFile="pinecone/__version__"
+          currentDate=$(date +%Y%m%d%H%M%S)
+          versionNumber=$(cat $versionFile)
+          devVersion="${versionNumber}.dev${currentDate}"
+          echo "$devVersion" > $versionFile
 
       - name: Adjust module name
         run: |
-            sed -i 's/pinecone-client/pinecone-client-nightly/g' setup.py
-    
+          sed -i 's/pinecone-client/pinecone-client-nightly/g' pyproject.toml
+
       - name: Update README
         run: |
-            echo "This is a nightly developer build of the Pinecone Python client. It is not intended for production use." > README.md
+          echo "This is a nightly developer build of the Pinecone Python client. It is not intended for production use." > README.md
 
       - uses: actions/setup-python@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,11 @@ exclude = '''
 '''
 
 [tool.poetry]
-name = "pinecone"
+name = "pinecone-client"
 version = "2.2.4"
+packages = [
+    { include="pinecone", from="." },
+]
 description = "Pinecone client and SDK"
 authors = ["Pinecone Systems, Inc. <support@pinecone.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Problem
After the poetry migration in https://github.com/pinecone-io/pinecone-python-client/pull/193 the `PyPI Release: Nightly (pinecone-client-nightly)` has been failing: https://github.com/pinecone-io/pinecone-python-client/actions/runs/6374232183/job/17298658421

The reason is we removed the `setup.py` file as a part of the migration and `nightly-release.yaml` used to adjust the module name via `sed -i 's/pinecone-client/pinecone-client-nightly/g' setup.py`. To achieve something similar now that we've changed our build / packaging process to use Poetry, we need to look at updating the `pyproject.toml` file.

While looking at correcting this, I realized the resulting build artifacts from `make package` (which now calls `poetry build`) now have different package names which may cause issues with PyPI:

- (Old) `pinecone-client-2.2.4.tar.gz`
- (New) `pinecone-2.2.4.tar.gz`
- (Old) `pinecone_client-2.2.4-py3-none-any.whl`
- (New) `pinecone-2.2.4-py3-none-any.whl`

## Solution

- I updated `nightly-release.yaml` to call `sed -i ...` on the `pyproject.toml` file instead of `setup.py`. This should swap out `name: pinecone-client` for `name: pinecone-client-nightly` under `[tools.poetry]` which should fix up the package naming.
- Added a `packages` section to `pyproject.toml` to define the top-level pinecone package entrypoint. Poetry uses the `name` field by default unless this is specified which is why we were ending up with artifacts called `pinecone-...` rather than `pinecone-client-...`.

**Note:**
Poetry swaps the hyphen in `pinecone-client` for an underscore in the resulting build output artifacts.

New packages:
- `pinecone_client-2.2.4.tar.gz`
- `pinecone_client-2.2.4-py3-none-any.whl`

The `.whl` naming is equivalent, and the `tar.gz` has an underscore rather than a hyphen. I think ultimately this shouldn't matter given the guidance around `name` here:
https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#name

> Comparison of project names is case insensitive and treats arbitrarily-long runs of underscores, hyphens, and/or periods as equal. For example, if you register a project named cool-stuff, users will be able to download it or declare a dependency on it using any of the following spellings:
Cool-Stuff
cool.stuff
COOL_STUFF
CoOl__-.-__sTuFF


## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
