### PR TITLE
Pass the openapi_config to the Index object

### DIFF
--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -524,9 +524,9 @@ class Pinecone:
 
         if host != '':
             # Use host url if it is provided
-            return Index(api_key=self.config.api_key, host=normalize_host(host), pool_threads=pt, **kwargs)
+            return Index(api_key=self.config.api_key, host=normalize_host(host), pool_threads=pt, openapi_config=self.config.openapi_config, **kwargs)
 
         if name != '':
             # Otherwise, get host url from describe_index using the index name
             index_host = self.index_host_store.get_host(self.index_api, self.config, name)
-            return Index(api_key=self.config.api_key, host=index_host, pool_threads=pt, **kwargs)
+            return Index(api_key=self.config.api_key, host=index_host, pool_threads=pt, openapi_config=self.config.openapi_config, **kwargs)

--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -78,7 +78,7 @@ class Index():
             **kwargs
         ):
         self._config = ConfigBuilder.build(api_key=api_key, host=host, **kwargs)
-        
+        self._config.openapi_config.host = host
         api_client = ApiClient(configuration=self._config.openapi_config, 
                                pool_threads=pool_threads)
 


### PR DESCRIPTION
## Problem

The Data API does not use the proxy set in the openapi_config in `Pinecone()`

## Solution

It passes the `openapi_config` down to `Index()`
 
## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Spin up a proxy

```
brew install mitmproxy
/opt/homebrew/bin/mitmweb
```

Execute the following script

```
import os

import pinecone
from pinecone import Pinecone
from pinecone.core.client.configuration import Configuration as OpenApiConfiguration

print(f"Version {pinecone.utils.version.get_version()}")

openapi_config = OpenApiConfiguration.get_default_copy()
openapi_config.proxy = "http://0.0.0.0:8080"
openapi_config.ssl_ca_cert = '~/.mitmproxy/mitmproxy-ca-cert.pem'
openapi_config.api_key = {"ApiKeyAuth": f"{os.getenv('PINECONE_API_KEY')}"}

pc = Pinecone(openapi_config=openapi_config)
index = pc.Index("test")
print(index.describe_index_stats())
```