### PR TITLE
[Fix] Prelease CI job uses bump action to version

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Poetry bump pyproject toml version
         run: |
-          poetry version ${{ inputs.releaseLevel }}
+          poetry version ${{ steps.bump.outputs.version }}
 
       - name: Build Python client
         run: make package


### PR DESCRIPTION
## Problem

When we migrated to `poetry`, the prerelease job did not get updated to set prerelease versions correctly.

## Solution

We need to use our action to compute the correct prerelease version.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure change (CI configs, etc)
