### PR TITLE
Spruce release workflows

### DIFF
--- a/.github/actions/bump-version/action.js
+++ b/.github/actions/bump-version/action.js
@@ -6,10 +6,10 @@ function bumpVersion(currentVersion, bumpType, prerelease) {
   if (prerelease) {
     newVersion = `${newVersion}.${prerelease}`;
   }
-  core.setOutput('previous_version', currentVersion)
-  core.setOutput('previous_version_tag', `v${currentVersion}`)
+  core.setOutput('previous_version', currentVersion);
+  core.setOutput('previous_version_tag', `v${currentVersion}`);
   core.setOutput('version', newVersion);
-  core.setOutput('version_tag', `v${newVersion}`)
+  core.setOutput('version_tag', `v${newVersion}`);
 
   return newVersion;
 }
@@ -35,4 +35,4 @@ function calculateNewVersion(currentVersion, bumpType) {
   return newVersion;
 }
 
-module.exports = { bumpVersion }
+module.exports = { bumpVersion };

--- a/.github/workflows/nightly-spruce-dev-release.yaml
+++ b/.github/workflows/nightly-spruce-dev-release.yaml
@@ -1,0 +1,66 @@
+name: 'Test PyPI Spruce Release: Nightly (pinecone-client-spruce-dev)'
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  run-tests:
+    uses: './.github/workflows/testing.yaml'
+
+  pypi-spruce-nightly:
+    needs: run-tests
+    timeout-minutes: 30
+    name: pypi-nightly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: spruce
+
+      - name: Get recent changes
+        id: list-commits
+        run: |
+          recentCommits=$(git log --since=yesterday --oneline)
+          echo "commits=$recentCommits" >> "$GITHUB_OUTPUT"
+
+      - name: Abort if no recent changes
+        if: steps.list-commits.outputs.commits == ''
+        uses: andymckay/cancel-action@0.3
+
+      - name: Set spruce dev version
+        id: version
+        run: |
+          versionFile="pinecone/__version__"
+          currentDate=$(date +%Y%m%d%H%M%S)
+          versionNumber=$(cat $versionFile)
+          devVersion="${versionNumber}.dev${currentDate}.spruceDev"
+          echo "$devVersion" > $versionFile
+
+      - name: Adjust module name
+        run: |
+          sed -i 's/pinecone-client/pinecone-client-spruce-dev/g' pyproject.toml
+
+      - name: Update README
+        run: |
+          echo "This is a nightly Spruce developer build of the Pinecone Python client. It is not intended for production use." > README.md
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+
+      - name: Build Python client
+        run: make package
+
+      - name: Upload Python Spruce client to Test PyPI
+        id: pypi_upload
+        env:
+          TWINE_REPOSITORY: testpypi
+          PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        run: make upload-spruce

--- a/.github/workflows/release-spruce.yaml
+++ b/.github/workflows/release-spruce.yaml
@@ -1,0 +1,53 @@
+name: 'Test PyPI Release: Spruce build (pinecone-client-spruce)'
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  testing:
+    uses: './.github/workflows/testing.yaml'
+
+  version-and-release-spruce:
+    timeout-minutes: 30
+    name: Release Spruce dev build to test pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Spruce
+        uses: actions/checkout@v4
+        with:
+          ref: spruce
+
+      - name: Set spruce dev version
+        id: version
+        run: |
+          versionFile="pinecone/__version__"
+          currentDate=$(date +%Y%m%d%H%M%S)
+          versionNumber=$(cat $versionFile)
+          devVersion="${versionNumber}.${currentDate}.spruce"
+          echo "$devVersion" > $versionFile
+
+      - name: Adjust module name
+        run: |
+          sed -i 's/pinecone-client/pinecone-client-spruce/g' pyproject.toml
+
+      - name: Update README
+        run: |
+          echo "This is Spruce build of the Pinecone Python client. It is not intended for production use." > README.md
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+
+      - name: Build Python client
+        run: make package
+
+      - name: Upload Python Spruce client to Test PyPI
+        id: pypi_upload
+        env:
+          TWINE_REPOSITORY: testpypi
+          PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        run: make upload-spruce

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,11 @@ package:
 
 upload:
 	poetry publish --verbose --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
+
+upload-spruce:
+	# Configure Poetry for publishing to testpypi
+	poetry config repositories.test-pypi https://test.pypi.org/legacy/
+	poetry publish --verbose -r test-pypi --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
 	
 license:
 	# Add license header using https://github.com/google/addlicense.


### PR DESCRIPTION
## Problem
We need a way to ship builds of the `spruce` branch.

## Solution
Modify existing workflows for `nightly-release` and `release` for shipping artifacts to Test PyPI.

Workflows update `pyproject.toml` `name` field: `pinecone-client-spruce-dev` and `pinecone-client-spruce`:
- `pinecone-client-spruce` releases are for use in 3rd party testing
- `pinecone-client-spruce-dev` releases are for use in internal testing

## Type of Change
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Trigger and validate workflows either locally or from the repo directly.
