### PR TITLE
Fix merge workflow by adding checkout step

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -10,6 +10,9 @@ jobs:
   build-and-deploy-documentation:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Generate pdoc documentation
         uses: ./.github/actions/build-docs
 


### PR DESCRIPTION
## Problem
The PR for adding pdoc integration via GitHub workflows was just merged: https://github.com/pinecone-io/pinecone-python-client/pull/207

The workflow is failing because we're not initially checking things out:
https://github.com/pinecone-io/pinecone-python-client/actions/runs/6421593962/job/17436307034

>Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/pinecone-python-client/pinecone-python-client/.github/actions/build-docs'. Did you forget to run actions/checkout before running your local action?

## Solution
- Add the `actions/checkout@v3` step to the start of the workflow

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Infrastructure change (CI configs, etc)

## Test Plan
I really need to get tooling setup to run these workflows locally to validate. This is a very tiny change and we should be able to re-evaluate on the merge. 😅 
