### PR TITLE
Query method to accepts kwargs only

### DIFF
--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -315,6 +315,7 @@ class Index():
     @validate_and_convert_errors
     def query(
         self,
+        *,
         top_k: int,
         vector: Optional[List[float]] = None,
         id: Optional[str] = None,

--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -288,6 +288,7 @@ class GRPCIndex(GRPCIndexBase):
 
     def query(
         self,
+        *,
         vector: Optional[List[float]] = None,
         id: Optional[str] = None,
         namespace: Optional[str] = None,


### PR DESCRIPTION
## Problem

Ever since I corrected a problem with `top_k` param not actually being optional and therefore needing to come first in the parameters list, people updating notebooks have been running into a lot of confusing errors. It seems that many people were relying on positional arguments with the query vector as the first param.

## Solution

For query to accept kwargs only. This will at least give people an error message that makes sense instead of the one they currently see about passing two `top_k` values.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Will do manual testing in collab to examine the errors that now occur when passing incorrect values.