### PR TITLE
Accept host urls both with and without https prefix

### DIFF
--- a/pinecone/config/config.py
+++ b/pinecone/config/config.py
@@ -4,14 +4,13 @@ import os
 from pinecone.exceptions import PineconeConfigurationError
 from pinecone.config.openapi import OpenApiConfigFactory
 from pinecone.core.client.configuration import Configuration as OpenApiConfiguration
-
+from pinecone.utils import normalize_host
 
 class Config(NamedTuple):
     api_key: str = ""
     host: str = ""
     openapi_config: Optional[OpenApiConfiguration] = None
     additional_headers: Optional[Dict[str, str]] = {}
-    
 
 class ConfigBuilder:
     """
@@ -40,6 +39,7 @@ class ConfigBuilder:
     ) -> Config:
         api_key = api_key or kwargs.pop("api_key", None) or os.getenv("PINECONE_API_KEY")
         host = host or kwargs.pop("host", None)
+        host = normalize_host(host)
 
         if not api_key:
             raise PineconeConfigurationError("You haven't specified an Api-Key.")

--- a/pinecone/control/index_host_store.py
+++ b/pinecone/control/index_host_store.py
@@ -2,6 +2,7 @@ from typing import Dict
 from pinecone.config import Config
 from pinecone.core.client.api.manage_pod_indexes_api import ManagePodIndexesApi as IndexOperationsApi
 from pinecone.core.client.exceptions import PineconeException
+from pinecone.utils import normalize_host
 
 class SingletonMeta(type):
     _instances: Dict[str, str] = {}
@@ -31,7 +32,7 @@ class IndexHostStore(metaclass=SingletonMeta):
     def set_host(self, config: Config, index_name: str, host: str):
         if host:
             key = self._key(config, index_name)
-            self._indexHosts[key] = "https://" + host
+            self._indexHosts[key] = normalize_host(host)
 
     def get_host(self, api: IndexOperationsApi, config: Config, index_name: str) -> str:
         key = self._key(config, index_name)

--- a/pinecone/utils/__init__.py
+++ b/pinecone/utils/__init__.py
@@ -4,3 +4,4 @@ from .user_agent import get_user_agent
 from .deprecation_notice import warn_deprecated
 from .fix_tuple_length import fix_tuple_length
 from .convert_to_list import convert_to_list
+from .normalize_host import normalize_host

--- a/pinecone/utils/normalize_host.py
+++ b/pinecone/utils/normalize_host.py
@@ -1,0 +1,8 @@
+def normalize_host(host):
+    if host is None:
+        return host
+    if host.startswith('https://'):
+        return host
+    if host.startswith('http://'):
+        return host
+    return 'https://' + host

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,16 +28,16 @@ class TestConfig:
 
     def test_init_with_environment_vars(self):
         os.environ["PINECONE_API_KEY"] = "test-api-key"
-        os.environ["PINECONE_CONTROLLER_HOST"] = "test-controller-host"
+        os.environ["PINECONE_CONTROLLER_HOST"] = "https://test-controller-host"
 
         config = PineconeConfig.build()
 
         assert config.api_key == "test-api-key"
-        assert config.host == "test-controller-host"
+        assert config.host == "https://test-controller-host"
 
     def test_init_with_positional_args(self):
         api_key = "my-api-key"
-        host = "my-controller-host"
+        host = "https://my-controller-host"
 
         config = PineconeConfig.build(api_key, host)
 
@@ -52,7 +52,7 @@ class TestConfig:
         config = PineconeConfig.build(api_key=api_key, host=controller_host, openapi_config=openapi_config)
 
         assert config.api_key == api_key
-        assert config.host == controller_host
+        assert config.host == 'https://' + controller_host
         assert config.openapi_config == openapi_config
 
     def test_resolution_order_kwargs_over_env_vars(self):
@@ -69,7 +69,7 @@ class TestConfig:
         config = PineconeConfig.build(api_key=api_key, host=controller_host)
 
         assert config.api_key == api_key
-        assert config.host == controller_host
+        assert config.host == 'https://' + controller_host
 
     def test_errors_when_no_api_key_is_present(self):
         with pytest.raises(PineconeConfigurationError):

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -19,7 +19,7 @@ class TestControl:
 
     def test_passing_host(self):
         p = Pinecone(api_key="123-456-789", host="my-host")
-        assert p.index_api.api_client.configuration.host == "my-host"
+        assert p.index_api.api_client.configuration.host == "https://my-host"
 
     def test_passing_additional_headers(self):
         extras = {"header1": "my-value", "header2": "my-value2"}

--- a/tests/unit/utils/test_normalize_host.py
+++ b/tests/unit/utils/test_normalize_host.py
@@ -1,0 +1,18 @@
+from pinecone.utils import normalize_host
+
+def test_when_url_is_none():
+    assert normalize_host(None) is None
+
+def test_when_url_is_https():
+    assert normalize_host('https://index-name-abcdef.svc.pinecone.io') == 'https://index-name-abcdef.svc.pinecone.io'
+
+def test_when_url_is_http():
+    # This should not occur in prod, but if it does, we will leave it alone. 
+    # Could be useful when testing with local proxies.
+    assert normalize_host('http://index-name-abcdef.svc.pinecone.io') == 'http://index-name-abcdef.svc.pinecone.io'
+
+def test_when_url_is_host_without_protocol():
+    assert normalize_host('index-name-abcdef.svc.pinecone.io') == 'https://index-name-abcdef.svc.pinecone.io'
+
+def test_can_be_called_multiple_times():
+    assert normalize_host(normalize_host('index-name-abcdef.svc.pinecone.io')) == 'https://index-name-abcdef.svc.pinecone.io'


### PR DESCRIPTION
## Problem

We want to make the client flexible enough to accept data plane host values both with and without the `https://` prefix. This is needed because the value is not prefixed with `https` in the describe_index response, but parts of the UI show the complete url with protocol.

## Solution

Add a new util method to normalize the urls. Incorporate the util into the IndexHostStore and ConfigBuilder. The ConfigBuilder usage should cover both the `Index` and `IndexGRPC` milestones.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Added new unit tests of util.