### PR TITLE
Remove `merge` workflow and update `build-and-publish-docs` workflow to be manually runnable

### DIFF
--- a/.github/workflows/build-and-publish-docs.yaml
+++ b/.github/workflows/build-and-publish-docs.yaml
@@ -1,10 +1,11 @@
-name: 'CI (main)'
+name: "Build and publish documentation to sdk-docs"
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch: {}
+  workflow_call:
+    secrets:
+      SSH_DEPLOY_KEY:
+        required: true
 
 jobs:
   build-and-deploy-documentation:
@@ -29,4 +30,4 @@ jobs:
           user-email: clients@pinecone.io
           target-branch: main
           target-directory: python
-          commit-message: 'Python: automated documentation build - pinecone-python-client merge SHA: ${{ github.sha }}'
+          commit-message: "Python: automated documentation build - pinecone-python-client merge SHA: ${{ github.sha }}"


### PR DESCRIPTION
## Problem
Currently, we have a couple different GitHub workflows which deal with building and publishing the client reference documentation:

- `merge.yaml`
- `build-and-publish-docs.yaml`

`merge` calls `build-and-publish-docs` on every merge to `main`. This is problematic as any changes that are made which change documentation will be reflected at in the [Python client reference](https://sdk.pinecone.io/python) as soon as they are merged to main even if we haven't cut a release.

## Solution

- Remove the `merge.yaml` workflow entirely. Previously it was only dealing with building and deploying the reference docs.
- Update `build-and-publish-docs` to be a manually runnable or callable from another workflow.

For now, we can manually trigger new reference docs builds as needed, most likely after we cut a release. This isn't the best solution, but I think it's important to get this process out of the merge action, and we can iterate on it later.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Make sure nothing is triggered on merge to `main`.