### PR TITLE
Add missing .names() for list_collections()

### DIFF
--- a/pinecone/models/collection_list.py
+++ b/pinecone/models/collection_list.py
@@ -5,6 +5,9 @@ class CollectionList:
         self.collection_list = collection_list
         self.current = 0
 
+    def names(self):
+        return [i['name'] for i in self.collection_list.collections]
+
     def __getitem__(self, key):
         return self.collection_list.collections[key]
     

--- a/tests/unit/models/test_collection_list.py
+++ b/tests/unit/models/test_collection_list.py
@@ -28,3 +28,10 @@ class TestCollectionList:
     def test_collection_list_proxies_methods(self, collection_list_response):
         # Forward compatibility, in case we add more attributes to IndexList for pagination
         assert CollectionList(collection_list_response).collection_list.collections == collection_list_response.collections
+
+    def test_when_results_are_empty(self):
+        assert len(CollectionList(OpenApiCollectionList(collections=[]))) == 0
+
+    def test_collection_list_names_syntactic_sugar(self, collection_list_response):
+        icl = CollectionList(collection_list_response)
+        assert icl.names() == ['collection1', 'collection2']


### PR DESCRIPTION
## Problem

The `list_indexes()` response has a convenience method that lets you easily get index names by chaining `.names()`. We want the same ergonomics on `list_collections()`.

## Solution

Add test and adjust model for implementation. Now you should be able to do:

```python
if index_name not in pc.list_indexes.names():
  # this already was working

if collection_name not in pc.list_collections.names():
  # this is what got added in this diff
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

