### PR TITLE
pinecone-client > pinecone

### DIFF
--- a/.github/actions/create-index-legacy/action.yml
+++ b/.github/actions/create-index-legacy/action.yml
@@ -32,10 +32,10 @@ runs:
       with:
         python-version: 3.9
 
-    - name: Install pinecone-client
+    - name: Install pinecone
       shell: bash
       run: |
-        pip install pinecone-client==${{ inputs.pinecone_client_version }}
+        pip install pinecone==${{ inputs.pinecone_client_version }}
     
     - name: Create index
       id: create-index

--- a/.github/workflows/alpha-release.yaml
+++ b/.github/workflows/alpha-release.yaml
@@ -1,4 +1,4 @@
-name: 'PyPI Release: Pre-Release (pinecone-client)'
+name: 'PyPI Release: Pre-Release (pinecone)'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -1,4 +1,4 @@
-name: 'PyPI Release: Nightly (pinecone-client-nightly)'
+name: 'PyPI Release: Nightly (pinecone-nightly)'
 
 on:
   workflow_dispatch:
@@ -55,7 +55,7 @@ jobs:
 
       - name: Adjust module name
         run: |
-          sed -i 's/pinecone-client/pinecone-client-nightly/g' pyproject.toml
+          sed -i 's/pinecone/pinecone-nightly/g' pyproject.toml
 
       - name: Update README
         run: |

--- a/.github/workflows/publish-to-pypi-test.yaml
+++ b/.github/workflows/publish-to-pypi-test.yaml
@@ -1,0 +1,136 @@
+name: Publish to PyPI Test
+
+on:
+  workflow_call:
+    secrets:
+      PYPI_USERNAME:
+        required: true
+      PYPI_PASSWORD:
+        required: true
+    inputs:
+      ref:
+        description: 'Git ref to build (branch name or SHA)'
+        required: true
+        type: string
+        default: 'main'
+      releaseLevel:
+        description: 'Release level'
+        required: true
+        type: string
+        default: 'patch'
+      isPrerelease:
+        description: 'Whether this is a prerelease'
+        required: true
+        type: boolean
+        default: true
+      prereleaseSuffix:
+        description: 'Suffix to add onto the new version number in order to mark it as a prerelease. Value ignored when shipping a release that is not a prerelease.'
+        required: false
+        type: string
+        default: 'rc1'
+      TWINE_REPOSITORY:
+        description: 'PyPI repository'
+        required: true
+        type: string
+        default: 'pypi' # options are: pypi, testpypi
+
+jobs:
+  pypi:
+    timeout-minutes: 30
+    name: pypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Need full history and tags to compute list of commits in release
+          ref: ${{ inputs.ref }}
+
+      - name: Verify prereleaseSuffix not empty if isPrerelease is true
+        if: ${{ inputs.isPrerelease == true }}
+        run: |
+          if [ -z "${{ inputs.prereleaseSuffix }}" ]; then
+            echo "prereleaseSuffix cannot be empty if isPrerelease is true"
+            exit 1
+          fi
+
+      - name: Bump version
+        id: bump
+        uses: './.github/actions/bump-version'
+        with:
+          versionFile: pinecone/__version__
+          bumpType: ${{ inputs.releaseLevel }}
+          prereleaseSuffix: ${{ inputs.prereleaseSuffix }}
+
+      - name: Verify unique release number
+        run: |
+          TAG_NAME=${{ steps.bump.outputs.VERSION_TAG }}
+          if git rev-parse -q --verify "refs/tags/$TAG_NAME" >/dev/null; then
+            echo "Tag $TAG_NAME already exists."
+            exit 1
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "Pinecone CI"
+          git config --global user.email "clients@pinecone.io"
+
+      - name: Poetry bump pyproject toml version
+        run: |
+          poetry version ${{ steps.bump.outputs.version }}
+
+      - name: Build Python client
+        run: make package
+
+      - name: Upload Python client to PyPI
+        id: pypi_upload
+        env:
+          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_REPOSITORY: ${{ inputs.TWINE_REPOSITORY }}
+        run: make upload-test
+
+      - name: Discard changes, if prerelease
+        if: ${{ inputs.isPrerelease == true }}
+        run: |
+          git checkout pinecone/__version__
+
+      - name: Commit changes, if not prerelease
+        if: ${{ inputs.isPrerelease == false }}
+        run: |
+          # Add the original pinecone client version file to git
+          # Even though Poetry is now the preferred means of working
+          # with this project, since this __version__ file has been the 
+          # one source of truth for our release process. We need to maintain
+          # both files for the time being, and they should always contain the
+          # identical package version
+          git add pinecone/__version__
+          # Add also the pyproject.toml, which is Poetry's source of truth, so
+          # that we maintain the exact same version across the two files 
+          git add pyproject.toml
+          git commit -m "[skip ci] Bump version to ${{ steps.bump.outputs.VERSION_TAG }}"
+
+      - name: Tag version
+        run: |
+          newVersionTag="${{ steps.bump.outputs.VERSION_TAG }}"
+          git tag -a $newVersionTag -m "Release $newVersionTag"
+
+      - name: Push tags (prerelease)
+        if: ${{ inputs.isPrerelease == true }}
+        # In the case of the prerelease, we discarded the version changes
+        # instead of committing them. So we need a slightly different
+        # command to push the git tag we created.
+        run: git push --tags
+
+      - name: Push tags (production release)
+        if: ${{ inputs.isPrerelease == false }}
+        run: git push --follow-tags

--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -1,0 +1,46 @@
+name: 'PyPI Test Release: Production (pinecone)'
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (branch name or SHA)'
+        required: true
+        type: string
+        default: 'main'
+      releaseLevel:
+        description: 'Release level'
+        required: true
+        type: choice
+        default: 'patch'
+        options:
+          - 'patch' # bug fixes
+          - 'minor' # new features, backwards compatible
+          - 'major' # breaking changes
+
+jobs:
+  unit-tests:
+    uses: './.github/workflows/testing-unit.yaml'
+    secrets: inherit
+  integration-tests:
+      uses: './.github/workflows/testing-integration.yaml'
+      secrets: inherit
+  dependency-tests:
+    uses: './.github/workflows/testing-dependency.yaml'
+    secrets: inherit
+
+  pypi:
+    uses: './.github/workflows/publish-to-pypi.yaml'
+    needs: 
+      - unit-tests
+      - integration-tests
+      - dependency-tests
+    with:
+      isPrerelease: false
+      ref: ${{ inputs.ref }}
+      releaseLevel: ${{ inputs.releaseLevel }}
+      TWINE_REPOSITORY: 'pypi'
+      prereleaseSuffix: ''
+    secrets:
+      PYPI_USERNAME: __token__
+      PYPI_PASSWORD: ${{ secrets.PROD_PYPI_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: 'PyPI Release: Production (pinecone-client)'
+name: 'PyPI Release: Production (pinecone)'
 
 on:
   workflow_dispatch:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ package:
 upload:
 	poetry publish --verbose --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD}
 
+upload-test:
+	poetry config repositories.test-pypi https://test.pypi.org/legacy/
+	poetry publish --verbose -r test-pypi --username ${TEST_PYPI_USERNAME} --password ${TEST_PYPI_PASSWORD}
+
 upload-spruce:
 	# Configure Poetry for publishing to testpypi
 	poetry config repositories.test-pypi https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The Pinecone Python client is compatible with Python 3.8 and greater.
 
 ## Installation
 
-There are two flavors of the Pinecone python client. The default client installed from PyPI as `pinecone-client` has a minimal set of dependencies and interacts with Pinecone via HTTP requests.
+There are two flavors of the Pinecone python client. The default client installed from PyPI as `pinecone` has a minimal set of dependencies and interacts with Pinecone via HTTP requests.
 
 If you are aiming to maximimize performance, you can install additional gRPC dependencies to access an alternate client implementation that relies on gRPC for data operations. See the guide on [tuning performance](https://docs.pinecone.io/docs/performance-tuning).
 
@@ -27,32 +27,32 @@ If you are aiming to maximimize performance, you can install additional gRPC dep
 
 ```shell
 # Install the latest version
-pip3 install pinecone-client
+pip3 install pinecone
 
 # Install the latest version, with extra grpc dependencies
-pip3 install "pinecone-client[grpc]"
+pip3 install "pinecone[grpc]"
 
 # Install a specific version
-pip3 install pinecone-client==3.0.0
+pip3 install pinecone==3.0.0
 
 # Install a specific version, with grpc extras
-pip3 install "pinecone-client[grpc]"==3.0.0
+pip3 install "pinecone[grpc]"==3.0.0
 ```
 
 ### Installing with poetry
 
 ```shell
 # Install the latest version
-poetry add pinecone-client
+poetry add pinecone
 
 # Install the latest version, with grpc extras
-poetry add pinecone-client --extras grpc
+poetry add pinecone --extras grpc
 
 # Install a specific version
-poetry add pinecone-client==3.0.0
+poetry add pinecone==3.0.0
 
 # Install a specific version, with grpc extras
-poetry add pinecone-client==3.0.0 --extras grpc
+poetry add pinecone==3.0.0 --extras grpc
 ```
 
 ## Usage

--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -13,20 +13,20 @@ You must install extra dependencies in order to install the GRPC client.
 
 ```bash
 # Install the latest version
-pip3 install pinecone-client[grpc]
+pip3 install pinecone[grpc]
 
 # Install a specific version
-pip3 install "pinecone-client[grpc]"==3.0.0
+pip3 install "pinecone[grpc]"==3.0.0
 ```
 
 #### Installing with poetry
 
 ```bash
 # Install the latest version
-poetry add pinecone-client --extras grpc
+poetry add pinecone --extras grpc
 
 # Install a specific version
-poetry add pinecone-client==3.0.0 --extras grpc
+poetry add pinecone==3.0.0 --extras grpc
 ```
 
 ### Using the gRPC client

--- a/pinecone/grpc/pinecone.py
+++ b/pinecone/grpc/pinecone.py
@@ -18,7 +18,7 @@ class PineconeGRPC(Pinecone):
     pip3 install pinecone[grpc]
 
     # Install a specific version
-    pip3 install "pinecone-client[grpc]"==3.0.0
+    pip3 install "pinecone[grpc]"==3.0.0
     ```
 
     #### Installing with poetry
@@ -28,7 +28,7 @@ class PineconeGRPC(Pinecone):
     poetry add pinecone --extras grpc
 
     # Install a specific version
-    poetry add pinecone-client==3.0.0 --extras grpc
+    poetry add pinecone==3.0.0 --extras grpc
     ```
 
     ### Using the gRPC client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = '''
 '''
 
 [tool.poetry]
-name = "pinecone-client"
+name = "pinecone"
 version = "3.2.2"
 packages = [
     { include="pinecone", from="." },


### PR DESCRIPTION
Per https://github.com/pypi/support/issues/2432#issuecomment-2066632560 -- we have the `pinecone` package name on PyPI

## Problem

This is a rough first pass at updating the package name on PyPI to `pinecone`. It doesn't attempt preserve the prior package workflow -- we may want to continue to publish to both for some period of time? We may also want to update the publishing workflow first, then doc changes later.

## Solution

Updated Readmes, inline docs, and github workflows to support `pinecone` instead of `pinecone-client`

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: (explain here): Package name update

## Test Plan

- Does it publish to the new namespace?
- How much work do we have to do to help users migrate from `pinecone-client` -- i.e. are there any automatic redirects, or is this a manual deprecation?