### PR TITLE
README.md: Update install steps to escape brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are aiming to maximimize performance, you can install additional gRPC dep
 pip3 install pinecone-client
 
 # Install the latest version, with extra grpc dependencies
-pip3 install pinecone-client[grpc]
+pip3 install "pinecone-client[grpc]"
 
 # Install a specific version
 pip3 install pinecone-client==3.0.0


### PR DESCRIPTION
## Problem

Some shells (e.g. zsh) treat the '[]' in the argument as a shell expansion, and fail to pass the correct argument to pip:

    % pip3 install pinecone-client[grpc] 
    zsh: no matches found: pinecone-client[grpc]

## Solution

Fix by quoting the package name.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Confirmed install still works with zsh and bash on macOS. 