### PR TITLE
Update publish workflows with new testing setup

### DIFF
--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -24,13 +24,18 @@ on:
         default: 'rc1'
 
 jobs:
-  testing:
-    uses: './.github/workflows/testing.yaml'
+  testing-rest:
+    uses: './.github/workflows/testing-rest.yaml'
+    secrets: inherit
+  testing-grpc:
+    uses: './.github/workflows/testing-grpc.yaml'
     secrets: inherit
 
   pypi:
     uses: './.github/workflows/publish-to-pypi.yaml'
-    needs: testing
+    needs: 
+      - testing-rest
+      - testing-grpc
     with:
       isPrerelease: true
       ref: ${{ inputs.ref }}

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -6,12 +6,17 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  run-tests:
-    uses: './.github/workflows/testing.yaml'
+  testing-rest:
+    uses: './.github/workflows/testing-rest.yaml'
+    secrets: inherit
+  testing-grpc:
+    uses: './.github/workflows/testing-grpc.yaml'
     secrets: inherit
 
   pypi-nightly:
-    needs: run-tests
+    needs: 
+      - testing-rest
+      - testing-grpc
     timeout-minutes: 30
     name: pypi-nightly
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,13 +19,18 @@ on:
           - 'major' # breaking changes
 
 jobs:
-  testing:
-    uses: './.github/workflows/testing.yaml'
+  testing-rest:
+    uses: './.github/workflows/testing-rest.yaml'
+    secrets: inherit
+  testing-grpc:
+    uses: './.github/workflows/testing-grpc.yaml'
     secrets: inherit
 
   pypi:
     uses: './.github/workflows/publish-to-pypi.yaml'
-    needs: testing
+    needs: 
+      - testing-rest
+      - testing-grpc
     with:
       isPrerelease: false
       ref: ${{ inputs.ref }}


### PR DESCRIPTION
## Problem

In #263 we split our tests across two different workflows. We need to update our publishing workflows to find the test configurations in the new locations.

## Solution

Replace references to `testing.yaml` with references to `testing-grpc.yaml` and `testing-rest.yaml`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
