### PR TITLE
Prevent _get_api_instance from modifying OpenAPI config

### DIFF
--- a/pinecone/manage.py
+++ b/pinecone/manage.py
@@ -1,5 +1,6 @@
 import time
 from typing import NamedTuple, Optional
+import copy
 
 import pinecone
 from pinecone.config import Config
@@ -49,7 +50,7 @@ class CollectionDescription(object):
 
 
 def _get_api_instance():
-    client_config = Config.OPENAPI_CONFIG
+    client_config = copy.deepcopy(Config.OPENAPI_CONFIG)
     client_config.api_key = client_config.api_key or {}
     client_config.api_key["ApiKeyAuth"] = client_config.api_key.get("ApiKeyAuth", Config.API_KEY)
     client_config.server_variables = {**{"environment": Config.ENVIRONMENT}, **client_config.server_variables}


### PR DESCRIPTION
## Problem
Previous revision we added some code to apply a custom `host` value to control plane operations: https://github.com/pinecone-io/pinecone-python-client/pull/218

This change caused 404s when calling dataplane operations. The `Configuration._base_path` value was being overwritten by the custom `host` that was provided due to the `Configuration.host` setter:

```
  @host.setter
  def host(self, value):
      """Fix base path."""
      self._base_path = value
      self.server_index = None
```
https://github.com/pinecone-io/pinecone-python-client/blob/7ff4ed877ac3e97eb557b747a072a84e57764b91/pinecone/core/client/configuration.py#L493

## Solution
The change I made was actually modifying the reference to `Config.OPENAPI_CONFIG` which overwrote things across the board.

Instead of operating on the singleton's instance of the config, we can use `copy.deepcopy(Config.OPENAPI_CONFIG)` and use that to construct things before handing it off to `ApiClient`

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan
Pull this branch down, use the client locally and make sure that dataplane calls work properly without a `host` or with one in the case of supplying a custom control plane URL.
