### PR TITLE
Temporarily revert docs changes

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -18,15 +18,15 @@ jobs:
         with:
           python-version: 3.11
 
-      - name: Push documentation artifacts to sdk-docs
-        uses: cpina/github-action-push-to-another-repository@main
-        env:
-          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
-        with:
-          source-directory: docs
-          destination-github-username: pinecone-io
-          destination-repository-name: sdk-docs
-          user-email: clients@pinecone.io
-          target-branch: main
-          target-directory: python
-          commit-message: 'Python: automated documentation build - pinecone-python-client merge SHA: ${{ github.sha }}'
+      # - name: Push documentation artifacts to sdk-docs
+      #   uses: cpina/github-action-push-to-another-repository@main
+      #   env:
+      #     SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+      #   with:
+      #     source-directory: docs
+      #     destination-github-username: pinecone-io
+      #     destination-repository-name: sdk-docs
+      #     user-email: clients@pinecone.io
+      #     target-branch: main
+      #     target-directory: python
+      #     commit-message: 'Python: automated documentation build - pinecone-python-client merge SHA: ${{ github.sha }}'

--- a/README.md
+++ b/README.md
@@ -28,36 +28,20 @@ pip3 install git+https://git@github.com/pinecone-io/pinecone-python-client.git@e
 pip3 install git+https://git@github.com/pinecone-io/pinecone-python-client.git@259deff
 ```
 
-## Create a client
-The following example creates an authenticated client.
-
-```python
-import os
-from pinecone import Pinecone
-
-pc = Pinecone(api_key=os.environ.get('PINECONE_API_KEY'))
-```
-To use gRPC for interacting with an index, instantiate with `PineconeGRPC` 
-```python
-import os
-from pinecone.grpc import PineconeGRPC
-
-pc = PineconeGRPC(api_key=os.environ.get('PINECONE_API_KEY'))
-# Functionality matches non-gRPC client
-index = pc.Index('index-name')
-```
-
-## Create an index
+## Creating an index
 
 The following example creates an index without a metadata
 configuration. By default, Pinecone indexes all metadata.
 
 ```python
-from pinecone import Pinecone, PodSpec
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-pc.create_index("example-index", dimension=1536, metric="cosine", spec=PodSpec(environment='us-west-2', pod_type='p1.x1'))
+import pinecone
 
+
+pinecone.init(api_key="YOUR_API_KEY",
+              environment="us-west1-gcp")
+
+pinecone.create_index("example-index", dimension=1024)
 ```
 
 The following example creates an index that only indexes
@@ -65,18 +49,12 @@ the "color" metadata field. Queries against this index
 cannot filter based on any other metadata field.
 
 ```python
-from pinecone import Pinecone, PodSpec
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-
 metadata_config = {
     "indexed": ["color"]
 }
 
-pc.create_index(
-    "example-index-2",
-    dimension=1536,
-    spec=PodSpec(environment='us-west-2', pod_type='p1.x1', metadata_config=metadata_config)
-)
+pinecone.create_index("example-index-2", dimension=1024,
+                      metadata_config=metadata_config)
 ```
 
 ## List indexes
@@ -84,11 +62,11 @@ pc.create_index(
 The following example returns all indexes in your project.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-for index in pc.list_indexes():
-    print(index['name'])
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
+
+active_indexes = pinecone.list_indexes()
 ```
 
 ## Describe index
@@ -96,11 +74,12 @@ for index in pc.list_indexes():
 The following example returns information about the index `example-index`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
 
-index_description = pc.describe_index("example-index")
+index_description = pinecone.describe_index("example-index")
+
 ```
 
 ## Delete an index
@@ -108,11 +87,11 @@ index_description = pc.describe_index("example-index")
 The following example deletes `example-index`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
 
-pc.delete_index("example-index")
+pinecone.delete_index("example-index")
 ```
 
 ## Scale replicas
@@ -120,12 +99,12 @@ pc.delete_index("example-index")
 The following example changes the number of replicas for `example-index`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
 
 new_number_of_replicas = 4
-pc.configure_index("example-index", replicas=new_number_of_replicas)
+pinecone.configure_index("example-index", replicas=new_number_of_replicas)
 ```
 
 ## Describe index statistics
@@ -133,10 +112,10 @@ pc.configure_index("example-index", replicas=new_number_of_replicas)
 The following example returns statistics about the index `example-index`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-index = pc.Index("example-index")
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
+index = pinecone.Index("example-index")
 
 index_stats_response = index.describe_index_stats()
 ```
@@ -147,10 +126,10 @@ index_stats_response = index.describe_index_stats()
 The following example upserts vectors to `example-index`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-index = pc.Index("example-index")
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
+index = pinecone.Index("example-index")
 
 upsert_response = index.upsert(
     vectors=[
@@ -167,10 +146,10 @@ The following example queries the index `example-index` with metadata
 filtering.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-index = pc.Index("example-index")
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
+index = pinecone.Index("example-index")
 
 query_response = index.query(
     namespace="example-namespace",
@@ -189,10 +168,10 @@ query_response = index.query(
 The following example deletes vectors by ID.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-index = pc.Index("example-index")
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
+index = pinecone.Index("example-index")
 
 delete_response = index.delete(ids=["vec1", "vec2"], namespace="example-namespace")
 ```
@@ -202,23 +181,24 @@ delete_response = index.delete(ids=["vec1", "vec2"], namespace="example-namespac
 The following example fetches vectors by ID.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-index = pc.Index("example-index")
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
+index = pinecone.Index("example-index")
 
 fetch_response = index.fetch(ids=["vec1", "vec2"], namespace="example-namespace")
 ```
+
 
 ## Update vectors
 
 The following example updates vectors by ID.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
-index = pc.Index("example-index")
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
+index = pinecone.Index("example-index")
 
 update_response = index.update(
     id="vec1",
@@ -234,11 +214,12 @@ The following example creates the collection `example-collection` from
 `example-index`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
+pinecone.init(api_key="YOUR_API_KEY",
+              environment="us-west1-gcp")
 
-pc.create_collection("example-collection", "example-index")
+pinecone.create_collection("example-collection", "example-index")
 ```
 
 ## List collections
@@ -246,11 +227,11 @@ pc.create_collection("example-collection", "example-index")
 The following example returns a list of the collections in the current project.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
 
-active_collections = pc.list_collections()
+active_collections = pinecone.list_collections()
 ```
 
 ## Describe a collection
@@ -259,11 +240,11 @@ The following example returns a description of the collection
 `example-collection`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
 
-collection_description = pc.describe_collection("example-collection")
+collection_description = pinecone.describe_collection("example-collection")
 ```
 
 ## Delete a collection
@@ -271,11 +252,11 @@ collection_description = pc.describe_collection("example-collection")
 The following example deletes the collection `example-collection`.
 
 ```python
-from pinecone import Pinecone
+import pinecone
 
-pc = Pinecone(api_key='<<PINECONE_API_KEY>>')
+pinecone.init(api_key="YOUR_API_KEY", environment="us-west1-gcp")
 
-pc.delete_collection("example-collection")
+pinecone.delete_collection("example-collection")
 ```
 
 # Contributing 


### PR DESCRIPTION
## Problem

Not ready to go live with new docs until we publish the release

## Solution

Revert readme changes, disable SDK reference doc generation on main.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
