### PR TITLE
Add control plane integration tests

### DIFF
--- a/tests/integration/control/test_configure_index.py
+++ b/tests/integration/control/test_configure_index.py
@@ -1,0 +1,76 @@
+import pytest
+import pinecone
+import os
+import tests.test_helpers as test_helpers
+
+
+class TestConfigureIndex:
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        # setup
+        api_key = os.getenv("PINECONE_API_KEY")
+        environment = os.getenv("PINECONE_ENVIRONMENT")
+
+        self.index_name = test_helpers.generate_index_name()
+        self.pinecone = pinecone
+        self.pinecone.init(api_key=api_key, environment=environment)
+        self.pinecone.create_index(name=self.index_name, dimension=5, replicas=2, timeout=-1)
+        self.enable_teardown = True
+
+        # run test
+        yield
+
+        # teardown
+        if self.enable_teardown:
+            self.pinecone.delete_index(name=self.index_name)
+
+    # region: error-handling
+
+    def test_configure_index_name_invalid(self):
+        with pytest.raises(pinecone.core.client.exceptions.NotFoundException) as excinfo:
+            self.pinecone.configure_index(name="nonexistant", replicas=2)
+
+        exception_msg = str(excinfo.value)
+        assert "Reason: Not Found" in exception_msg
+        assert "HTTP response body: 404: Not Found" in exception_msg
+
+    def test_configure_index_exceeds_quota(self):
+        with pytest.raises(pinecone.core.client.exceptions.ApiException) as excinfo:
+            self.pinecone.configure_index(name=self.index_name, replicas=10)
+
+        exception_msg = str(excinfo.value)
+        assert "Reason: Bad Request" in exception_msg
+        assert "HTTP response body: The index exceeds the project quota of 5 pods by 5 pods." in exception_msg
+
+    # endregion error-handling
+
+    def test_configure_index_scale_replicas(self):
+        index = self.pinecone.describe_index(name=self.index_name)
+        assert index.replicas == 2
+
+        # scale up
+        self.pinecone.configure_index(name=self.index_name, replicas=3)
+        index = self.pinecone.describe_index(name=self.index_name)
+        assert index.replicas == 3
+
+        # scale down
+        self.pinecone.configure_index(name=self.index_name, replicas=1)
+        index = self.pinecone.describe_index(name=self.index_name)
+        assert index.replicas == 1
+
+    def test_configure_index_scale_pod_type(self):
+        index = self.pinecone.describe_index(name=self.index_name)
+        assert index.pod_type == "p1.x1"
+
+        # scale up
+        self.pinecone.configure_index(name=self.index_name, pod_type="p1.x2")
+        index = self.pinecone.describe_index(name=self.index_name)
+        assert index.pod_type == "p1.x2"
+
+        # scale down (expected error)
+        with pytest.raises(pinecone.core.client.exceptions.ApiException) as excinfo:
+            self.pinecone.configure_index(name=self.index_name, pod_type="p1.x1")
+
+        exception_msg = str(excinfo.value)
+        assert "Reason: Bad Request" in exception_msg
+        assert "HTTP response body: scaling down pod type is not supported" in exception_msg

--- a/tests/integration/control/test_create_index.py
+++ b/tests/integration/control/test_create_index.py
@@ -1,0 +1,82 @@
+import pytest
+import pinecone
+import os
+import tests.test_helpers as test_helpers
+
+
+class TestCreateIndex:
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        # setup
+        api_key = os.getenv("PINECONE_API_KEY")
+        environment = os.getenv("PINECONE_ENVIRONMENT")
+
+        self.index_name = test_helpers.generate_index_name()
+        self.pinecone = pinecone
+        self.pinecone.init(api_key=api_key, environment=environment)
+        self.enable_teardown = True
+
+        # run test
+        yield
+
+        # teardown
+        if self.enable_teardown:
+            pinecone.delete_index(name=self.index_name, timeout=-1)
+
+    # region: error handling
+
+    def test_create_index_invalid_name(self):
+        self.enable_teardown = False
+
+        with pytest.raises(pinecone.core.client.exceptions.ApiException) as excinfo:
+            self.pinecone.create_index(name=self.index_name + "-", dimension=5)
+
+        exception_msg = str(excinfo.value)
+        assert "Reason: Bad Request" in exception_msg
+        assert "must be an empty string or consist of alphanumeric characters" in exception_msg
+
+    def test_create_index_nonexistant_collection(self):
+        self.enable_teardown = False
+
+        with pytest.raises(pinecone.core.client.exceptions.ApiException) as excinfo:
+            self.pinecone.create_index(name=self.index_name, dimension=5, source_collection="nonexistant")
+
+        exception_msg = str(excinfo.value)
+        assert "Reason: Bad Request" in exception_msg
+        assert "HTTP response body: failed to fetch source collection nonexistant" in exception_msg
+
+    def test_create_index_insufficient_quota(self):
+        self.enable_teardown = False
+
+        with pytest.raises(pinecone.core.client.exceptions.ApiException) as excinfo:
+            self.pinecone.create_index(name=self.index_name, dimension=5, replicas=20)
+
+        exception_msg = str(excinfo.value)
+        assert "Reason: Bad Request" in exception_msg
+        assert "HTTP response body: The index exceeds the project quota of 5 pods by 15 pods." in exception_msg
+
+    # endregion
+
+    def test_create_index(self):
+        self.pinecone.create_index(name=self.index_name, dimension=10, timeout=-1)
+        index = self.pinecone.describe_index(name=self.index_name)
+
+        assert index.name == self.index_name
+        assert index.dimension == 10
+        assert index.metric == "cosine"
+        assert index.pods == 1
+        assert index.replicas == 1
+        assert index.shards == 1
+
+    def test_create_index_with_options(self):
+        self.pinecone.create_index(
+            name=self.index_name, dimension=10, metric="euclidean", replicas=2, pod_type="p1.x2", timeout=-1
+        )
+        index = self.pinecone.describe_index(name=self.index_name)
+
+        assert index.name == self.index_name
+        assert index.dimension == 10
+        assert index.metric == "euclidean"
+        assert index.pods == 2
+        assert index.replicas == 2
+        assert index.shards == 1

--- a/tests/integration/control/test_describe_index.py
+++ b/tests/integration/control/test_describe_index.py
@@ -1,0 +1,42 @@
+import pytest
+import pinecone
+import os
+import tests.test_helpers as test_helpers
+
+
+class TestDescribeIndex:
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        # setup
+        api_key = os.getenv("PINECONE_API_KEY")
+        environment = os.getenv("PINECONE_ENVIRONMENT")
+
+        self.index_name = test_helpers.generate_index_name()
+        self.pinecone = pinecone
+        self.pinecone.init(api_key=api_key, environment=environment)
+        self.pinecone.create_index(name=self.index_name, dimension=5, timeout=-1)
+        self.enable_teardown = True
+
+        # run test
+        yield
+
+        # teardown
+        if self.enable_teardown:
+            self.pinecone.delete_index(name=self.index_name, timeout=-1)
+
+    def test_describe_index(self):
+        description = self.pinecone.describe_index(name=self.index_name)
+        assert description.name == self.index_name
+        assert description.dimension == 5
+        assert description.metric == "cosine"
+        assert description.pods == 1
+        assert description.replicas == 1
+        assert description.shards == 1
+
+    def test_describe_index_invalid_name(self):
+        with pytest.raises(pinecone.core.client.exceptions.NotFoundException) as excinfo:
+            self.pinecone.describe_index(name="invalid-index-name")
+
+        exception_msg = str(excinfo.value)
+        assert "Reason: Not Found" in exception_msg
+        assert "HTTP response body: 404: Not Found" in exception_msg

--- a/tests/integration/control/test_list_indexes.py
+++ b/tests/integration/control/test_list_indexes.py
@@ -1,0 +1,30 @@
+import pytest
+import pinecone
+import os
+import tests.test_helpers as test_helpers
+
+
+class TestListIndexes:
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        # setup
+        api_key = os.getenv("PINECONE_API_KEY")
+        environment = os.getenv("PINECONE_ENVIRONMENT")
+        pinecone.init(api_key=api_key, environment=environment)
+
+        self.index_name = test_helpers.generate_index_name()
+        self.pinecone = pinecone
+        self.pinecone.create_index(name=self.index_name, dimension=5, timeout=-1)
+
+        # run test
+        yield
+
+        # teardown
+        pinecone.delete_index(name=self.index_name, timeout=-1)
+
+    def test_list_indexes(self):
+        indexes = self.pinecone.list_indexes()
+
+        assert indexes is not None
+        assert len(indexes) > 0
+        assert self.index_name in indexes

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,12 @@
+import random
+
+def generate_random_string(length: int):
+    letters = "abcdefghijklmnopqrstuvwxyz0123456789"
+    return ''.join(random.choice(letters) for i in range(length))
+
+def generate_index_name():
+    return f"python-index-{generate_random_string(10)}"
+
+
+# generate records 
+# generate sparse values


### PR DESCRIPTION
## Problem
Our Python client doesn't have true integration tests. Currently, we have tests under `/integ/test_index.py` which mock all the requests and responses and primarily stress the connections between various elements of the client codebase. Fleshing out integration tests would help us have more confidence when making changes to the Python client, especially when involving the network layer.

## Solution
The plan is to split between control plane and data plane tests. For PRs I thought it'd be reasonable to split things out, and then finish off with CI changes to bring everything together.

- Add a new section for integration tests under `/tests/integration/control/`
- Implement control plane integration tests:
    - `test_create_index.py`
    - `test_configure_index.py`
    - `test_describe_index.py`
    - `test_list_indexes.py`

Currently, the entire control plane suite completes in about ~35 seconds or so. `sdk-python-testing` currently has a Pod Limit of 7, and these seem to complete fine, but I'd like to get quote bumped to reduce possibility of flaking.

![Screenshot 2023-10-19 at 1 45 55 PM](https://github.com/pinecone-io/pinecone-python-client/assets/119623786/83043915-ae98-48d6-8244-f12c02117cca)

**Question: ** Should I look at rolling some collection tests here as well?

## Type of Change
- [X] Infrastructure change (CI configs, etc)

## Test Plan
Currently, these tests aren't being run in CI. That will come in a following PR. The environment variables that are used will be setup in GitHub secrets for the repo/workflows.

To test locally, you'll need to set environment variables and then call `pytest`:

```
$ export PINECONE_API_KEY="my-api-key"
$ export PINECONE_ENVIRONMENT="my-environment"

$ poetry run pytest tests/integration/control/
...
```
