### PR TITLE
List vector ids by prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,53 @@ update_response = index.update(
 )
 ```
 
+## List vectors
+
+The `list` and `list_paginated` methods can be used to list vector ids matching a particular id prefix. 
+With clever assignment of vector ids, this can be used to help model hierarchical relationships between
+different vectors such as when there are embeddings for multiple chunks or fragments related to the 
+same document.
+
+The `list` method returns a generator that handles pagination on your behalf.
+
+```python
+from pinecone import Pinecone
+
+pc = Pinecone(api_key='xxx')
+index = pc.Index(host='hosturl')
+
+# To iterate over all result pages using a generator function
+namespace = 'foo-namespace'
+for ids in index.list(prefix='pref', limit=3, namespace=namespace):
+    print(ids) # ['pref1', 'pref2', 'pref3']
+
+    # Now you can pass this id array to other methods, such as fetch or delete.
+    vectors = index.fetch(ids=ids, namespace=namespace)
+```
+
+There is also an option to fetch each page of results yourself with `list_paginated`.
+
+```python
+from pinecone import Pinecone
+
+pc = Pinecone(api_key='xxx')
+index = pc.Index(host='hosturl')
+
+# For manual control over pagination
+results = index.list_paginated(
+    prefix='pref',
+    limit=3,
+    namespace='foo',
+    pagination_token='eyJza2lwX3Bhc3QiOiI5IiwicHJlZml4IjpudWxsfQ=='
+)
+print(results.namespace) # 'foo'
+print([v.id for v in results.vectors]) # ['pref1', 'pref2', 'pref3']
+print(results.pagination.next) # 'eyJza2lwX3Bhc3QiOiI5IiwicHJlZml4IjpudWxsfQ=='
+print(results.usage) # { 'read_units': 1 }
+```
+
+# Collections
+
 ## Create collection
 
 The following example creates the collection `example-collection` from

--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -512,6 +512,31 @@ class Index():
         namespace: Optional[str] = None,
         **kwargs
     ) ->  ListResponse:
+        """
+        The list_paginated operation finds vectors based on an id prefix within a single namespace.
+        It returns matching ids in a paginated form, with a pagination token to fetch the next page of results.
+        This id list can then be passed to fetch or delete operations, depending on your use case.
+        
+        Consider using the `list` method to avoid having to handle pagination tokens manually.
+
+        Examples:
+            >>> results = index.list_paginated(prefix='99', limit=5, namespace='my_namespace')
+            >>> [v.id for v in results.vectors]
+            ['99', '990', '991', '992', '993']
+            >>> results.pagination.next
+            eyJza2lwX3Bhc3QiOiI5OTMiLCJwcmVmaXgiOiI5OSJ9
+            >>> next_results = index.list_paginated(prefix='99', limit=5, namespace='my_namespace', pagination_token=results.pagination.next)
+
+        Args:
+            prefix (Optional[str]): The id prefix to match. If unspecified, an empty string prefix will 
+                                    be used with the effect of listing all ids in a namespace [optional]
+            limit (Optional[int]): The maximum number of ids to return. If unspecified, the server will use a default value. [optional]
+            pagination_token (Optional[str]): A token needed to fetch the next page of results. This token is returned 
+                in the response if additional results are available. [optional]
+            namespace (Optional[str]): The namespace to fetch vectors from. If not specified, the default namespace is used. [optional]
+        
+        Returns: ListResponse object which contains the list of ids, the namespace name, pagination information, and usage showing the number of read_units consumed.
+        """
         args_dict = self._parse_non_empty_args(
             [
                 ("prefix", prefix),
@@ -524,15 +549,33 @@ class Index():
 
     @validate_and_convert_errors
     def list(self, **kwargs):
-        limit = kwargs.get("limit", 100)
+        """
+        The list operation accepts all of the same arguments as list_paginated, and returns a generator that yields
+        a list of the matching vector ids in each page of results. It automatically handles pagination tokens on your
+        behalf.
+
+        Examples:
+            >>> for ids in index.list(prefix='99', limit=5, namespace='my_namespace'):
+            >>>     print(ids)
+            ['99', '990', '991', '992', '993']
+            ['994', '995', '996', '997', '998']
+            ['999']
+
+        Args:
+            prefix (Optional[str]): The id prefix to match. If unspecified, an empty string prefix will 
+                                    be used with the effect of listing all ids in a namespace [optional]
+            limit (Optional[int]): The maximum number of ids to return. If unspecified, the server will use a default value. [optional]
+            pagination_token (Optional[str]): A token needed to fetch the next page of results. This token is returned 
+                in the response if additional results are available. [optional]
+            namespace (Optional[str]): The namespace to fetch vectors from. If not specified, the default namespace is used. [optional]
+        """
         done = False
         while not done:
             results = self.list_paginated(**kwargs)
             if len(results.vectors) > 0:
                 yield [v.id for v in results.vectors]
             
-            full_page = len(results.vectors) == limit
-            if results.pagination and full_page:
+            if results.pagination:
                 kwargs.update({"pagination_token": results.pagination.next})
             else:
                 done = True

--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -440,9 +440,33 @@ class GRPCIndex(GRPCIndexBase):
             limit: Optional[int] = None,
             pagination_token: Optional[str] = None,
             namespace: Optional[str] = None,
-            timeout: Optional[float] = None,
             **kwargs
         ) -> SimpleListResponse:
+        """
+        The list_paginated operation finds vectors based on an id prefix within a single namespace.
+        It returns matching ids in a paginated form, with a pagination token to fetch the next page of results.
+        This id list can then be passed to fetch or delete operations, depending on your use case.
+        
+        Consider using the `list` method to avoid having to handle pagination tokens manually.
+
+        Examples:
+            >>> results = index.list_paginated(prefix='99', limit=5, namespace='my_namespace')
+            >>> [v.id for v in results.vectors]
+            ['99', '990', '991', '992', '993']
+            >>> results.pagination.next
+            eyJza2lwX3Bhc3QiOiI5OTMiLCJwcmVmaXgiOiI5OSJ9
+            >>> next_results = index.list_paginated(prefix='99', limit=5, namespace='my_namespace', pagination_token=results.pagination.next)
+
+        Args:
+            prefix (Optional[str]): The id prefix to match. If unspecified, an empty string prefix will 
+                                    be used with the effect of listing all ids in a namespace [optional]
+            limit (Optional[int]): The maximum number of ids to return. If unspecified, the server will use a default value. [optional]
+            pagination_token (Optional[str]): A token needed to fetch the next page of results. This token is returned 
+                in the response if additional results are available. [optional]
+            namespace (Optional[str]): The namespace to fetch vectors from. If not specified, the default namespace is used. [optional]
+        
+        Returns: SimpleListResponse object which contains the list of ids, the namespace name, pagination information, and usage showing the number of read_units consumed.
+        """
         args_dict = self._parse_non_empty_args(
             [
                 ("prefix", prefix),
@@ -452,6 +476,7 @@ class GRPCIndex(GRPCIndexBase):
             ]
         )
         request = ListRequest(**args_dict, **kwargs)
+        timeout = kwargs.pop("timeout", None)
         response = self._wrap_grpc_call(self.stub.List, request, timeout=timeout)
         
         if response.pagination and response.pagination.next != '':
@@ -466,7 +491,26 @@ class GRPCIndex(GRPCIndexBase):
         )
     
     def list(self, **kwargs):
-        limit = kwargs.get("limit", 100)
+        """
+        The list operation accepts all of the same arguments as list_paginated, and returns a generator that yields
+        a list of the matching vector ids in each page of results. It automatically handles pagination tokens on your
+        behalf.
+
+        Examples:
+            >>> for ids in index.list(prefix='99', limit=5, namespace='my_namespace'):
+            >>>     print(ids)
+            ['99', '990', '991', '992', '993']
+            ['994', '995', '996', '997', '998']
+            ['999']
+
+        Args:
+            prefix (Optional[str]): The id prefix to match. If unspecified, an empty string prefix will 
+                                    be used with the effect of listing all ids in a namespace [optional]
+            limit (Optional[int]): The maximum number of ids to return. If unspecified, the server will use a default value. [optional]
+            pagination_token (Optional[str]): A token needed to fetch the next page of results. This token is returned 
+                in the response if additional results are available. [optional]
+            namespace (Optional[str]): The namespace to fetch vectors from. If not specified, the default namespace is used. [optional]
+        """
         done = False
         while not done:
             try:
@@ -477,8 +521,7 @@ class GRPCIndex(GRPCIndexBase):
             if len(results.vectors) > 0:
                 yield [v.id for v in results.vectors]
             
-            full_page = len(results.vectors) == limit
-            if results.pagination and results.pagination.next and full_page:
+            if results.pagination and results.pagination.next:
                 kwargs.update({"pagination_token": results.pagination.next})
             else:
                 done = True

--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -13,6 +13,10 @@ from pinecone.core.client.models import (
     QueryResponse,
     DescribeIndexStatsResponse,
 )
+from pinecone.models.list_response import (
+    ListResponse as SimpleListResponse,
+    Pagination
+)
 from pinecone.core.grpc.protos.vector_service_pb2 import (
     Vector as GRPCVector,
     QueryVector as GRPCQueryVector,
@@ -22,6 +26,8 @@ from pinecone.core.grpc.protos.vector_service_pb2 import (
     QueryRequest,
     FetchRequest,
     UpdateRequest,
+    ListRequest,
+    ListResponse,
     DescribeIndexStatsRequest,
     DeleteResponse,
     UpdateResponse,
@@ -40,7 +46,6 @@ _logger = logging.getLogger(__name__)
 class SparseVectorTypedDict(TypedDict):
     indices: List[int]
     values: List[float]
-
 
 class GRPCIndex(GRPCIndexBase):
     """A client for interacting with a Pinecone index via GRPC API."""
@@ -428,6 +433,55 @@ class GRPCIndex(GRPCIndexBase):
             return PineconeGrpcFuture(future)
         else:
             return self._wrap_grpc_call(self.stub.Update, request, timeout=timeout)
+
+    def list_paginated(
+            self,
+            prefix: Optional[str] = None,
+            limit: Optional[int] = None,
+            pagination_token: Optional[str] = None,
+            namespace: Optional[str] = None,
+            timeout: Optional[float] = None,
+            **kwargs
+        ) -> SimpleListResponse:
+        args_dict = self._parse_non_empty_args(
+            [
+                ("prefix", prefix),
+                ("limit", limit),
+                ("namespace", namespace),
+                ("pagination_token", pagination_token),
+            ]
+        )
+        request = ListRequest(**args_dict, **kwargs)
+        response = self._wrap_grpc_call(self.stub.List, request, timeout=timeout)
+        
+        if response.pagination and response.pagination.next != '':
+            pagination = Pagination(next=response.pagination.next)
+        else:
+            pagination = None
+        
+        return SimpleListResponse(
+            namespace=response.namespace,
+            vectors=response.vectors,
+            pagination=pagination,
+        )
+    
+    def list(self, **kwargs):
+        limit = kwargs.get("limit", 100)
+        done = False
+        while not done:
+            try:
+                results = self.list_paginated(**kwargs)
+            except Exception as e:
+                raise e
+            
+            if len(results.vectors) > 0:
+                yield [v.id for v in results.vectors]
+            
+            full_page = len(results.vectors) == limit
+            if results.pagination and results.pagination.next and full_page:
+                kwargs.update({"pagination_token": results.pagination.next})
+            else:
+                done = True
 
     def describe_index_stats(
         self, filter: Optional[Dict[str, Union[str, float, int, bool, List, dict]]] = None, **kwargs

--- a/pinecone/models/list_response.py
+++ b/pinecone/models/list_response.py
@@ -1,0 +1,9 @@
+from typing import NamedTuple, Optional, List
+
+class Pagination(NamedTuple):
+    next: str
+
+class ListResponse(NamedTuple):
+    namespace: str
+    vectors: List
+    pagination: Optional[Pagination]

--- a/tests/integration/data/conftest.py
+++ b/tests/integration/data/conftest.py
@@ -3,7 +3,7 @@ import os
 import time
 import json
 from ..helpers import get_environment_var, random_string
-from .seed import setup_data
+from .seed import setup_data, setup_list_data
 
 # Test matrix needs to consider the following dimensions:
 # - pod vs serverless
@@ -41,12 +41,16 @@ def spec():
 
 @pytest.fixture(scope='session')
 def index_name():
-    # return 'dataplane-lol'
     return 'dataplane-' + random_string(20)
     
 @pytest.fixture(scope='session')
 def namespace():
     # return 'banana'
+    return random_string(10)
+
+@pytest.fixture(scope='session')
+def list_namespace():
+    # return 'list-banana'
     return random_string(10)
 
 @pytest.fixture(scope='session')
@@ -57,20 +61,25 @@ def idx(client, index_name, index_host):
 def index_host(index_name, metric, spec):
     pc = build_client()
     print('Creating index with name: ' + index_name)
-    pc.create_index(
-        name=index_name, 
-        dimension=2, 
-        metric=metric, 
-        spec=spec
-    )
+    if index_name not in pc.list_indexes().names():
+        pc.create_index(
+            name=index_name, 
+            dimension=2, 
+            metric=metric, 
+            spec=spec
+        )
     description = pc.describe_index(name=index_name)
     yield description.host
+
     print('Deleting index with name: ' + index_name)
     pc.delete_index(index_name, -1)
 
 @pytest.fixture(scope='session', autouse=True)
-def seed_data(idx, namespace, index_host):
+def seed_data(idx, namespace, index_host, list_namespace):
     print('Seeding data in host ' + index_host)
+
+    print('Seeding list data in namespace "' + list_namespace + '"')
+    setup_list_data(idx, list_namespace, True)
 
     print('Seeding data in namespace "' + namespace + '"')
     setup_data(idx, namespace, False)
@@ -79,5 +88,6 @@ def seed_data(idx, namespace, index_host):
     setup_data(idx, '', True)
 
     print('Waiting a bit more to ensure freshness')
-    time.sleep(60)
+    time.sleep(120)
+
     yield

--- a/tests/integration/data/seed.py
+++ b/tests/integration/data/seed.py
@@ -32,3 +32,15 @@ def setup_data(idx, target_namespace, wait):
 
     if wait:
         poll_fetch_for_ids_in_namespace(idx, ids=['1', '2', '3', '4', '5', '6', '7', '8', '9'], namespace=target_namespace)
+
+def setup_list_data(idx, target_namespace, wait):
+    # Upsert a bunch more stuff for testing list pagination
+    for i in range(0, 1000, 50):
+        idx.upsert(vectors=[
+                (str(i+d), embedding_values(2)) for d in range(50)
+            ], 
+            namespace=target_namespace
+        )
+    
+    if wait:
+        poll_fetch_for_ids_in_namespace(idx, ids=['999'], namespace=target_namespace)

--- a/tests/integration/data/test_list.py
+++ b/tests/integration/data/test_list.py
@@ -1,0 +1,100 @@
+class TestListPaginated:
+    def test_list_when_no_results(self, idx):
+        results = idx.list_paginated(namespace='no-results')
+        assert results != None
+        assert results.namespace == 'no-results'
+        assert len(results.vectors) == 0
+        # assert results.pagination == None
+
+    def test_list_no_args(self, idx):
+        results = idx.list_paginated()
+        
+        assert results != None
+        assert len(results.vectors) == 9
+        assert results.namespace == ''
+        # assert results.pagination == None
+    
+    def test_list_when_limit(self, idx, list_namespace):
+        results = idx.list_paginated(limit=10, namespace=list_namespace)
+        
+        assert results != None
+        assert len(results.vectors) == 10
+        assert results.namespace == list_namespace
+        assert results.pagination != None
+        assert results.pagination.next != None
+        assert isinstance(results.pagination.next, str)
+        assert results.pagination.next != ''
+
+    def test_list_when_using_pagination(self, idx, list_namespace):
+        results = idx.list_paginated(
+            prefix='99', limit=5, namespace=list_namespace
+        )
+        next_results = idx.list_paginated(
+            prefix='99', limit=5, namespace=list_namespace, pagination_token=results.pagination.next
+        )
+        next_next_results = idx.list_paginated(
+            prefix='99', limit=5, namespace=list_namespace, pagination_token=next_results.pagination.next        
+        )
+
+        assert results.namespace == list_namespace
+        assert len(results.vectors) == 5
+        assert [v.id for v in results.vectors] == ['99', '990', '991', '992', '993']
+        assert len(next_results.vectors) == 5
+        assert [v.id for v in next_results.vectors] == ['994', '995', '996', '997', '998']
+        assert len(next_next_results.vectors) == 1
+        assert [v.id for v in next_next_results.vectors] == ['999']
+        # assert next_next_results.pagination == None
+
+class TestList:
+    def test_list_with_defaults(self, idx):
+        pages = []
+        page_sizes = []
+        page_count = 0
+        for ids in idx.list():
+            page_count += 1
+            assert ids != None
+            page_sizes.append(len(ids))
+            pages.append(ids)
+
+        assert page_count == 1
+        assert page_sizes == [9]
+
+    def test_list(self, idx, list_namespace):
+        results = idx.list(prefix='99', limit=20, namespace=list_namespace)
+
+        page_count = 0
+        for ids in results:
+            page_count += 1
+            assert ids != None
+            assert len(ids) == 11
+            assert ids == ['99', '990', '991', '992', '993', '994', '995', '996', '997', '998', '999']
+        assert page_count == 1
+
+    def test_list_when_no_results_for_prefix(self, idx, list_namespace):
+        page_count = 0
+        for ids in idx.list(prefix='no-results', namespace=list_namespace):
+            page_count += 1
+        assert page_count == 0
+
+    def test_list_when_no_results_for_namespace(self, idx):
+        page_count = 0
+        for ids in idx.list(prefix='99', namespace='no-results'):
+            page_count += 1
+        assert page_count == 0
+
+    def test_list_when_multiple_pages(self, idx, list_namespace):
+        pages = []
+        page_sizes = []
+        page_count = 0
+
+        for ids in idx.list(prefix='99', limit=5, namespace=list_namespace):
+            page_count += 1
+            assert ids != None
+            page_sizes.append(len(ids))
+            pages.append(ids)
+
+        assert page_count == 3
+        assert page_sizes == [5, 5, 1]
+        assert pages[0] == ['99', '990', '991', '992', '993']
+        assert pages[1] == ['994', '995', '996', '997', '998']
+        assert pages[2] == ['999']

--- a/tests/integration/data/test_list.py
+++ b/tests/integration/data/test_list.py
@@ -1,3 +1,5 @@
+from pinecone import Vector
+
 class TestListPaginated:
     def test_list_when_no_results(self, idx):
         results = idx.list_paginated(namespace='no-results')
@@ -98,3 +100,14 @@ class TestList:
         assert pages[0] == ['99', '990', '991', '992', '993']
         assert pages[1] == ['994', '995', '996', '997', '998']
         assert pages[2] == ['999']
+
+    def test_list_then_fetch(self, idx, list_namespace):
+        vectors = []
+
+        for ids in idx.list(prefix='99', limit=5, namespace=list_namespace):
+            result = idx.fetch(ids=ids, namespace=list_namespace)
+            vectors.extend([v for _, v in result.vectors.items()])
+
+        assert len(vectors) == 11
+        assert isinstance(vectors[0], Vector)
+        assert set([v.id for v in vectors]) == set(['99', '990', '991', '992', '993', '994', '995', '996', '997', '998', '999'])

--- a/tests/integration/data/test_list_errors.py
+++ b/tests/integration/data/test_list_errors.py
@@ -1,0 +1,16 @@
+from pinecone import PineconeException
+import pytest
+
+class TestListErrors:
+    def test_list_change_prefix_while_fetching_next_page(self, idx, list_namespace):
+        results = idx.list_paginated(prefix='99', limit=5, namespace=list_namespace)
+        with pytest.raises(PineconeException) as e:
+            idx.list_paginated(prefix='98', limit=5, pagination_token=results.pagination.next)
+        assert 'prefix' in str(e.value)
+
+    @pytest.mark.skip(reason='Bug filed')
+    def test_list_change_namespace_while_fetching_next_page(self, idx, namespace):
+        results = idx.list_paginated(limit=5, namespace=namespace)
+        with pytest.raises(PineconeException) as e:
+            idx.list_paginated(limit=5, namespace='new-namespace', pagination_token=results.pagination.next)
+        assert 'namespace' in str(e.value)


### PR DESCRIPTION
## Problem

Need to implement the new data plane list endpoint.

## Solution

- Update generated code. Pull in list endpoint. All changes under `pinecone/core` are generated from spec files and can be ignored for this review.
- Implement changes for list endpoint in:
  - `pinecone/data/index.py` main implementation
  - `pinecone/grpc/index_grpc.py` main implementation
  - `tests/integration/data/conftest.py` adjustments to test setup, mainly to generate a new namespace to hold vectors for list testing data.
  - `tests/integration/data/seed.py` to upsert a larger number of vectors, so I would have enough data to page through
  - `tests/integration/data/test_list.py`
  -  `tests/integration/data/test_list_errors.py`

## Open questions

- Do we expect to ever return more data than just `{'id': '1'}` in the vectors array? For convenience the `list()` method is currently implemented as a generator function that abstracts the pagination steps and yields a flat list of id values. For a use case where you were going to immediately fetch those ids, this seems ideal. But would be limiting if we ever wanted to return more than just ids here.
 
## Usage

Install the dev client version `install "pinecone-client[grpc]"==3.1.0.dev1`

### REST

```python
from pinecone import Pinecone

pc = Pinecone(api_key='xxx')
index = pc.Index(host='hosturl')

# To iterate over all result pages using a generator function
for ids in index.list(prefix='pref', limit=3, namespace='foo'):
    print(ids) // ['pref1', 'pref2', 'pref3']

# For manual control over pagination
results = index.list_paginated(
    prefix='pref', 
    limit=3, 
    namespace='foo', 
    pagination_token='eyJza2lwX3Bhc3QiOiI5IiwicHJlZml4IjpudWxsfQ=='
)
print(results.namespace)
print([v.id for v in results.vectors])
print(results.pagination.next)
print(results.usage)
```

### GRPC

```python
from pinecone.grpc import PineconeGRPC

pc = PineconeGRPC(api_key='xxx')
index = pc.Index(host='hosturl')

# To iterate over all result pages using a generator function
for ids in index.list(prefix='pref', limit=3, namespace='foo'):
    print(ids) // ['pref1', 'pref2', 'pref3']

# For manual control over pagination
results = index.list_paginated(
    prefix='pref', 
    limit=3, 
    namespace='foo', 
    pagination_token='eyJza2lwX3Bhc3QiOiI5IiwicHJlZml4IjpudWxsfQ=='
)
print(results.namespace)
print([v.id for v in results.vectors])
print(results.pagination.next)
print(results.usage)
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

Try out the dev version.

```
pip install "pinecone-client[grpc]"==3.1.0.dev1
```
