### PR TITLE
Cleanup exception hierarchy

### DIFF
--- a/pinecone/config/config.py
+++ b/pinecone/config/config.py
@@ -2,7 +2,7 @@ from typing import NamedTuple, Optional, Dict
 import os
 
 from pinecone.exceptions import PineconeConfigurationError
-from pinecone.core.client.exceptions import ApiKeyError
+from pinecone.core.client.exceptions import PineconeApiKeyError
 from pinecone.config.openapi import OpenApiConfigFactory
 from pinecone.core.client.configuration import Configuration as OpenApiConfiguration
 

--- a/pinecone/config/config.py
+++ b/pinecone/config/config.py
@@ -2,7 +2,6 @@ from typing import NamedTuple, Optional, Dict
 import os
 
 from pinecone.exceptions import PineconeConfigurationError
-from pinecone.core.client.exceptions import PineconeApiKeyError
 from pinecone.config.openapi import OpenApiConfigFactory
 from pinecone.core.client.configuration import Configuration as OpenApiConfiguration
 

--- a/pinecone/control/index_host_store.py
+++ b/pinecone/control/index_host_store.py
@@ -1,6 +1,7 @@
 from typing import Dict
 from pinecone.config import Config
 from pinecone.core.client.api.manage_pod_indexes_api import ManagePodIndexesApi as IndexOperationsApi
+from pinecone.core.client.exceptions import PineconeException
 
 class SingletonMeta(type):
     _instances: Dict[str, str] = {}
@@ -40,5 +41,5 @@ class IndexHostStore(metaclass=SingletonMeta):
             description = api.describe_index(index_name)
             self.set_host(config, index_name, description.host)
             if not self.key_exists(key):
-                raise Exception(f"Could not get host for index: {index_name}. Call describe_index('{index_name}') to check the current status.")
+                raise PineconeException(f"Could not get host for index: {index_name}. Call describe_index('{index_name}') to check the current status.")
             return self._indexHosts[key]

--- a/pinecone/core/client/__init__.py
+++ b/pinecone/core/client/__init__.py
@@ -19,9 +19,9 @@ from pinecone.core.client.api_client import ApiClient
 from pinecone.core.client.configuration import Configuration
 
 # import exceptions
-from pinecone.core.client.exceptions import OpenApiException
-from pinecone.core.client.exceptions import ApiAttributeError
-from pinecone.core.client.exceptions import ApiTypeError
-from pinecone.core.client.exceptions import ApiValueError
-from pinecone.core.client.exceptions import ApiKeyError
-from pinecone.core.client.exceptions import ApiException
+from pinecone.core.client.exceptions import PineconeException
+from pinecone.core.client.exceptions import PineconeApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiTypeError
+from pinecone.core.client.exceptions import PineconeApiValueError
+from pinecone.core.client.exceptions import PineconeApiKeyError
+from pinecone.core.client.exceptions import PineconeApiException

--- a/pinecone/core/client/api_client.py
+++ b/pinecone/core/client/api_client.py
@@ -22,7 +22,7 @@ from urllib3.fields import RequestField
 
 from pinecone.core.client import rest
 from pinecone.core.client.configuration import Configuration
-from pinecone.core.client.exceptions import ApiTypeError, ApiValueError, ApiException
+from pinecone.core.client.exceptions import PineconeApiTypeError, PineconeApiValueError, PineconeApiException
 from pinecone.core.client.model_utils import (
     ModelNormal,
     ModelSimple,
@@ -197,7 +197,7 @@ class ApiClient(object):
                 post_params=post_params, body=body,
                 _preload_content=_preload_content,
                 _request_timeout=_request_timeout)
-        except ApiException as e:
+        except PineconeApiException as e:
             e.body = e.body.decode('utf-8')
             raise e
 
@@ -284,7 +284,7 @@ class ApiClient(object):
             return [cls.sanitize_for_serialization(item) for item in obj]
         if isinstance(obj, dict):
             return {key: cls.sanitize_for_serialization(val) for key, val in obj.items()}
-        raise ApiValueError('Unable to prepare type {} for serialization'.format(obj.__class__.__name__))
+        raise PineconeApiValueError('Unable to prepare type {} for serialization'.format(obj.__class__.__name__))
 
     def deserialize(self, response, response_type, _check_type):
         """Deserializes response into an object.
@@ -482,7 +482,7 @@ class ApiClient(object):
                                            _request_timeout=_request_timeout,
                                            body=body)
         else:
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "http method must be `GET`, `HEAD`, `OPTIONS`,"
                 " `POST`, `PATCH`, `PUT` or `DELETE`."
             )
@@ -543,7 +543,7 @@ class ApiClient(object):
                     # if the file field is nullable, skip None values
                     continue
                 if file_instance.closed is True:
-                    raise ApiValueError(
+                    raise PineconeApiValueError(
                         "Cannot read a closed file. The passed in file_type "
                         "for %s must be open." % param_name
                     )
@@ -614,7 +614,7 @@ class ApiClient(object):
                 elif auth_setting['in'] == 'query':
                     querys.append((auth_setting['key'], auth_setting['value']))
                 else:
-                    raise ApiValueError(
+                    raise PineconeApiValueError(
                         'Authentication token must be in `query` or `header`'
                     )
 
@@ -784,7 +784,7 @@ class Endpoint(object):
             )
         except IndexError:
             if self.settings['servers']:
-                raise ApiValueError(
+                raise PineconeApiValueError(
                     "Invalid host index. Must be 0 <= index < %s" %
                     len(self.settings['servers'])
                 )
@@ -792,17 +792,17 @@ class Endpoint(object):
 
         for key, value in kwargs.items():
             if key not in self.params_map['all']:
-                raise ApiTypeError(
+                raise PineconeApiTypeError(
                     "Got an unexpected parameter '%s'"
                     " to method `%s`" %
                     (key, self.settings['operation_id'])
                 )
-            # only throw this nullable ApiValueError if _check_input_type
+            # only throw this nullable PineconeApiValueError if _check_input_type
             # is False, if _check_input_type==True we catch this case
             # in self.__validate_inputs
             if (key not in self.params_map['nullable'] and value is None
                     and kwargs['_check_input_type'] is False):
-                raise ApiValueError(
+                raise PineconeApiValueError(
                     "Value may not be None for non-nullable parameter `%s`"
                     " when calling `%s`" %
                     (key, self.settings['operation_id'])
@@ -810,7 +810,7 @@ class Endpoint(object):
 
         for key in self.params_map['required']:
             if key not in kwargs.keys():
-                raise ApiValueError(
+                raise PineconeApiValueError(
                     "Missing the required parameter `%s` when calling "
                     "`%s`" % (key, self.settings['operation_id'])
                 )

--- a/pinecone/core/client/configuration.py
+++ b/pinecone/core/client/configuration.py
@@ -15,7 +15,7 @@ import sys
 import urllib3
 
 from http import client as http_client
-from pinecone.core.client.exceptions import ApiValueError
+from pinecone.core.client.exceptions import PineconeApiValueError
 
 
 JSON_SCHEMA_VALIDATION_KEYWORDS = {
@@ -234,7 +234,7 @@ conf = pinecone.core.client.Configuration(
             s = set(filter(None, value.split(',')))
             for v in s:
                 if v not in JSON_SCHEMA_VALIDATION_KEYWORDS:
-                    raise ApiValueError(
+                    raise PineconeApiValueError(
                         "Invalid keyword: '{0}''".format(v))
             self._disabled_client_side_validations = s
 

--- a/pinecone/core/client/exceptions.py
+++ b/pinecone/core/client/exceptions.py
@@ -9,11 +9,11 @@
 
 
 
-class OpenApiException(Exception):
-    """The base exception class for all OpenAPIExceptions"""
+class PineconeException(Exception):
+    """The base exception class for all exceptions in the Pinecone Python SDK"""
 
 
-class ApiTypeError(OpenApiException, TypeError):
+class PineconeApiTypeError(PineconeException, TypeError):
     def __init__(self, msg, path_to_item=None, valid_classes=None,
                  key_type=None):
         """ Raises an exception for TypeErrors
@@ -39,10 +39,10 @@ class ApiTypeError(OpenApiException, TypeError):
         full_msg = msg
         if path_to_item:
             full_msg = "{0} at {1}".format(msg, render_path(path_to_item))
-        super(ApiTypeError, self).__init__(full_msg)
+        super(PineconeApiTypeError, self).__init__(full_msg)
 
 
-class ApiValueError(OpenApiException, ValueError):
+class PineconeApiValueError(PineconeException, ValueError):
     def __init__(self, msg, path_to_item=None):
         """
         Args:
@@ -57,10 +57,10 @@ class ApiValueError(OpenApiException, ValueError):
         full_msg = msg
         if path_to_item:
             full_msg = "{0} at {1}".format(msg, render_path(path_to_item))
-        super(ApiValueError, self).__init__(full_msg)
+        super(PineconeApiValueError, self).__init__(full_msg)
 
 
-class ApiAttributeError(OpenApiException, AttributeError):
+class PineconeApiAttributeError(PineconeException, AttributeError):
     def __init__(self, msg, path_to_item=None):
         """
         Raised when an attribute reference or assignment fails.
@@ -76,10 +76,10 @@ class ApiAttributeError(OpenApiException, AttributeError):
         full_msg = msg
         if path_to_item:
             full_msg = "{0} at {1}".format(msg, render_path(path_to_item))
-        super(ApiAttributeError, self).__init__(full_msg)
+        super(PineconeApiAttributeError, self).__init__(full_msg)
 
 
-class ApiKeyError(OpenApiException, KeyError):
+class PineconeApiKeyError(PineconeException, KeyError):
     def __init__(self, msg, path_to_item=None):
         """
         Args:
@@ -93,10 +93,10 @@ class ApiKeyError(OpenApiException, KeyError):
         full_msg = msg
         if path_to_item:
             full_msg = "{0} at {1}".format(msg, render_path(path_to_item))
-        super(ApiKeyError, self).__init__(full_msg)
+        super(PineconeApiKeyError, self).__init__(full_msg)
 
 
-class ApiException(OpenApiException):
+class PineconeApiException(PineconeException):
 
     def __init__(self, status=None, reason=None, http_resp=None):
         if http_resp:
@@ -124,25 +124,25 @@ class ApiException(OpenApiException):
         return error_message
 
 
-class NotFoundException(ApiException):
+class NotFoundException(PineconeApiException):
 
     def __init__(self, status=None, reason=None, http_resp=None):
         super(NotFoundException, self).__init__(status, reason, http_resp)
 
 
-class UnauthorizedException(ApiException):
+class UnauthorizedException(PineconeApiException):
 
     def __init__(self, status=None, reason=None, http_resp=None):
         super(UnauthorizedException, self).__init__(status, reason, http_resp)
 
 
-class ForbiddenException(ApiException):
+class ForbiddenException(PineconeApiException):
 
     def __init__(self, status=None, reason=None, http_resp=None):
         super(ForbiddenException, self).__init__(status, reason, http_resp)
 
 
-class ServiceException(ApiException):
+class ServiceException(PineconeApiException):
 
     def __init__(self, status=None, reason=None, http_resp=None):
         super(ServiceException, self).__init__(status, reason, http_resp)

--- a/pinecone/core/client/model/aws_regions.py
+++ b/pinecone/core/client/model/aws_regions.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -156,7 +156,7 @@ class AwsRegions(ModelSimple):
             args = list(args)
             value = args.pop(0)
         else:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "value is required, but not passed in args or kwargs and doesn't have default",
                 path_to_item=_path_to_item,
                 valid_classes=(self.__class__,),
@@ -168,7 +168,7 @@ class AwsRegions(ModelSimple):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -185,7 +185,7 @@ class AwsRegions(ModelSimple):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
         self.value = value
         if kwargs:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (
                     kwargs,
                     self.__class__.__name__,
@@ -248,7 +248,7 @@ class AwsRegions(ModelSimple):
             args = list(args)
             value = args.pop(0)
         else:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "value is required, but not passed in args or kwargs and doesn't have default",
                 path_to_item=_path_to_item,
                 valid_classes=(self.__class__,),
@@ -260,7 +260,7 @@ class AwsRegions(ModelSimple):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -277,7 +277,7 @@ class AwsRegions(ModelSimple):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
         self.value = value
         if kwargs:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (
                     kwargs,
                     self.__class__.__name__,

--- a/pinecone/core/client/model/collection_list.py
+++ b/pinecone/core/client/model/collection_list.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -152,7 +152,7 @@ class CollectionList(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -232,7 +232,7 @@ class CollectionList(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -257,5 +257,5 @@ class CollectionList(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/collection_model.py
+++ b/pinecone/core/client/model/collection_model.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -172,7 +172,7 @@ class CollectionModel(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -264,7 +264,7 @@ class CollectionModel(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -294,5 +294,5 @@ class CollectionModel(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/configure_index_request.py
+++ b/pinecone/core/client/model/configure_index_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -154,7 +154,7 @@ class ConfigureIndexRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -237,7 +237,7 @@ class ConfigureIndexRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -263,5 +263,5 @@ class ConfigureIndexRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/configure_index_request_spec.py
+++ b/pinecone/core/client/model/configure_index_request_spec.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -154,7 +154,7 @@ class ConfigureIndexRequestSpec(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -237,7 +237,7 @@ class ConfigureIndexRequestSpec(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -263,5 +263,5 @@ class ConfigureIndexRequestSpec(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/configure_index_request_spec_pod.py
+++ b/pinecone/core/client/model/configure_index_request_spec_pod.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -152,7 +152,7 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -233,7 +233,7 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -258,5 +258,5 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/create_collection_request.py
+++ b/pinecone/core/client/model/create_collection_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -151,7 +151,7 @@ class CreateCollectionRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -236,7 +236,7 @@ class CreateCollectionRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -263,5 +263,5 @@ class CreateCollectionRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/create_index_request.py
+++ b/pinecone/core/client/model/create_index_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -166,7 +166,7 @@ class CreateIndexRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -255,7 +255,7 @@ class CreateIndexRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -284,5 +284,5 @@ class CreateIndexRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/delete_request.py
+++ b/pinecone/core/client/model/delete_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -157,7 +157,7 @@ class DeleteRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -240,7 +240,7 @@ class DeleteRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -265,5 +265,5 @@ class DeleteRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/describe_index_stats_request.py
+++ b/pinecone/core/client/model/describe_index_stats_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -146,7 +146,7 @@ class DescribeIndexStatsRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -226,7 +226,7 @@ class DescribeIndexStatsRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -251,5 +251,5 @@ class DescribeIndexStatsRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/describe_index_stats_response.py
+++ b/pinecone/core/client/model/describe_index_stats_response.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -161,7 +161,7 @@ class DescribeIndexStatsResponse(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -244,7 +244,7 @@ class DescribeIndexStatsResponse(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -269,5 +269,5 @@ class DescribeIndexStatsResponse(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/error_response.py
+++ b/pinecone/core/client/model/error_response.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -157,7 +157,7 @@ class ErrorResponse(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -242,7 +242,7 @@ class ErrorResponse(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -269,5 +269,5 @@ class ErrorResponse(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/error_response_error.py
+++ b/pinecone/core/client/model/error_response_error.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -174,7 +174,7 @@ class ErrorResponseError(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -260,7 +260,7 @@ class ErrorResponseError(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -287,5 +287,5 @@ class ErrorResponseError(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/fetch_response.py
+++ b/pinecone/core/client/model/fetch_response.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -155,7 +155,7 @@ class FetchResponse(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -236,7 +236,7 @@ class FetchResponse(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -261,5 +261,5 @@ class FetchResponse(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/gcp_regions.py
+++ b/pinecone/core/client/model/gcp_regions.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -159,7 +159,7 @@ class GcpRegions(ModelSimple):
             args = list(args)
             value = args.pop(0)
         else:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "value is required, but not passed in args or kwargs and doesn't have default",
                 path_to_item=_path_to_item,
                 valid_classes=(self.__class__,),
@@ -171,7 +171,7 @@ class GcpRegions(ModelSimple):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -188,7 +188,7 @@ class GcpRegions(ModelSimple):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
         self.value = value
         if kwargs:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (
                     kwargs,
                     self.__class__.__name__,
@@ -251,7 +251,7 @@ class GcpRegions(ModelSimple):
             args = list(args)
             value = args.pop(0)
         else:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "value is required, but not passed in args or kwargs and doesn't have default",
                 path_to_item=_path_to_item,
                 valid_classes=(self.__class__,),
@@ -263,7 +263,7 @@ class GcpRegions(ModelSimple):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -280,7 +280,7 @@ class GcpRegions(ModelSimple):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
         self.value = value
         if kwargs:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (
                     kwargs,
                     self.__class__.__name__,

--- a/pinecone/core/client/model/index_list.py
+++ b/pinecone/core/client/model/index_list.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -152,7 +152,7 @@ class IndexList(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -232,7 +232,7 @@ class IndexList(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -257,5 +257,5 @@ class IndexList(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/index_model.py
+++ b/pinecone/core/client/model/index_model.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -180,7 +180,7 @@ class IndexModel(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -273,7 +273,7 @@ class IndexModel(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -304,5 +304,5 @@ class IndexModel(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/index_model_spec.py
+++ b/pinecone/core/client/model/index_model_spec.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -157,7 +157,7 @@ class IndexModelSpec(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -238,7 +238,7 @@ class IndexModelSpec(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -263,5 +263,5 @@ class IndexModelSpec(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/index_model_status.py
+++ b/pinecone/core/client/model/index_model_status.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -161,7 +161,7 @@ class IndexModelStatus(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -246,7 +246,7 @@ class IndexModelStatus(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -273,5 +273,5 @@ class IndexModelStatus(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/namespace_summary.py
+++ b/pinecone/core/client/model/namespace_summary.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -146,7 +146,7 @@ class NamespaceSummary(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -226,7 +226,7 @@ class NamespaceSummary(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -251,5 +251,5 @@ class NamespaceSummary(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/pod_spec.py
+++ b/pinecone/core/client/model/pod_spec.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -185,7 +185,7 @@ class PodSpec(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -282,7 +282,7 @@ class PodSpec(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -312,5 +312,5 @@ class PodSpec(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/pod_spec_metadata_config.py
+++ b/pinecone/core/client/model/pod_spec_metadata_config.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -146,7 +146,7 @@ class PodSpecMetadataConfig(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -226,7 +226,7 @@ class PodSpecMetadataConfig(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -251,5 +251,5 @@ class PodSpecMetadataConfig(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/protobuf_any.py
+++ b/pinecone/core/client/model/protobuf_any.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -149,7 +149,7 @@ class ProtobufAny(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -230,7 +230,7 @@ class ProtobufAny(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -255,5 +255,5 @@ class ProtobufAny(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/protobuf_null_value.py
+++ b/pinecone/core/client/model/protobuf_null_value.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -162,7 +162,7 @@ class ProtobufNullValue(ModelSimple):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -179,7 +179,7 @@ class ProtobufNullValue(ModelSimple):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
         self.value = value
         if kwargs:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (
                     kwargs,
                     self.__class__.__name__,
@@ -250,7 +250,7 @@ class ProtobufNullValue(ModelSimple):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -267,7 +267,7 @@ class ProtobufNullValue(ModelSimple):
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
         self.value = value
         if kwargs:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid named arguments=%s passed to %s. Remove those invalid named arguments." % (
                     kwargs,
                     self.__class__.__name__,

--- a/pinecone/core/client/model/query_request.py
+++ b/pinecone/core/client/model/query_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -191,7 +191,7 @@ class QueryRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -282,7 +282,7 @@ class QueryRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -308,5 +308,5 @@ class QueryRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/query_response.py
+++ b/pinecone/core/client/model/query_response.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -160,7 +160,7 @@ class QueryResponse(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -242,7 +242,7 @@ class QueryResponse(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -267,5 +267,5 @@ class QueryResponse(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/query_vector.py
+++ b/pinecone/core/client/model/query_vector.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -172,7 +172,7 @@ class QueryVector(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -259,7 +259,7 @@ class QueryVector(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -285,5 +285,5 @@ class QueryVector(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/rpc_status.py
+++ b/pinecone/core/client/model/rpc_status.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -158,7 +158,7 @@ class RpcStatus(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -240,7 +240,7 @@ class RpcStatus(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -265,5 +265,5 @@ class RpcStatus(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/scored_vector.py
+++ b/pinecone/core/client/model/scored_vector.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -170,7 +170,7 @@ class ScoredVector(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -257,7 +257,7 @@ class ScoredVector(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -283,5 +283,5 @@ class ScoredVector(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/serverless_spec.py
+++ b/pinecone/core/client/model/serverless_spec.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -156,7 +156,7 @@ class ServerlessSpec(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -241,7 +241,7 @@ class ServerlessSpec(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -268,5 +268,5 @@ class ServerlessSpec(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/single_query_results.py
+++ b/pinecone/core/client/model/single_query_results.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -155,7 +155,7 @@ class SingleQueryResults(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -236,7 +236,7 @@ class SingleQueryResults(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -261,5 +261,5 @@ class SingleQueryResults(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/sparse_values.py
+++ b/pinecone/core/client/model/sparse_values.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -155,7 +155,7 @@ class SparseValues(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -240,7 +240,7 @@ class SparseValues(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -267,5 +267,5 @@ class SparseValues(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/update_request.py
+++ b/pinecone/core/client/model/update_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -172,7 +172,7 @@ class UpdateRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -259,7 +259,7 @@ class UpdateRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -285,5 +285,5 @@ class UpdateRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/upsert_request.py
+++ b/pinecone/core/client/model/upsert_request.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -159,7 +159,7 @@ class UpsertRequest(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -243,7 +243,7 @@ class UpsertRequest(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -269,5 +269,5 @@ class UpsertRequest(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/upsert_response.py
+++ b/pinecone/core/client/model/upsert_response.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 
@@ -146,7 +146,7 @@ class UpsertResponse(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -226,7 +226,7 @@ class UpsertResponse(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -251,5 +251,5 @@ class UpsertResponse(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model/vector.py
+++ b/pinecone/core/client/model/vector.py
@@ -12,7 +12,7 @@ import re  # noqa: F401
 import sys  # noqa: F401
 
 from pinecone.core.client.model_utils import (  # noqa: F401
-    ApiTypeError,
+    PineconeApiTypeError,
     ModelComposed,
     ModelNormal,
     ModelSimple,
@@ -26,7 +26,7 @@ from pinecone.core.client.model_utils import (  # noqa: F401
     validate_get_composed_info,
 )
 from ..model_utils import OpenApiModel
-from pinecone.core.client.exceptions import ApiAttributeError
+from pinecone.core.client.exceptions import PineconeApiAttributeError
 
 
 def lazy_import():
@@ -169,7 +169,7 @@ class Vector(ModelNormal):
         self = super(OpenApiModel, cls).__new__(cls)
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -256,7 +256,7 @@ class Vector(ModelNormal):
         _visited_composed_classes = kwargs.pop('_visited_composed_classes', ())
 
         if args:
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 "Invalid positional arguments=%s passed to %s. Remove those invalid positional arguments." % (
                     args,
                     self.__class__.__name__,
@@ -283,5 +283,5 @@ class Vector(ModelNormal):
                 continue
             setattr(self, var_name, var_value)
             if var_name in self.read_only_vars:
-                raise ApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
+                raise PineconeApiAttributeError(f"`{var_name}` is a read-only attribute. Use `from_openapi_data` to instantiate "
                                      f"class with read only attributes.")

--- a/pinecone/core/client/model_utils.py
+++ b/pinecone/core/client/model_utils.py
@@ -19,10 +19,10 @@ import tempfile
 from dateutil.parser import parse
 
 from pinecone.core.client.exceptions import (
-    ApiKeyError,
-    ApiAttributeError,
-    ApiTypeError,
-    ApiValueError,
+    PineconeApiKeyError,
+    PineconeApiAttributeError,
+    PineconeApiTypeError,
+    PineconeApiValueError,
 )
 
 none_type = type(None)
@@ -129,7 +129,7 @@ class OpenApiModel(object):
         if name in self.openapi_types:
             required_types_mixed = self.openapi_types[name]
         elif self.additional_properties_type is None:
-            raise ApiAttributeError(
+            raise PineconeApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
                 path_to_item
@@ -144,7 +144,7 @@ class OpenApiModel(object):
                 valid_classes=(str,),
                 key_type=True
             )
-            raise ApiTypeError(
+            raise PineconeApiTypeError(
                 error_msg,
                 path_to_item=path_to_item,
                 valid_classes=(str,),
@@ -238,7 +238,7 @@ class OpenApiModel(object):
         else:
             # The input data does not contain the discriminator property.
             path_to_item = kwargs.get('_path_to_item', ())
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "Cannot deserialize input data due to missing discriminator. "
                 "The discriminator property '%s' is missing at path: %s" %
                 (discr_propertyname_js, path_to_item)
@@ -254,7 +254,7 @@ class OpenApiModel(object):
             path_to_item = kwargs.get('_path_to_item', ())
             disc_prop_value = kwargs.get(
                 discr_propertyname_js, kwargs.get(discr_propertyname_py))
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "Cannot deserialize input data due to invalid discriminator "
                 "value. The OpenAPI document has no mapping for discriminator "
                 "property '%s'='%s' at path: %s" %
@@ -354,7 +354,7 @@ class OpenApiModel(object):
         else:
             # The input data does not contain the discriminator property.
             path_to_item = kwargs.get('_path_to_item', ())
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "Cannot deserialize input data due to missing discriminator. "
                 "The discriminator property '%s' is missing at path: %s" %
                 (discr_propertyname_js, path_to_item)
@@ -370,7 +370,7 @@ class OpenApiModel(object):
             path_to_item = kwargs.get('_path_to_item', ())
             disc_prop_value = kwargs.get(
                 discr_propertyname_js, kwargs.get(discr_propertyname_py))
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "Cannot deserialize input data due to invalid discriminator "
                 "value. The OpenAPI document has no mapping for discriminator "
                 "property '%s'='%s' at path: %s" %
@@ -439,7 +439,7 @@ class ModelSimple(OpenApiModel):
         if name in self:
             return self.get(name)
 
-        raise ApiAttributeError(
+        raise PineconeApiAttributeError(
             "{0} has no attribute '{1}'".format(
                 type(self).__name__, name),
             [e for e in [self._path_to_item, name] if e]
@@ -494,7 +494,7 @@ class ModelNormal(OpenApiModel):
         if name in self:
             return self.get(name)
 
-        raise ApiAttributeError(
+        raise PineconeApiAttributeError(
             "{0} has no attribute '{1}'".format(
                 type(self).__name__, name),
             [e for e in [self._path_to_item, name] if e]
@@ -589,7 +589,7 @@ class ModelComposed(OpenApiModel):
             - have additionalProperties set
             """
             if name not in self.openapi_types:
-                raise ApiAttributeError(
+                raise PineconeApiAttributeError(
                     "{0} has no attribute '{1}'".format(
                         type(self).__name__, name),
                     [e for e in [self._path_to_item, name] if e]
@@ -629,7 +629,7 @@ class ModelComposed(OpenApiModel):
         elif len_values == 1:
             return values[0]
         elif len_values > 1:
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "Values stored for property {0} in {1} differ when looking "
                 "at self and self's composed instances. All values must be "
                 "the same".format(name, type(self).__name__),
@@ -640,7 +640,7 @@ class ModelComposed(OpenApiModel):
         """get the value of an attribute using square-bracket notation: `instance[attr]`"""
         value = self.get(name, self.__unset_attribute_value__)
         if value is self.__unset_attribute_value__:
-            raise ApiAttributeError(
+            raise PineconeApiAttributeError(
                 "{0} has no attribute '{1}'".format(
                     type(self).__name__, name),
                     [e for e in [self._path_to_item, name] if e]
@@ -820,7 +820,7 @@ def check_allowed_values(allowed_values, input_variable_path, input_values):
                 set(these_allowed_values))):
         invalid_values = ", ".join(
             map(str, set(input_values) - set(these_allowed_values))),
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid values for `%s` [%s], must be a subset of [%s]" %
             (
                 input_variable_path[0],
@@ -833,7 +833,7 @@ def check_allowed_values(allowed_values, input_variable_path, input_values):
                 input_values.keys()).issubset(set(these_allowed_values))):
         invalid_values = ", ".join(
             map(str, set(input_values.keys()) - set(these_allowed_values)))
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid keys in `%s` [%s], must be a subset of [%s]" %
             (
                 input_variable_path[0],
@@ -843,7 +843,7 @@ def check_allowed_values(allowed_values, input_variable_path, input_values):
         )
     elif (not isinstance(input_values, (list, dict))
             and input_values not in these_allowed_values):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s` (%s), must be one of %s" %
             (
                 input_variable_path[0],
@@ -890,7 +890,7 @@ def check_validations(
             isinstance(input_values, (int, float)) and
             not (float(input_values) / current_validations['multiple_of']).is_integer()):
         # Note 'multipleOf' will be as good as the floating point arithmetic.
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, value must be a multiple of "
             "`%s`" % (
                 input_variable_path[0],
@@ -901,7 +901,7 @@ def check_validations(
     if (is_json_validation_enabled('maxLength', configuration) and
             'max_length' in current_validations and
             len(input_values) > current_validations['max_length']):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, length must be less than or equal to "
             "`%s`" % (
                 input_variable_path[0],
@@ -912,7 +912,7 @@ def check_validations(
     if (is_json_validation_enabled('minLength', configuration) and
             'min_length' in current_validations and
             len(input_values) < current_validations['min_length']):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, length must be greater than or equal to "
             "`%s`" % (
                 input_variable_path[0],
@@ -923,7 +923,7 @@ def check_validations(
     if (is_json_validation_enabled('maxItems', configuration) and
             'max_items' in current_validations and
             len(input_values) > current_validations['max_items']):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, number of items must be less than or "
             "equal to `%s`" % (
                 input_variable_path[0],
@@ -958,7 +958,7 @@ def check_validations(
     if (is_json_validation_enabled('exclusiveMaximum', configuration) and
             'exclusive_maximum' in current_validations and
             max_val >= current_validations['exclusive_maximum']):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, must be a value less than `%s`" % (
                 input_variable_path[0],
                 current_validations['exclusive_maximum']
@@ -968,7 +968,7 @@ def check_validations(
     if (is_json_validation_enabled('maximum', configuration) and
             'inclusive_maximum' in current_validations and
             max_val > current_validations['inclusive_maximum']):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, must be a value less than or equal to "
             "`%s`" % (
                 input_variable_path[0],
@@ -979,7 +979,7 @@ def check_validations(
     if (is_json_validation_enabled('exclusiveMinimum', configuration) and
             'exclusive_minimum' in current_validations and
             min_val <= current_validations['exclusive_minimum']):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, must be a value greater than `%s`" %
             (
                 input_variable_path[0],
@@ -990,7 +990,7 @@ def check_validations(
     if (is_json_validation_enabled('minimum', configuration) and
             'inclusive_minimum' in current_validations and
             min_val < current_validations['inclusive_minimum']):
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid value for `%s`, must be a value greater than or equal "
             "to `%s`" % (
                 input_variable_path[0],
@@ -1010,7 +1010,7 @@ def check_validations(
             # Don't print the regex flags if the flags are not
             # specified in the OAS document.
             err_msg = r"%s with flags=`%s`" % (err_msg, flags)
-        raise ApiValueError(err_msg)
+        raise PineconeApiValueError(err_msg)
 
 
 def order_response_types(required_types):
@@ -1041,7 +1041,7 @@ def order_response_types(required_types):
             return COERCION_INDEX_BY_TYPE[ModelSimple]
         elif class_or_instance in COERCION_INDEX_BY_TYPE:
             return COERCION_INDEX_BY_TYPE[class_or_instance]
-        raise ApiValueError("Unsupported type: %s" % class_or_instance)
+        raise PineconeApiValueError("Unsupported type: %s" % class_or_instance)
 
     sorted_types = sorted(
         required_types,
@@ -1196,7 +1196,7 @@ def get_type_error(var_value, path_to_item, valid_classes, key_type=False):
         valid_classes=valid_classes,
         key_type=key_type
     )
-    return ApiTypeError(
+    return PineconeApiTypeError(
         error_msg,
         path_to_item=path_to_item,
         valid_classes=valid_classes,
@@ -1248,7 +1248,7 @@ def deserialize_primitive(data, klass, path_to_item):
             return converted_value
     except (OverflowError, ValueError) as ex:
         # parse can raise OverflowError
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "{0}Failed to parse {1} as {2}".format(
                 additional_message, repr(data), klass.__name__
             ),
@@ -1328,9 +1328,9 @@ def deserialize_model(model_data, model_class, path_to_item, check_type,
         model instance
 
     Raise:
-        ApiTypeError
-        ApiValueError
-        ApiKeyError
+        PineconeApiTypeError
+        PineconeApiValueError
+        PineconeApiKeyError
     """
 
     kw_args = dict(_check_type=check_type,
@@ -1408,9 +1408,9 @@ def attempt_convert_item(input_value, valid_classes, path_to_item,
         instance (any) the fixed item
 
     Raises:
-        ApiTypeError
-        ApiValueError
-        ApiKeyError
+        PineconeApiTypeError
+        PineconeApiValueError
+        PineconeApiKeyError
     """
     valid_classes_ordered = order_response_types(valid_classes)
     valid_classes_coercible = remove_uncoercible(
@@ -1431,7 +1431,7 @@ def attempt_convert_item(input_value, valid_classes, path_to_item,
                 return deserialize_file(input_value, configuration)
             return deserialize_primitive(input_value, valid_class,
                                          path_to_item)
-        except (ApiTypeError, ApiValueError, ApiKeyError) as conversion_exc:
+        except (PineconeApiTypeError, PineconeApiValueError, PineconeApiKeyError) as conversion_exc:
             if must_convert:
                 raise conversion_exc
             # if we have conversion errors when must_convert == False
@@ -1527,7 +1527,7 @@ def validate_and_convert_types(input_value, required_types_mixed, path_to_item,
         the correctly typed value
 
     Raises:
-        ApiTypeError
+        PineconeApiTypeError
     """
     results = get_required_type_classes(required_types_mixed, spec_property_naming)
     valid_classes, child_req_types_by_current_type = results
@@ -1750,7 +1750,7 @@ def get_allof_instances(self, model_args, constant_args):
             allof_instance = allof_class(**model_args, **constant_args)
             composed_instances.append(allof_instance)
         except Exception as ex:
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "Invalid inputs given to generate an instance of '%s'. The "
                 "input data was invalid for the allOf schema '%s' in the composed "
                 "schema '%s'. Error=%s" % (
@@ -1826,13 +1826,13 @@ def get_oneof_instance(cls, model_kwargs, constant_kwargs, model_arg=None):
         except Exception:
             pass
     if len(oneof_instances) == 0:
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid inputs given to generate an instance of %s. None "
             "of the oneOf schemas matched the input data." %
             cls.__name__
         )
     elif len(oneof_instances) > 1:
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid inputs given to generate an instance of %s. Multiple "
             "oneOf schemas matched the inputs, but a max of one is allowed." %
             cls.__name__
@@ -1872,7 +1872,7 @@ def get_anyof_instances(self, model_args, constant_args):
         except Exception:
             pass
     if len(anyof_instances) == 0:
-        raise ApiValueError(
+        raise PineconeApiValueError(
             "Invalid inputs given to generate an instance of %s. None of the "
             "anyOf schemas matched the inputs." %
             self.__class__.__name__

--- a/pinecone/core/client/rest.py
+++ b/pinecone/core/client/rest.py
@@ -18,7 +18,7 @@ from urllib.parse import urlencode
 
 import urllib3
 
-from pinecone.core.client.exceptions import ApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, ApiValueError
+from pinecone.core.client.exceptions import PineconeApiException, UnauthorizedException, ForbiddenException, NotFoundException, ServiceException, PineconeApiValueError
 
 
 class bcolors:
@@ -147,7 +147,7 @@ class RESTClientObject(object):
                 print(bcolors.OKBLUE + "curl -X {method} '{url}' {formatted_headers} -d '{data}'".format(method=method, url=formatted_url, formatted_headers=formatted_headers, data=formatted_body) + bcolors.ENDC)
 
         if post_params and body:
-            raise ApiValueError(
+            raise PineconeApiValueError(
                 "body parameter cannot be used with post_params parameter."
             )
 
@@ -217,7 +217,7 @@ class RESTClientObject(object):
                     msg = """Cannot prepare a request message for provided
                              arguments. Please check that your arguments match
                              declared content type."""
-                    raise ApiException(status=0, reason=msg)
+                    raise PineconeApiException(status=0, reason=msg)
             # For `GET`, `HEAD`
             else:
                 r = self.pool_manager.request(method, url,
@@ -227,7 +227,7 @@ class RESTClientObject(object):
                                               headers=headers)
         except urllib3.exceptions.SSLError as e:
             msg = "{0}\n{1}".format(type(e).__name__, str(e))
-            raise ApiException(status=0, reason=msg)
+            raise PineconeApiException(status=0, reason=msg)
 
         if os.environ.get('PINECONE_DEBUG_CURL'):
             o = RESTResponse(r)
@@ -257,7 +257,7 @@ class RESTClientObject(object):
             if 500 <= r.status <= 599:
                 raise ServiceException(http_resp=r)
 
-            raise ApiException(http_resp=r)
+            raise PineconeApiException(http_resp=r)
 
         return r
 

--- a/pinecone/exceptions.py
+++ b/pinecone/exceptions.py
@@ -1,18 +1,15 @@
 from .core.client.exceptions import (
-    OpenApiException,
-    ApiAttributeError,
-    ApiTypeError,
-    ApiValueError,
-    ApiKeyError,
-    ApiException,
+    PineconeException,
+    PineconeApiAttributeError,
+    PineconeApiTypeError,
+    PineconeApiValueError,
+    PineconeApiKeyError,
+    PineconeApiException,
     NotFoundException,
     UnauthorizedException,
     ForbiddenException,
     ServiceException,
 )
-
-class PineconeException(Exception):
-    """The base exception class for all Pinecone client exceptions."""
 
 class PineconeProtocolError(PineconeException):
     """Raised when something unexpected happens mid-request/response."""
@@ -22,14 +19,13 @@ class PineconeConfigurationError(PineconeException):
 
 __all__ = [
     "PineconeConfigurationError",
+    "PineconeProtocolError"
     "PineconeException",
-    "PineconeProtocolError",
-    "OpenApiException",
-    "ApiAttributeError",
-    "ApiTypeError",
-    "ApiValueError",
-    "ApiKeyError",
-    "ApiException",
+    "PineconeApiAttributeError",
+    "PineconeApiTypeError",
+    "PineconeApiValueError",
+    "PineconeApiKeyError",
+    "PineconeApiException",
     "NotFoundException",
     "UnauthorizedException",
     "ForbiddenException",

--- a/pinecone/exceptions.py
+++ b/pinecone/exceptions.py
@@ -19,7 +19,7 @@ class PineconeConfigurationError(PineconeException):
 
 __all__ = [
     "PineconeConfigurationError",
-    "PineconeProtocolError"
+    "PineconeProtocolError",
     "PineconeException",
     "PineconeApiAttributeError",
     "PineconeApiTypeError",

--- a/tests/integ/test_index.py
+++ b/tests/integ/test_index.py
@@ -5,7 +5,7 @@ from urllib3_mock import Responses
 import responses as req_responses
 
 import pinecone
-from pinecone import ApiTypeError, ApiException
+from pinecone import PineconeApiTypeError, PineconeApiException
 
 responses_req = Responses()
 responses = Responses("requests.packages.urllib3")
@@ -38,7 +38,7 @@ def test_invalid_upsert_request_vector_value_type():
     )
 
     pinecone.init("example-api-key", environment="example-environment")
-    with pytest.raises(ApiException) as exc_info:
+    with pytest.raises(PineconeApiException) as exc_info:
         index = pinecone.Index("example-index")
         resp = index.upsert(vectors=[("vec1", [0.1] * 8), ("vec2", [0.2] * 8)])
 
@@ -133,6 +133,6 @@ def _test_invalid_delete_response_wrong_type():
 
     index = pinecone.Index("example-index")
 
-    with pytest.raises(ApiTypeError) as exc_info:
+    with pytest.raises(PineconeApiTypeError) as exc_info:
         resp = index.delete(ids=["vec1", "vec2"])
         assert resp.deleted_count == 2

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 import time
-from pinecone import Pinecone, NotFoundException, ApiException
+from pinecone import Pinecone, NotFoundException, PineconeApiException
 from .helpers.helpers import generate_index_name, get_environment_var
 
 @pytest.fixture()
@@ -66,7 +66,7 @@ def delete_with_retry(client, index_name, retries=0, sleep_interval=5):
         client.delete_index(index_name, -1)
     except NotFoundException:
         pass
-    except ApiException as e:
+    except PineconeApiException as e:
         if e.error.code == 'PRECONDITON_FAILED':
             if retries > 5:
                 raise 'Unable to delete index ' + index_name

--- a/tests/integration/test_create_index_api_errors.py
+++ b/tests/integration/test_create_index_api_errors.py
@@ -1,25 +1,25 @@
 import pytest
-from pinecone import ApiException, ApiValueError
+from pinecone import PineconeApiException, PineconeApiValueError
 
 class TestCreateIndexApiErrorCases:
     def test_create_index_with_invalid_name(self, client, create_sl_index_params):
         create_sl_index_params['name'] = '-invalid-name'
-        with pytest.raises(ApiException):
+        with pytest.raises(PineconeApiException):
             client.create_index(**create_sl_index_params)
 
     def test_create_index_invalid_metric(self, client, create_sl_index_params):
         create_sl_index_params['metric'] = 'invalid'
-        with pytest.raises(ApiValueError):
+        with pytest.raises(PineconeApiValueError):
             client.create_index(**create_sl_index_params)
 
     def test_create_index_with_invalid_neg_dimension(self, client, create_sl_index_params):
         create_sl_index_params['dimension'] = -1
-        with pytest.raises(ApiValueError):
+        with pytest.raises(PineconeApiValueError):
             client.create_index(**create_sl_index_params)
 
     def test_create_index_that_already_exists(self, client, create_sl_index_params):
         client.create_index(**create_sl_index_params)
-        with pytest.raises(ApiException):
+        with pytest.raises(PineconeApiException):
             client.create_index(**create_sl_index_params)
 
     @pytest.mark.skip(reason='Bug filed https://app.asana.com/0/1205078872348810/1205917627868143')
@@ -27,5 +27,5 @@ class TestCreateIndexApiErrorCases:
         create_sl_index_params['pod_type'] = 'p1.x2'
         create_sl_index_params['environment'] = 'us-east1-gcp'
         create_sl_index_params['replicas'] = 2
-        with pytest.raises(ApiException):
+        with pytest.raises(PineconeApiException):
             client.create_index(**create_sl_index_params)

--- a/tests/integration/test_create_index_type_errors.py
+++ b/tests/integration/test_create_index_type_errors.py
@@ -1,10 +1,10 @@
 import pytest
-from pinecone import ApiTypeError
+from pinecone import PineconeApiTypeError
 
 class TestCreateIndexTypeErrorCases:
     def test_create_index_with_invalid_str_dimension(self, client, create_sl_index_params):
         create_sl_index_params['dimension'] = '10'
-        with pytest.raises(ApiTypeError):
+        with pytest.raises(PineconeApiTypeError):
             client.create_index(**create_sl_index_params)
 
     def test_create_index_with_missing_dimension(self, client, create_sl_index_params):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,5 @@
 import pinecone
-from pinecone.exceptions import ApiKeyError, PineconeConfigurationError
+from pinecone.exceptions import PineconeApiKeyError, PineconeConfigurationError
 from pinecone.config import PineconeConfig
 from pinecone.core.client.configuration import Configuration as OpenApiConfiguration
 


### PR DESCRIPTION
## Problem

We want to create a base exception `PineconeException` that all other errors extend to simplify error handling. 

## Solution

These changes are mainly derived from updated openapi templates. New exception hierarchy is:

- PineconeException
    - PineconeConfigurationError
    - PineconeApiException
        - NotFoundException
        - ForbiddenException
        - ...etc
    - PineconeProtocolError (GRPC)

Almost all find-and-replace changes except some tiny modifications in `pinecone/exceptions.py` to extend a different type with the same name in order for all types to share a common base type coming from the generated code. Not much to see here.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
