### PR TITLE
upsert_from_dataframe: Hide all progressbars if !show_progress

### DIFF
--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -188,7 +188,8 @@ class GRPCIndex(GRPCIndexBase):
 
         if use_async_requests:
             cast_results = cast(List[PineconeGrpcFuture], results)
-            results = [async_result.result() for async_result in tqdm(cast_results, desc="collecting async responses")]
+            results = [async_result.result() for async_result in
+                       tqdm(cast_results, disable=not show_progress, desc="collecting async responses")]
 
         upserted_count = 0
         for res in results:


### PR DESCRIPTION
## Problem

For GRPCIndex.upsert_from_dataframe() there is a second progressbar
used when use_async_requests is true (the default) - 'collecting async
responses'. However this progressbar is always shown, even if
show_progress is false.

## Solution

Make it respect the show_progress argument.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

