### PR TITLE
Add new setup-poetry action and fix nightly-release

### DIFF
--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -7,6 +7,7 @@ runs:
       uses: snok/install-poetry@v1
 
     - name: Install dependencies
+      shell: bash
       run: |
         poetry install
 
@@ -15,5 +16,6 @@ runs:
     # The dependencies that are specific to gRPC are defined in pyproject.toml
     # under tool.poetry.extras
     - name: Install gRPC dependencies
+      shell: bash
       run: |
         poetry install --extras "grpc"

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -1,0 +1,19 @@
+name: 'Setup Poetry'
+description: 'Installs Poetry and dependencies'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+
+    - name: Install dependencies
+      run: |
+        poetry install
+
+    # We separate the gRPC dependencies from the REST client's install
+    # behavior, so we test installing the grpc dependencies here as well
+    # The dependencies that are specific to gRPC are defined in pyproject.toml
+    # under tool.poetry.extras
+    - name: Install gRPC dependencies
+      run: |
+        poetry install --extras "grpc"

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -49,6 +49,9 @@ jobs:
         with:
           python-version: 3.x
 
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+
       - name: Build Python client
         run: make package
 

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -12,7 +12,7 @@ on:
         description: 'Git ref to build (branch name or SHA)'
         required: true
         type: string
-        default: 'main' 
+        default: 'main'
       releaseLevel:
         description: 'Release level'
         required: true
@@ -59,10 +59,10 @@ jobs:
         id: bump
         uses: './.github/actions/bump-version'
         with:
-          versionFile: pinecone/__version__ 
+          versionFile: pinecone/__version__
           bumpType: ${{ inputs.releaseLevel }}
           prereleaseSuffix: ${{ inputs.prereleaseSuffix }}
-      
+
       - name: Verify unique release number
         run: |
           TAG_NAME=${{ steps.bump.outputs.VERSION_TAG }}
@@ -71,19 +71,23 @@ jobs:
             exit 1
           fi
 
-      - name: Poetry bump pyproject toml version
-        run: |
-          poetry version ${{ inputs.releaseLevel }}
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
 
       - name: Set up Git
         run: |
           git config --global user.name "Pinecone CI"
           git config --global user.email "clients@pinecone.io"
-  
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-  
+
+      - name: Poetry bump pyproject toml version
+        run: |
+          poetry version ${{ inputs.releaseLevel }}
+
       - name: Build Python client
         run: make package
 
@@ -99,7 +103,7 @@ jobs:
         if: ${{ inputs.isPrerelease == true }}
         run: |
           git checkout pinecone/__version__
-      
+
       - name: Commit changes, if not prerelease
         if: ${{ inputs.isPrerelease == false }}
         run: |
@@ -119,14 +123,14 @@ jobs:
         run: |
           newVersionTag="${{ steps.bump.outputs.VERSION_TAG }}"
           git tag -a $newVersionTag -m "Release $newVersionTag"
-    
+
       - name: Push tags (prerelease)
         if: ${{ inputs.isPrerelease == true }}
         # In the case of the prerelease, we discarded the version changes
         # instead of committing them. So we need a slightly different
         # command to push the git tag we created.
         run: git push --tags
-      
+
       - name: Push tags (production release)
         if: ${{ inputs.isPrerelease == false }}
         run: git push --follow-tags

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,6 +1,6 @@
 name: Testing
 
-on: 
+on:
   workflow_call: {}
 
 jobs:
@@ -12,37 +12,21 @@ jobs:
         python-version: [3.8, 3.9, '3.10', 3.11]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install Poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python -
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
 
-    - name: Install dependencies
-      run: |
-        poetry install
+      - name: Run tests
+        run: make tests
 
-    # We separate the gRPC dependencies from the REST client's install 
-    # behavior, so we test installing the grpc dependencies here as well
-    # The dependencies that are specific to gRPC are defined in pyproject.toml
-    # under tool.poetry.extras
-    - name: Install gRPC dependencies 
-      run: |
-        poetry install --extras "grpc"
+      - name: Build Python client
+        run: make package
 
-    - name: Run tests
-      run: make tests
-
-    - name: Build Python client
-      run: make package
-
-    - name: Build docs
-      run: make docs
-
-    - name: Build Project
-      run: poetry build
+      - name: Build docs
+        run: make docs


### PR DESCRIPTION
## Problem
`nightly-release` workflow is still failing after the previous "fix": https://github.com/pinecone-io/pinecone-python-client/pull/208.

This time it's due to `make package` failing on `poetry build`, because `poetry` wasn't setup properly in the workflow.
https://github.com/pinecone-io/pinecone-python-client/actions/runs/6399744230/job/17372332268

> Run make package
poetry build
make: poetry: No such file or directory
make: *** [Makefile:22: package] Error [12](https://github.com/pinecone-io/pinecone-python-client/actions/runs/6399744230/job/17372332268#step:9:13)7
Error: Process completed with exit code 2.

While fixing this I noticed we're also not installing Poetry in the `publish-to-pypi` workflow, so calling `poetry version` and `make` commands there would fail. We need to make sure we're installing Poetry properly before using `make` in our workflows, as they call Poetry under the hood.

## Solution
- Add a new `setup-poetry` action that encapsulates the install + dependencies bits. I noticed we were doing this explicitly in several workflows and thought it called for an action.
- Fix `nightly-release` worfklow: call the new action before calling `make package`.
- Fix `release-to-pypi` worfklow: call the new action before calling `poetry version`, and `make` commands for publishing.
- Clean up / use the action in `testing` worfklow.

## Type of Change
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Validate PR workflows pass as expected. Merge and check `nightly-release` to make sure we're in good shape.
