### PR TITLE
Update github actions dependencies to fix warnings

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -9,7 +9,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -25,5 +25,5 @@ outputs:
     description: 'The previous version tag'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/.github/actions/create-index-legacy/action.yml
+++ b/.github/actions/create-index-legacy/action.yml
@@ -28,7 +28,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/actions/create-index/action.yml
+++ b/.github/actions/create-index/action.yml
@@ -35,7 +35,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/actions/delete-index/action.yml
+++ b/.github/actions/delete-index/action.yml
@@ -14,7 +14,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/actions/test-data-plane/action.yaml
+++ b/.github/actions/test-data-plane/action.yaml
@@ -35,7 +35,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
 

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate pdoc documentation
         uses: ./.github/actions/build-docs

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -38,7 +38,7 @@ jobs:
         if: steps.list-commits.outputs.commits == ''
         uses: andymckay/cancel-action@0.3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get recent changes
         id: list-commits

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build docs with pdoc
         uses: './.github/actions/build-docs'
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Poetry

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -72,7 +72,7 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Need full history and tags to compute list of commits in release
           ref: ${{ inputs.ref }}

--- a/.github/workflows/testing-dependency.yaml
+++ b/.github/workflows/testing-dependency.yaml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -86,7 +86,7 @@ jobs:
       - name: Install googleapis-common-protos ${{ matrix.googleapis-common-protos-version }}
         run: poetry add googleapis-common-protos==${{ matrix.googleapis-common-protos-version }}
 
-      - uses: nick-fields/retry@v2
+      - uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Setup Poetry
@@ -131,7 +131,7 @@ jobs:
           include_types: false
       - name: 'Install urllib3 ${{ matrix.urllib3-version }}'
         run: 'poetry add urllib3==${{ matrix.urllib3-version }}'
-      - uses: nick-fields/retry@v2
+      - uses: nick-fields/retry@v3
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.github/workflows/testing-integration.yaml
+++ b/.github/workflows/testing-integration.yaml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up Python ${{ matrix.testConfig.python-version }}'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.testConfig.python-version }}'
       - name: Setup Poetry
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up Python ${{ matrix.testConfig.python-version }}'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.testConfig.python-version }}'
       - name: Setup Poetry

--- a/.github/workflows/testing-unit.yaml
+++ b/.github/workflows/testing-unit.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: 'Set up Python ${{ matrix.python-version }}'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '${{ matrix.python-version }}'
       - name: Setup Poetry


### PR DESCRIPTION
## Problem

Our test runs produce a large number of warnings related to deprecated node16 usage. 

![Screenshot 2024-02-07 at 10 52 25 AM](https://github.com/pinecone-io/pinecone-python-client/assets/1326365/299eeff5-961b-4804-b918-fa9657726f85)


## Solution

Update the version of the shared tasks we are using.

## Type of Change

- [x] Infrastructure change (CI configs, etc)
