### PR TITLE
Add `query()` validation to prevent sending both `id` and `vector`

### DIFF
--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -368,6 +368,9 @@ class Index():
 
         _check_type = kwargs.pop("_check_type", False)
 
+        if vector is not None and id is not None:
+            raise ValueError("Cannot specify both `id` and `vector`")
+
         sparse_vector = self._parse_sparse_values_arg(sparse_vector)
         args_dict = self._parse_non_empty_args(
             [

--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -315,10 +315,10 @@ class GRPCIndex(GRPCIndexBase):
         Args:
             vector (List[float]): The query vector. This should be the same length as the dimension of the index
                                   being queried. Each `query()` request can contain only one of the parameters
-                                  `queries`, `id` or `vector`.. [optional]
+                                  `id` or `vector`.. [optional]
             id (str): The unique ID of the vector to be used as a query vector.
                       Each `query()` request can contain only one of the parameters
-                      `queries`, `vector`, or  `id`.. [optional]
+                      `vector` or  `id`.. [optional]
             top_k (int): The number of results to return for each query. Must be an integer greater than 1.
             namespace (str): The namespace to fetch vectors from.
                              If not specified, the default namespace is used. [optional]
@@ -337,7 +337,8 @@ class GRPCIndex(GRPCIndexBase):
                  and namespace name.
         """
 
-        queries = None
+        if vector is not None and id is not None:
+            raise ValueError("Cannot specify both `id` and `vector`")
 
         if filter is not None:
             filter_struct = dict_to_proto_struct(filter)
@@ -349,7 +350,6 @@ class GRPCIndex(GRPCIndexBase):
             [
                 ("vector", vector),
                 ("id", id),
-                ("queries", queries),
                 ("namespace", namespace),
                 ("top_k", top_k),
                 ("filter", filter_struct),

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -370,6 +370,10 @@ class TestRestIndex:
             pinecone.QueryRequest(top_k=10, id="vec1", include_metadata=True, include_values=False)
         )
 
+    def test_query_rejects_both_id_and_vector(self):
+        with pytest.raises(ValueError, match="Cannot specify both `id` and `vector`"):
+            self.index.query(top_k=10, id="vec1", vector=[1, 2, 3])
+
     # endregion
 
     # region: delete tests

--- a/tests/unit_grpc/test_grpc_index_query.py
+++ b/tests/unit_grpc/test_grpc_index_query.py
@@ -42,3 +42,7 @@ class TestGrpcIndexQuery:
             QueryRequest(top_k=10, id="vec1", include_metadata=True, include_values=False),
             timeout=None,
         )
+
+    def test_query_rejects_both_id_and_vector(self):
+        with pytest.raises(ValueError, match="Cannot specify both `id` and `vector`"):
+            self.index.query(top_k=10, id="vec1", vector=[1, 2, 3])


### PR DESCRIPTION
## Problem

Currently the python SDK allows users to send a request that contains values for both the `id` and `vector` fields. This request doesn't make sense to the API since the `id` field, when provided, is used to look up a vector in the index whose values should be used as the query.

We'd like to give clear feedback to the user that this is not correct usage rather than showing empty results.

## Solution

- Implement the validation as a simple if-statement. 
- Update docstrings.

## Type of Change

- [x] None of the above: UX improvement

## Test Plan

Added unit tests for this error handling case