### PR TITLE
[spruce] Fix issue with polling after delete index

### DIFF
--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -123,7 +123,7 @@ class Pinecone:
         self.index_host_store.delete_host(self.config, name)
 
         def get_remaining():
-            return name in api_instance.list_indexes().names()
+            return name in self.list_indexes().names()
 
         if timeout == -1:
             return

--- a/tests/unit/models/test_index_list.py
+++ b/tests/unit/models/test_index_list.py
@@ -57,4 +57,17 @@ class TestIndexList:
         # Forward compatibility, in case we add more attributes to IndexList for pagination
         assert IndexList(index_list_response).index_list.indexes == index_list_response.indexes
 
+    def test_when_results_are_empty(self):
+        iil = IndexList(OpenApiIndexList(indexes=[]))
+        assert len(iil) == 0
+        assert iil.index_list.indexes == []
+        assert iil.indexes == []
+        assert iil.names() == []
+
+    def test_when_results_are_none(self):
+        iil = IndexList(OpenApiIndexList(indexes=None))
+        assert len(iil) == 0
+        assert iil.index_list.indexes == []
+        assert iil.indexes == []
+        assert iil.names() == []
 

--- a/tests/unit/models/test_index_list.py
+++ b/tests/unit/models/test_index_list.py
@@ -64,10 +64,3 @@ class TestIndexList:
         assert iil.indexes == []
         assert iil.names() == []
 
-    def test_when_results_are_none(self):
-        iil = IndexList(OpenApiIndexList(indexes=None))
-        assert len(iil) == 0
-        assert iil.index_list.indexes == []
-        assert iil.indexes == []
-        assert iil.names() == []
-


### PR DESCRIPTION
## Problem

There was a small error in a recent change to add a `names()` utility method on the response from `Pinecone#list_indexes` to facilitate easy iteration over index names. This resulted in an error when deleting indexes:

```
    def get_remaining():
>       return name in api_instance.list_indexes().names()
E       TypeError: 'NoneType' object is not callable
```

This error got introduced because `api_instance.list_indexes()` and `self.list_indexes()` are both a thing in this context, but only `self.list_indexes()` returns a result with the `.names()` helper.

## Solution

Call names on the correct object to avoid the error.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

I confirmed with manual testing that this resolves the issue. 