### PR TITLE
Improve error message when using positional arguments with query()

### DIFF
--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -315,6 +315,7 @@ class Index():
     @validate_and_convert_errors
     def query(
         self,
+        *args,
         top_k: int,
         vector: Optional[List[float]] = None,
         id: Optional[str] = None,
@@ -366,10 +367,13 @@ class Index():
                  and namespace name.
         """
 
-        _check_type = kwargs.pop("_check_type", False)
+        if len(args) > 0:
+            raise ValueError("The argument order for `query()` has changed; please use keyword arguments instead of positional arguments. Example: index.query(vector=[0.1, 0.2, 0.3], top_k=10, namespace='my_namespace')")
 
         if vector is not None and id is not None:
             raise ValueError("Cannot specify both `id` and `vector`")
+
+        _check_type = kwargs.pop("_check_type", False)
 
         sparse_vector = self._parse_sparse_values_arg(sparse_vector)
         args_dict = self._parse_non_empty_args(

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -374,6 +374,11 @@ class TestRestIndex:
         with pytest.raises(ValueError, match="Cannot specify both `id` and `vector`"):
             self.index.query(top_k=10, id="vec1", vector=[1, 2, 3])
 
+    def test_query_with_positional_args(self, mocker):
+        with pytest.raises(ValueError) as e:
+            self.index.query([0.1, 0.2, 0.3], top_k=10)
+        assert "The argument order for `query()` has changed; please use keyword arguments instead of positional arguments" in str(e.value)
+
     # endregion
 
     # region: delete tests


### PR DESCRIPTION
## Problem

In v3.0, the order of arguments to `query()` was changed to reflect that `top_k` is required and should therefore come first in the list of parameters. This is unfortunate, since it means any usage relying on `vector` being the first positional parameter will see a cryptic error about passing two values of `top_k`. 

## Solution

Disable positional arguments for this function. This allows us to throw an error message with clearer instructions to the user.

## Type of Change

- [x] None of the above: Error UX

## Test Plan

Added unit test.

```
>>> from pinecone import Pinecone
>>> pc = Pinecone(api_key='XXX')
>>> index = pc.Index('foo')
>>> index.query([0.1, 0.2], top_k=10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jhamon/workspace/pinecone-python-client/pinecone/utils/error_handling.py", line 10, in inner_func
    return func(*args, **kwargs)
  File "/Users/jhamon/workspace/pinecone-python-client/pinecone/data/index.py", line 373, in query
    raise ValueError("""The argument order for `query()` has changed; please use keyword arguments instead of positional arguments.
ValueError: The argument order for `query()` has changed; please use keyword arguments instead of positional arguments. Example: index.query(vector=[0.1, 0.2, 0.3], top_k=10, namespace='my_namespace')

>>> index.query(vector=[0.1, 0.2], top_k=10)
{"results":[],"matches":[],"namespace":"","usage":{"readUnits":0}}
```