### PR TITLE
Remove deprecated `queries` option in `query()`

### DIFF
--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -3,9 +3,7 @@ from .pinecone import PineconeGRPC
 
 from pinecone.core.grpc.protos.vector_service_pb2 import (
     Vector as GRPCVector,
-    QueryVector as GRPCQueryVector,
     SparseValues as GRPCSparseValues,
     Vector,
-    QueryVector,
     SparseValues
 )

--- a/pinecone/grpc/utils.py
+++ b/pinecone/grpc/utils.py
@@ -1,4 +1,9 @@
+import uuid
+
 from google.protobuf.struct_pb2 import Struct
+
+def _generate_request_id() -> str:
+    return str(uuid.uuid4())
 
 from pinecone.core.client.models import (
     Vector as _Vector,

--- a/pinecone/grpc/vector_factory_grpc.py
+++ b/pinecone/grpc/vector_factory_grpc.py
@@ -20,7 +20,6 @@ from ..data import (
 
 from pinecone.core.grpc.protos.vector_service_pb2 import (
     Vector as GRPCVector,
-    QueryVector as GRPCQueryVector,
     SparseValues as GRPCSparseValues,
 )
 from pinecone import (

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -363,28 +363,6 @@ class TestRestIndex:
             pinecone.QueryRequest(top_k=10, vector=self.vals1, filter=self.filter1, namespace="ns")
         )
 
-    def test_query_byTuplesNoFilter_queryVectorsNoFilter(self, mocker):
-        mocker.patch.object(self.index._vector_api, "query", autospec=True)
-        self.index.query(top_k=10, queries=[(self.vals1,), (self.vals2,)])
-        self.index._vector_api.query.assert_called_once_with(
-            pinecone.QueryRequest(
-                top_k=10, queries=[pinecone.QueryVector(values=self.vals1), pinecone.QueryVector(values=self.vals2)]
-            )
-        )
-
-    def test_query_byTuplesWithFilter_queryVectorsWithFilter(self, mocker):
-        mocker.patch.object(self.index._vector_api, "query", autospec=True)
-        self.index.query(top_k=10, queries=[(self.vals1, self.filter1), (self.vals2, self.filter2)])
-        self.index._vector_api.query.assert_called_once_with(
-            pinecone.QueryRequest(
-                top_k=10,
-                queries=[
-                    pinecone.QueryVector(values=self.vals1, filter=self.filter1),
-                    pinecone.QueryVector(values=self.vals2, filter=self.filter2),
-                ],
-            )
-        )
-
     def test_query_byVecId_queryByVecId(self, mocker):
         mocker.patch.object(self.index._vector_api, "query", autospec=True)
         self.index.query(top_k=10, id="vec1", include_metadata=True, include_values=False)

--- a/tests/unit_grpc/test_grpc_index_query.py
+++ b/tests/unit_grpc/test_grpc_index_query.py
@@ -8,10 +8,8 @@ from pinecone import Config
 from pinecone.grpc import GRPCIndex
 from pinecone.core.grpc.protos.vector_service_pb2 import (
     QueryRequest,
-    QueryVector,
 )
 from pinecone.grpc.utils import dict_to_proto_struct
-
 
 class TestGrpcIndexQuery:
     def setup_method(self):
@@ -34,32 +32,6 @@ class TestGrpcIndexQuery:
             self.index.stub.Query,
             QueryRequest(top_k=10, vector=vals1, filter=dict_to_proto_struct(filter1), namespace="ns"),
             timeout=10,
-        )
-
-    def test_query_byTuplesNoFilter_queryVectorsNoFilter(self, mocker, vals1, vals2):
-        mocker.patch.object(self.index, "_wrap_grpc_call", autospec=True)
-        self.index.query(top_k=10, queries=[(vals1,), (vals2,)])
-        self.index._wrap_grpc_call.assert_called_once_with(
-            self.index.stub.Query,
-            QueryRequest(
-                queries=[QueryVector(values=vals1, filter={}), QueryVector(values=vals2, filter={})], top_k=10
-            ),
-            timeout=None,
-        )
-
-    def test_query_byTuplesWithFilter_queryVectorsWithFilter(self, mocker, vals1, vals2, filter1, filter2):
-        mocker.patch.object(self.index, "_wrap_grpc_call", autospec=True)
-        self.index.query(top_k=10, queries=[(vals1, filter1), (vals2, filter2)])
-        self.index._wrap_grpc_call.assert_called_once_with(
-            self.index.stub.Query,
-            QueryRequest(
-                queries=[
-                    QueryVector(values=vals1, filter=dict_to_proto_struct(filter1)),
-                    QueryVector(values=vals2, filter=dict_to_proto_struct(filter2)),
-                ],
-                top_k=10,
-            ),
-            timeout=None,
         )
 
     def test_query_byVecId_queryByVecId(self, mocker):


### PR DESCRIPTION
## Problem

There was an argument on the `query()` method for passing multiple queries at once. This has long been deprecated in the API and SDK, so it's time to remove it.
 
## Solution

- Clean up the `queries` option to both `Index#query` and `IndexGRPC#query`.
- Remove code no longer needed to interpret the many forms these query options could take
- Cleanup and simplify response parsing logic
- Remove related tests passing `queries` kwarg

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Plan

Recently added integration test suite gives high confidence queries still work after this change.