### PR TITLE
Suppress TqdmExperimentalWarning

### DIFF
--- a/pinecone/__init__.py
+++ b/pinecone/__init__.py
@@ -1,6 +1,11 @@
 """
 .. include:: ../README.md
 """
+import warnings
+from tqdm import TqdmExperimentalWarning
+
+warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
+
 from .config import *
 from .exceptions import *
 from .control import *


### PR DESCRIPTION
## Problem

When loading our library in notebook settings, tqdm (progress bar widget) throws off an annoying warning even though it works fine. It's not a good look.

<img width="600" alt="Screenshot 2024-01-12 at 9 51 39 PM" src="https://github.com/pinecone-io/pinecone-python-client/assets/1326365/ebbfed5c-0d9a-4ed3-8513-2c9b13efe1a6">


## Solution

Suppress the warning using the `warnings` standard library.
