### PR TITLE
Add missing certifi dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -35,13 +35,13 @@ tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pyte
 
 [[package]]
 name = "certifi"
-version = "2023.7.22"
+version = "2023.11.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
-    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
+    {file = "certifi-2023.11.17-py3-none-any.whl", hash = "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"},
+    {file = "certifi-2023.11.17.tar.gz", hash = "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"},
 ]
 
 [[package]]
@@ -1198,4 +1198,4 @@ grpc = ["googleapis-common-protos", "grpc-gateway-protoc-gen-openapiv2", "grpcio
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.13"
-content-hash = "9b463283ead14a000789fdc1d8ef0797759103b326dea21a2ae07083011ba2ad"
+content-hash = "8c61e1d38e8f8a0e1bc3f770033707f04ccccbc5af91d6ec4972ab7b27127987"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ python = ">=3.8,<3.13"
 typing-extensions = ">=3.7.4"
 urllib3 = ">=1.26.0"
 tqdm = ">=4.64.1"
+# certifi does not follow semver. Should always be 
+# on latest but setting a broad range to have maximum
+# compatibility with libraries that may pin version.
+certifi = ">=2019.11.17"
 grpcio = { version = ">=1.44.0", optional = true }
 grpc-gateway-protoc-gen-openapiv2 = { version = "0.1.0", optional = true }
 googleapis-common-protos = { version = ">=1.53.0", optional = true }


### PR DESCRIPTION
## Problem

Recent integration testing with our published dev releases shows we are missing a dependency: `certifi`.

```
Traceback (most recent call last):
  File "/home/runner/work/pinecone-python-client/pinecone-python-client/scripts/3.x/delete-all-indexes.py", line 4, in <module>
    from pinecone import Pinecone
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pinecone/__init__.py", line 4, in <module>
    from .config import *
  File "/opt/hostedtoolcache/Python/3.9.18/x[64](https://github.com/pinecone-io/pinecone-python-client/actions/runs/7514956364/job/20458392131#step:3:69)/lib/python3.9/site-packages/pinecone/config/__init__.py", line 4, in <module>
    from .config import ConfigBuilder, Config
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pinecone/config/config.py", line 5, in <module>
    from pinecone.config.openapi import OpenApiConfigFactory
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/pinecone/config/openapi.py", line 4, in <module>
    import certifi
ModuleNotFoundError: No module named 'certifi'
```

## Solution

We need to declare a direct dependency on `certifi`, which is used when we setup configuration to get information about current SSL certs. We used to get this as a transitive dependency when we had a dependency on the `requests` package, but that was recently removed while pruning unused dependencies.

The `certifi` package does not follow semver (versions are date based) and should ideally always be on the latest version. But since we are developing a library that needs broad compatibility we will specify a very broad range to be compatible with everyone's apps and other libraries that may be pinned to specific versions or narrow ranges.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Need to build a new dev release and rerun install-based integration test.
