### PR TITLE
Remove deprecated scale_index method

### DIFF
--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -179,17 +179,6 @@ class Pinecone:
         configure_index_request = ConfigureIndexRequest(**config_args)
         api_instance.configure_index(name, configure_index_request=configure_index_request)
 
-    def scale_index(self, name: str, replicas: int):
-        """Change the number of replicas for the index. Replicas may be scaled up or down.
-
-        :param name: the name of the Index
-        :type name: str
-        :param replicas: the number of replicas in the index now, lowest value is 1.
-        :type replicas: int
-        """
-        api_instance = self.index_api
-        api_instance.configure_index(name, patch_request=ConfigureIndexRequest(replicas=replicas, pod_type=""))
-
     def create_collection(self, name: str, source: str):
         """Create a collection
         :param name: Name of the collection


### PR DESCRIPTION
## Problem

Found this deprecated method while updating doc strings. It won't work in its current state, and it was described as deprecated in the Changelog 2 years ago.

## Solution

- [x] Delete it 🗑️ 
- [x] Verified not used in notebook examples
- [x] Verified not used in readme-docs  

