### PR TITLE
[Fix] Incorporate poetry changes into nightly build workflows

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -28,14 +28,20 @@ jobs:
         if: steps.list-commits.outputs.commits == ''
         uses: andymckay/cancel-action@0.3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+
       - name: Set dev version
         id: version
         run: |
-          versionFile="pinecone/__version__"
           currentDate=$(date +%Y%m%d%H%M%S)
-          versionNumber=$(cat $versionFile)
+          versionNumber=$(poetry version -s)
           devVersion="${versionNumber}.dev${currentDate}"
-          echo "$devVersion" > $versionFile
+          poetry version $devVersion
 
       - name: Adjust module name
         run: |
@@ -44,13 +50,6 @@ jobs:
       - name: Update README
         run: |
           echo "This is a nightly developer build of the Pinecone Python client. It is not intended for production use." > README.md
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-
-      - name: Setup Poetry
-        uses: ./.github/actions/setup-poetry
 
       - name: Build Python client
         run: make package

--- a/.github/workflows/nightly-spruce-dev-release.yaml
+++ b/.github/workflows/nightly-spruce-dev-release.yaml
@@ -30,13 +30,19 @@ jobs:
         if: steps.list-commits.outputs.commits == ''
         uses: andymckay/cancel-action@0.3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+
       - name: Set spruce dev version
         run: |
-          versionFile="pinecone/__version__"
           currentDate=$(date +%Y%m%d%H%M%S)
-          versionNumber=$(cat $versionFile)
-          devVersion="${versionNumber}.dev${currentDate}.spruceDev"
-          echo "$devVersion" > $versionFile
+          versionNumber=$(poetry version -s)
+          devVersion="${versionNumber}.dev${currentDate}"
+          poetry version $devVersion
 
       - name: Adjust module name
         run: |
@@ -45,13 +51,6 @@ jobs:
       - name: Update README
         run: |
           echo "This is a nightly Spruce developer build of the Pinecone Python client. It is not intended for production use." > README.md
-
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-
-      - name: Setup Poetry
-        uses: ./.github/actions/setup-poetry
 
       - name: Build Python client
         run: make package


### PR DESCRIPTION
## Problem

Nightly builds have no succeeded since poetry stuff got merged a couple of weeks ago. This is because the version update step was not updated to change the version number in pyproject.toml and pypi complained of version conflicts.

## Solution

Use poetry to set version in `pyproject.toml` before uploading to pypi.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure change (CI configs, etc)
