### PR TITLE
Wire up pool_threads config

### DIFF
--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -24,6 +24,7 @@ class Pinecone:
         host: Optional[str] = None,
         config: Optional[Config] = None,
         additional_headers: Optional[Dict[str, str]] = {},
+        pool_threads: Optional[int] = 1,
         index_api: Optional[IndexOperationsApi] = None,
         **kwargs,
     ):
@@ -39,7 +40,8 @@ class Pinecone:
         if index_api:
             self.index_api = index_api
         else:
-            api_client = ApiClient(configuration=self.config.openapi_config)
+            self.pool_threads = pool_threads
+            api_client = ApiClient(configuration=self.config.openapi_config, pool_threads=pool_threads)
             api_client.user_agent = get_user_agent()
             extra_headers = self.config.additional_headers or {}
             for key, value in extra_headers.items():
@@ -222,6 +224,7 @@ class Pinecone:
         response = api_instance.describe_index(name)
         return response["status"]
 
-    def Index(self, name: str):
-        index_host = self.index_host_store.get_host(self.index_api, self.config, name)
-        return Index(api_key=self.config.api_key, host=index_host)
+    def Index(self, name: str, host: Optional[str] = None):
+        if host is None:
+            host = self.index_host_store.get_host(self.index_api, self.config, name)
+        return Index(api_key=self.config.api_key, host=host, pool_threads=self.pool_threads)

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -41,7 +41,7 @@ class Pinecone:
             self.index_api = index_api
         else:
             self.pool_threads = pool_threads
-            api_client = ApiClient(configuration=self.config.openapi_config, pool_threads=pool_threads)
+            api_client = ApiClient(configuration=self.config.openapi_config, pool_threads=self.pool_threads)
             api_client.user_agent = get_user_agent()
             extra_headers = self.config.additional_headers or {}
             for key, value in extra_headers.items():

--- a/pinecone/grpc/pinecone.py
+++ b/pinecone/grpc/pinecone.py
@@ -1,9 +1,11 @@
 from ..control.pinecone import Pinecone
 from ..config.config import ConfigBuilder
 from .index_grpc import GRPCIndex
+from typing import Optional
 
 class PineconeGRPC(Pinecone):
-    def Index(self, name: str):
-        index_host = self.index_host_store.get_host(self.index_api, self.config, name)
-        config = ConfigBuilder.build(api_key=self.config.api_key, host=index_host)
+    def Index(self, name: str, host: Optional[str] = None):
+        if host is None:
+            host = self.index_host_store.get_host(self.index_api, self.config, name)
+        config = ConfigBuilder.build(api_key=self.config.api_key, host=host, pool_threads=self.pool_threads)
         return GRPCIndex(index_name=name, config=config)

--- a/pinecone/grpc/pinecone.py
+++ b/pinecone/grpc/pinecone.py
@@ -7,5 +7,5 @@ class PineconeGRPC(Pinecone):
     def Index(self, name: str, host: Optional[str] = None):
         if host is None:
             host = self.index_host_store.get_host(self.index_api, self.config, name)
-        config = ConfigBuilder.build(api_key=self.config.api_key, host=host, pool_threads=self.pool_threads)
+        config = ConfigBuilder.build(api_key=self.config.api_key, host=host)
         return GRPCIndex(index_name=name, config=config)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,5 @@
-import pinecone
-from pinecone.exceptions import PineconeApiKeyError, PineconeConfigurationError
+from pinecone import Pinecone
+from pinecone.exceptions import PineconeConfigurationError
 from pinecone.config import PineconeConfig
 from pinecone.core.client.configuration import Configuration as OpenApiConfiguration
 
@@ -74,3 +74,10 @@ class TestConfig:
     def test_errors_when_no_api_key_is_present(self):
         with pytest.raises(PineconeConfigurationError):
             PineconeConfig.build()
+    
+    def test_config_pool_threads(self):
+        pc = Pinecone(api_key="test-api-key", host="test-controller-host", pool_threads=10)
+        assert pc.index_api.api_client.pool_threads == 10
+        idx = pc.Index(host='my-index-host', name='my-index-name')
+        assert idx._api_client.pool_threads == 10
+        


### PR DESCRIPTION
## Problem

We need to expose the `pool_threads` config in the new `Pinecone` constructor. This config property is ultimately used by the `ApiClient` class ([see here](https://github.com/pinecone-io/pinecone-python-client/blob/e81807de685d08297ea4ad642639fbc0d0ab24fd/pinecone/core/client/api_client.py#L61)), which is generated by the OpenAPI python generator. It is only used when performing operations over REST using the `async_req=True` param.

## Solution

Add a property and wire it up with the underlying `ApiClient` object and `Index` constructor.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
