### PR TITLE
[spruce] Allow GRPCIndexBase to use config.host to establish endpoint

### DIFF
--- a/pinecone/grpc/base.py
+++ b/pinecone/grpc/base.py
@@ -18,6 +18,7 @@ from pinecone.exceptions import PineconeException
 
 _logger = logging.getLogger(__name__)
 
+
 class GRPCIndexBase(ABC):
     """
     Base class for grpc-based interaction with Pinecone indexes
@@ -29,12 +30,13 @@ class GRPCIndexBase(ABC):
         self,
         index_name: str,
         config: Config,
-        channel: Optional[Channel] =None,
+        channel: Optional[Channel] = None,
         grpc_config: Optional[GRPCClientConfig] = None,
         _endpoint_override: Optional[str] = None,
     ):
         self.name = index_name
 
+        self.config = config
         self.grpc_client_config = grpc_config or GRPCClientConfig()
         self.retry_config = self.grpc_client_config.retry_config or RetryConfig()
         self.fixed_metadata = {"api-key": config.api_key, "service-name": index_name, "client-version": CLIENT_VERSION}
@@ -76,11 +78,8 @@ class GRPCIndexBase(ABC):
         pass
 
     def _endpoint(self):
-        return (
-            self._endpoint_override
-            if self._endpoint_override
-            else f"{self.name}-{Config.PROJECT_NAME}.svc.{Config.ENVIRONMENT}.pinecone.io:443"
-        )
+        grpcHost = self.config.host.replace("https://", "")
+        return self._endpoint_override if self._endpoint_override else f"{grpcHost}:443"
 
     def _gen_channel(self, options=None):
         target = self._endpoint()


### PR DESCRIPTION
## Problem
Currently, you cannot target an index using the `PineconeGRPC` client. `GRPCIndexBase._endpoint` is still trying to use `Config.PROJECT_NAME` and `Config.ENVIRONMENT` which have been deprecated.

<img width="853" alt="Screenshot 2023-11-26 at 9 20 49 PM" src="https://github.com/pinecone-io/pinecone-python-client/assets/119623786/d5964d2f-8bf6-4fa0-ba7a-9c9b69e5ae07">

## Solution
Update `GRPCIndexBase` to properly leverage the `config` which is passed via `PineconeGRPC`. We also need to strip out the `https://` and keep the port `443`.

<img width="639" alt="Screenshot 2023-11-26 at 9 50 36 PM" src="https://github.com/pinecone-io/pinecone-python-client/assets/119623786/0d70089a-1230-48dc-982a-0219a6a230c0">

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

