### PR TITLE
Parameterize integration tests on environment

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -37,19 +37,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.11]
         pineconeEnv:
           - prod
           # - staging
+        testConfig:
+          - python-version: 3.8 # Do one test run with 3.8 for sanity check
+            pod: { environment: 'us-east1-gcp'}
+            serverless: { cloud: 'aws', region: 'us-west-2'}
+          - python-version: 3.11
+            pod: { environment: 'us-east1-gcp'}
+            serverless: { cloud: 'aws', region: 'us-west-2'}
       max-parallel: 1
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.testConfig.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.testConfig.python-version }}
 
       - name: Setup Poetry
         uses: ./.github/actions/setup-poetry
@@ -61,6 +67,9 @@ jobs:
           PINECONE_CONTROLLER_HOST: 'https://api.pinecone.io'
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           GITHUB_BUILD_NUMBER: "${{ github.run_number }}-p-${{ matrix.python-version}}"
+          POD_ENVIRONMENT: ${{ matrix.testConfig.pod.environment }}
+          SERVERLESS_CLOUD: ${{ matrix.testConfig.serverless.cloud }}
+          SERVERLESS_REGION: ${{ matrix.testConfig.serverless.region }}
 
       - name: Run integration tests (REST, staging)
         if: matrix.pineconeEnv == 'staging'
@@ -69,6 +78,9 @@ jobs:
           PINECONE_CONTROLLER_HOST: 'https://api-staging.pinecone.io'
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY_STAGING }}
           GITHUB_BUILD_NUMBER: "${{ github.run_number }}-s-${{ matrix.python-version}}"
+          POD_ENVIRONMENT: ${{ matrix.testConfig.pod.environment }}
+          SERVERLESS_CLOUD: ${{ matrix.testConfig.serverless.cloud }}
+          SERVERLESS_REGION: ${{ matrix.testConfig.serverless.region }}
 
   units-grpc:
     name: Unit tests (GRPC)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,14 +10,26 @@ def client():
     return Pinecone(api_key=api_key)
 
 @pytest.fixture()
+def pod_environment():
+    return get_environment_var('POD_ENVIRONMENT', 'us-east1-gcp')
+
+@pytest.fixture()
+def serverless_cloud():
+    return get_environment_var('SERVERLESS_CLOUD', 'aws')
+
+@pytest.fixture()
+def serverless_region():
+    return get_environment_var('SERVERLESS_REGION', 'us-west-2')
+
+@pytest.fixture()
 def environment():
     return get_environment_var('PINECONE_ENVIRONMENT')
 
 @pytest.fixture()
-def create_sl_index_params(index_name):
+def create_sl_index_params(index_name, serverless_cloud, serverless_region):
     spec = {"serverless": {
-        'cloud': 'aws',
-        'region': 'us-west-2'
+        'cloud': serverless_cloud,
+        'region': serverless_region
     }}
     return dict(name=index_name, dimension=10, metric='cosine', spec=spec)
 

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -37,8 +37,8 @@ def generate_index_name(test_name: str) -> str:
 
     return index_name.lower()
 
-def get_environment_var(name: str) -> str:
-    val = os.getenv(name)
+def get_environment_var(name: str, defaultVal: None) -> str:
+    val = os.getenv(name, defaultVal)
     if (val is None):
         raise Exception('Expected environment variable '  + name + ' is not set')
     else:


### PR DESCRIPTION
## Problem

I want to be able to run the integration tests with a variety of environments.

## Solution

Add some variables to the test matrix and wire them into the test execution.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

