### PR TITLE
[Fix] openapi_config deprecation warning incorrectly shown

### DIFF
--- a/pinecone/config/openapi.py
+++ b/pinecone/config/openapi.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 import certifi
 import socket
 import copy
-import warnings
 
 from urllib3.connection import HTTPConnection
 
@@ -34,7 +33,6 @@ class OpenApiConfigFactory:
         we don't modify those settings.
         '''
         copied = copy.deepcopy(openapi_config)
-        warnings.warn("Passing openapi_config is deprecated and will be removed in a future release. Please pass settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at https://github.com/pinecone-io/pinecone-python-client for examples.", DeprecationWarning)
 
         copied.api_key = {"ApiKeyAuth": api_key}
         copied.host = host

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -1,4 +1,5 @@
 import time
+import warnings
 from typing import Optional, Dict, Any, Union, List, cast, NamedTuple
 
 from .index_host_store import IndexHostStore
@@ -174,8 +175,6 @@ class Pinecone:
         pc.list_indexes()
 
         ```
-        
-
         """
         if config:
             if not isinstance(config, Config):
@@ -193,6 +192,9 @@ class Pinecone:
                 ssl_verify=ssl_verify,
                 **kwargs
             )
+
+        if kwargs.get("openapi_config", None):
+            warnings.warn("Passing openapi_config is deprecated and will be removed in a future release. Please pass settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at https://github.com/pinecone-io/pinecone-python-client for examples.", DeprecationWarning)
 
         self.openapi_config = ConfigBuilder.build_openapi_config(self.config, **kwargs)
         self.pool_threads = pool_threads


### PR DESCRIPTION
## Problem

A deprecation warning about openapi_config was appearing even when users were not passing in that keyword parameter. 

## Solution

One of the things that makes the `openapi_config` object (instance of `OpenApiConfiguration`, a generated class) difficult to work with is that it carries a large amount of state; some of the fields inside of it are essentially constant (e.g. API key header) and others need to be adjusted based on which index you are trying to upsert/query/etc from. But you can't simply update those host values because multiple `Index` client objects could be sharing the same object reference. Consequently, a `copy()` method was added to make a deepcopy of this object before modifying any configuration properties when targeting an index.

For similar reasons, the same `copy()` method was being invoked when users passed in an `openapi_config` object as a kwarg to `Pinecone(openapi_config=config, api_key='key')`. This object was traditionally used as a vehicle for proxy configuration but needed to be merged with other configuration information, and the copy method ensures those changes are isolated from any other references to the object passed by the user.

Anyway, the deprecation notice was erroneously added inside the copy method even though it has these two very different use cases and only one of those use cases make sense for the warning notice to appear. To fix the issue, we simply migration the warning notice into the constructor method of the `Pinecone` class. This `__init__()` method is only invoked when creating the client, there's no concern about code reuse causing the notice to appear at other times.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
