### PR TITLE
[spruce] Add additional_headers config

### DIFF
--- a/pinecone/config/config.py
+++ b/pinecone/config/config.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Dict
 import os
 
 from pinecone.exceptions import PineconeConfigurationError
@@ -11,7 +11,8 @@ class Config(NamedTuple):
     api_key: str = ""
     host: str = ""
     openapi_config: Optional[OpenApiConfiguration] = None
-
+    additional_headers: Optional[Dict[str, str]] = {}
+    
 
 class ConfigBuilder:
     """
@@ -35,6 +36,7 @@ class ConfigBuilder:
         api_key: Optional[str] = None,
         host: Optional[str] = None,
         openapi_config: Optional[OpenApiConfiguration] = None,
+        additional_headers: Optional[Dict[str, str]] = {},
         **kwargs,
     ) -> Config:
         api_key = api_key or kwargs.pop("api_key", None) or os.getenv("PINECONE_API_KEY")
@@ -51,4 +53,4 @@ class ConfigBuilder:
             or OpenApiConfigFactory.build(api_key=api_key, host=host)
         )
 
-        return Config(api_key, host, openapi_config)
+        return Config(api_key, host, openapi_config, additional_headers)

--- a/pinecone/config/pinecone_config.py
+++ b/pinecone/config/pinecone_config.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 import os
 from .config import ConfigBuilder, Config
 
@@ -7,6 +7,6 @@ DEFAULT_CONTROLLER_HOST = "https://api.pinecone.io"
 
 class PineconeConfig():
     @staticmethod
-    def build(api_key: Optional[str] = None, host: Optional[str] = None, **kwargs) -> Config:
+    def build(api_key: Optional[str] = None, host: Optional[str] = None, additional_headers: Optional[Dict[str, str]] = {},  **kwargs) -> Config:
         host = host or kwargs.get("host") or os.getenv("PINECONE_CONTROLLER_HOST") or DEFAULT_CONTROLLER_HOST
-        return ConfigBuilder.build(api_key=api_key, host=host, **kwargs)
+        return ConfigBuilder.build(api_key=api_key, host=host, additional_headers=additional_headers, **kwargs)

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -43,7 +43,8 @@ class Pinecone:
         else:
             api_client = ApiClient(configuration=self.config.openapi_config)
             api_client.user_agent = get_user_agent()
-            for key, value in self.config.additional_headers.items():
+            extra_headers = self.config.additional_headers or {}
+            for key, value in extra_headers.items():
                 api_client.set_default_header(key, value)
             self.index_api = IndexOperationsApi(api_client)
 

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -25,6 +25,7 @@ class Pinecone:
         api_key: Optional[str] = None,
         host: Optional[str] = None,
         config: Optional[Config] = None,
+        additional_headers: Optional[Dict[str, str]] = {},
         index_api: Optional[IndexOperationsApi] = None,
         **kwargs,
     ):
@@ -35,13 +36,15 @@ class Pinecone:
             else:
                 self.config = configKwarg
         else:
-            self.config = PineconeConfig.build(api_key=api_key, host=host, **kwargs)
+            self.config = PineconeConfig.build(api_key=api_key, host=host, additional_headers=additional_headers, **kwargs)
 
         if index_api:
             self.index_api = index_api
         else:
             api_client = ApiClient(configuration=self.config.openapi_config)
             api_client.user_agent = get_user_agent()
+            for key, value in self.config.additional_headers.items():
+                api_client.set_default_header(key, value)
             self.index_api = IndexOperationsApi(api_client)
 
         self.index_host_store = IndexHostStore()

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -11,6 +11,12 @@ class TestControl:
         p = Pinecone(api_key="123-456-789", host="my-host")
         assert p.index_api.api_client.configuration.host == "my-host"
 
+    def test_passing_additional_headers(self):
+        extras = {"header1": "my-value", "header2": "my-value2"}
+        p = Pinecone(api_key="123-456-789", additional_headers=extras)
+
+        for key, value in extras.items():
+            assert p.index_api.api_client.default_headers[key] == value
 
     @pytest.mark.parametrize("timeout_value, describe_index_responses, expected_describe_index_calls, expected_sleep_calls", [
         # When timeout=None, describe_index is called until ready


### PR DESCRIPTION
## Problem

To support API development and testing, we would like a way to pass additional headers with every request.

## Solution

Add a new `additional_headers` config option and wire up the api client internals to use them.

Usage:

```python
from pinecone import Pinecone

p = Pinecone(api_key='asdf', additional_headers={'X-SECRET-EXTRAS': 'secret secret'})
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Added a unit test and also verified manually running with `PINECONE_DEBUG_CURL=true`

![Screenshot 2023-11-18 at 5 53 56 PM](https://github.com/pinecone-io/pinecone-python-client/assets/1326365/2b31c8a3-96ba-42da-a171-3d3061fe487e)
