### PR TITLE
Re-enable integration test for `configure_index`

### DIFF
--- a/tests/integration/control/test_configure_pod_index.py
+++ b/tests/integration/control/test_configure_pod_index.py
@@ -1,7 +1,6 @@
 import pytest
 import time
 
-@pytest.mark.skip(reason='API bug reported')
 class TestCreatePodIndex():
     def test_create_pod_index(self, client, ready_pod_index):
         time.sleep(30) # Wait a little more, just in case.

--- a/tests/integration/control/test_configure_pod_index.py
+++ b/tests/integration/control/test_configure_pod_index.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 
-class TestCreatePodIndex():
-    def test_create_pod_index(self, client, ready_pod_index):
+class TestConfigurePodIndex():
+    def test_configure_pod_index(self, client, ready_pod_index):
         time.sleep(30) # Wait a little more, just in case.
         client.configure_index(ready_pod_index, replicas=1, pod_type='p1.x1')


### PR DESCRIPTION
## Problem

We temporarily disabled this integration test earlier after reporting a bug to the backend team. Now we can bring it back.

## Solution

Enable test. 

## Type of Change

- [x] Infrastructure change (CI configs, etc)
