### PR TITLE
Fix Spruce workflows

### DIFF
--- a/.github/workflows/nightly-spruce-dev-release.yaml
+++ b/.github/workflows/nightly-spruce-dev-release.yaml
@@ -31,7 +31,6 @@ jobs:
         uses: andymckay/cancel-action@0.3
 
       - name: Set spruce dev version
-        id: version
         run: |
           versionFile="pinecone/__version__"
           currentDate=$(date +%Y%m%d%H%M%S)
@@ -58,7 +57,6 @@ jobs:
         run: make package
 
       - name: Upload Python Spruce client to Test PyPI
-        id: pypi_upload
         env:
           TWINE_REPOSITORY: testpypi
           PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}

--- a/.github/workflows/release-spruce.yaml
+++ b/.github/workflows/release-spruce.yaml
@@ -18,7 +18,6 @@ jobs:
           ref: spruce
 
       - name: Set spruce dev version
-        id: version
         run: |
           versionFile="pinecone/__version__"
           currentDate=$(date +%Y%m%d%H%M%S)
@@ -45,7 +44,6 @@ jobs:
         run: make package
 
       - name: Upload Python Spruce client to Test PyPI
-        id: pypi_upload
         env:
           TWINE_REPOSITORY: testpypi
           PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image develop tests tag-and-push docs version package upload license
+.PHONY: image develop tests tag-and-push docs version package upload upload-spruce license
 mkfile_path := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 PYPI_USERNAME ?= __token__


### PR DESCRIPTION
## Problem
For managing Spruce artifacts I added a new command in the makefile, but I didn't update `.PHONY:` at the top of the file to include the new command. 

## Solution
- Add `upload-spruce` to `.PHONY:` in the Makefile.
- Remove some unneeded `ids` from `release-spruce` and `nightly-spruce-dev-release`.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Re-run workflows with corrected make.
