### PR TITLE
Pin docs-build python version

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: {{ inputs.python-version }}
+        python-version: ${{ inputs.python-version }}
 
     - name: Setup Poetry
       uses: ./.github/actions/setup-poetry

--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -1,12 +1,17 @@
 name: 'Build client documentation'
 description: 'Generates client documentation using pdoc'
+inputs:
+  python-version:
+    description: 'Python version to use'
+    required: true
+    default: '3.x'
 runs:
   using: 'composite'
   steps:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.x
+        python-version: {{ inputs.python-version }}
 
     - name: Setup Poetry
       uses: ./.github/actions/setup-poetry

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Generate pdoc documentation
         uses: ./.github/actions/build-docs
+        with:
+          python-version: 3.11
 
       - name: Push documentation artifacts to sdk-docs
         uses: cpina/github-action-push-to-another-repository@main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: [3.9, '3.10', 3.11, 3.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,7 @@ jobs:
     name: Build docs with pdoc
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.9, '3.10', 3.11, 3.12]
     steps:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,14 +14,10 @@ jobs:
   build-docs:
     name: Build docs with pdoc
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.9, '3.10', 3.11, 3.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build docs with pdoc
         uses: './.github/actions/build-docs'
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.11

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,8 +14,13 @@ jobs:
   build-docs:
     name: Build docs with pdoc
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11, 3.12]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build docs with pdoc
         uses: './.github/actions/build-docs'
+        with:
+          python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Problem

The build-docs workflow action has been failing since `setup-python`, which was configured with floating version `3.x`, rolled over to install the new 3.12 cpython release.

## Solution

Pin to cpython 3.11 so things can build while we do more investigation about how to unblock running with 3.12.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

See builds passing again.