### PR TITLE
Support overriding `additional_headers` with `PINECONE_ADDITIONAL_HEADERS` environment variable

### DIFF
--- a/pinecone/config/pinecone_config.py
+++ b/pinecone/config/pinecone_config.py
@@ -13,11 +13,12 @@ class PineconeConfig():
     @staticmethod
     def build(api_key: Optional[str] = None, host: Optional[str] = None, additional_headers: Optional[Dict[str, str]] = {},  **kwargs) -> Config:
         host = host or kwargs.get("host") or os.getenv("PINECONE_CONTROLLER_HOST") or DEFAULT_CONTROLLER_HOST
-        try:
-          headers_json = os.getenv("PINECONE_ADDITIONAL_HEADERS")
-          headers = json.loads(headers_json)
-          additional_headers = additional_headers or headers
-        except json.decoder.JSONDecodeError as e:
-          logger.warn(f'Ignoring PINECONE_ADDITIONAL_HEADERS: {e}')
+        headers_json = os.getenv("PINECONE_ADDITIONAL_HEADERS")
+        if headers_json:
+          try:
+            headers = json.loads(headers_json)
+            additional_headers = additional_headers or headers
+          except json.decoder.JSONDecodeError as e:
+            logger.warn(f'Ignoring PINECONE_ADDITIONAL_HEADERS: {e}')
 
         return ConfigBuilder.build(api_key=api_key, host=host, additional_headers=additional_headers, **kwargs)

--- a/pinecone/config/pinecone_config.py
+++ b/pinecone/config/pinecone_config.py
@@ -18,7 +18,7 @@ class PineconeConfig():
           try:
             headers = json.loads(headers_json)
             additional_headers = additional_headers or headers
-          except json.decoder.JSONDecodeError as e:
+          except Exception as e:
             logger.warn(f'Ignoring PINECONE_ADDITIONAL_HEADERS: {e}')
 
         return ConfigBuilder.build(api_key=api_key, host=host, additional_headers=additional_headers, **kwargs)

--- a/pinecone/config/pinecone_config.py
+++ b/pinecone/config/pinecone_config.py
@@ -18,6 +18,6 @@ class PineconeConfig():
           headers = json.loads(headers_json)
           additional_headers = additional_headers or headers
         except json.decoder.JSONDecodeError as e:
-          logger.warn(f'Ignoring PINECONE_ADDITIONAL_HEADERS: {}', e)
+          logger.warn(f'Ignoring PINECONE_ADDITIONAL_HEADERS: {e}')
 
         return ConfigBuilder.build(api_key=api_key, host=host, additional_headers=additional_headers, **kwargs)

--- a/pinecone/config/pinecone_config.py
+++ b/pinecone/config/pinecone_config.py
@@ -1,6 +1,10 @@
 from typing import Optional, Dict
+import logging
+import json
 import os
 from .config import ConfigBuilder, Config
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_CONTROLLER_HOST = "https://api.pinecone.io"
 
@@ -9,4 +13,11 @@ class PineconeConfig():
     @staticmethod
     def build(api_key: Optional[str] = None, host: Optional[str] = None, additional_headers: Optional[Dict[str, str]] = {},  **kwargs) -> Config:
         host = host or kwargs.get("host") or os.getenv("PINECONE_CONTROLLER_HOST") or DEFAULT_CONTROLLER_HOST
+        try:
+          headers_json = os.getenv("PINECONE_ADDITIONAL_HEADERS")
+          headers = json.loads(headers_json)
+          additional_headers = additional_headers or headers
+        except json.decoder.JSONDecodeError as e:
+          logger.warn(f'Ignoring PINECONE_ADDITIONAL_HEADERS: {}', e)
+
         return ConfigBuilder.build(api_key=api_key, host=host, additional_headers=additional_headers, **kwargs)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -70,7 +70,7 @@ class TestConfig:
         controller_host = "kwargs-controller-host"
         additional_headers = {"header": "value2"}
 
-        config = PineconeConfig.build(api_key=api_key, host=controller_host, additional_headers)
+        config = PineconeConfig.build(api_key=api_key, host=controller_host, additional_headers=additional_headers)
 
         assert config.api_key == api_key
         assert config.host == 'https://' + controller_host

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,7 +14,7 @@ class TestConfig:
         # Defend against unexpected env vars. Since we clear these variables below
         # after each test execution, these should only be raised if there is
         # test pollution in the environment coming from some other test file/setup.
-        known_env_vars = ["PINECONE_API_KEY", "PINECONE_ENVIRONMENT", "PINECONE_CONTROLLER_HOST"]
+        known_env_vars = ["PINECONE_API_KEY", "PINECONE_ENVIRONMENT", "PINECONE_CONTROLLER_HOST", "PINECONE_ADDITIONAL_HEADERS"]
         for var in known_env_vars:
             if os.getenv(var):
                 raise ValueError(f"Unexpected env var {var} found in environment. Check for test pollution.")
@@ -29,11 +29,13 @@ class TestConfig:
     def test_init_with_environment_vars(self):
         os.environ["PINECONE_API_KEY"] = "test-api-key"
         os.environ["PINECONE_CONTROLLER_HOST"] = "https://test-controller-host"
+        os.environ["PINECONE_ADDITIONAL_HEADERS"] = '{"header": "value"}'
 
         config = PineconeConfig.build()
 
         assert config.api_key == "test-api-key"
         assert config.host == "https://test-controller-host"
+        assert config.additional_headers == {"header": "value"}
 
     def test_init_with_positional_args(self):
         api_key = "my-api-key"
@@ -62,14 +64,17 @@ class TestConfig:
         """
         os.environ["PINECONE_API_KEY"] = "env-var-api-key"
         os.environ["PINECONE_CONTROLLER_HOST"] = "env-var-controller-host"
+        os.environ["PINECONE_ADDITIONAL_HEADERS"] = '{"header": "value1"}'
 
         api_key = "kwargs-api-key"
         controller_host = "kwargs-controller-host"
+        additional_headers = {"header": "value2"}
 
-        config = PineconeConfig.build(api_key=api_key, host=controller_host)
+        config = PineconeConfig.build(api_key=api_key, host=controller_host, additional_headers)
 
         assert config.api_key == api_key
         assert config.host == 'https://' + controller_host
+        assert config.additional_headers == additional_headers
 
     def test_errors_when_no_api_key_is_present(self):
         with pytest.raises(PineconeConfigurationError):


### PR DESCRIPTION
## Problem

We need a way to attach special request headers in integration testing.

## Solution

Add support for overriding additional_headers via the `PINECONE_ADDITIONAL_HEADERS` environment variable.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Unit tests

```
$ cd pinecone-python-client/
$ export PINECONE_ADDITIONAL_HEADERS='{"header": "value"}'
$ python3
>>> from pinecone import Pinecone
>>> client = Pinecone(api_key='key', host='host')
>>> vars(client)
{'config': ... additional_headers={'header': 'value'}), ...}
```

