### PR TITLE
Remove serverless public preview warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ index.query(vector=[...], top_key=10)
 ### Create a serverless index
 
 The following example creates a serverless index in the `us-west-2`
-region of AWS.
+region of AWS. For more information on serverless and regional availability, see [Understanding indexes](https://docs.pinecone.io/guides/indexes/understanding-indexes#serverless-indexes).
 
 ```python
 from pinecone import Pinecone, ServerlessSpec

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pc = Pinecone(api_key=os.environ.get('CUSTOM_VAR'))
 ### Proxy configuration
 
 If your network setup requires you to interact with Pinecone via a proxy, you will need
-to pass additional configuration using optional keyword parameters. These optional parameters are forwarded to `urllib3`, which is the underlying library currently used by the Pinecone client to make HTTP requests. You may find it helpful to refer to the  [urllib3 documentation on working with proxies](https://urllib3.readthedocs.io/en/stable/advanced-usage.html#http-and-https-proxies) while troubleshooting these settings. 
+to pass additional configuration using optional keyword parameters. These optional parameters are forwarded to `urllib3`, which is the underlying library currently used by the Pinecone client to make HTTP requests. You may find it helpful to refer to the [urllib3 documentation on working with proxies](https://urllib3.readthedocs.io/en/stable/advanced-usage.html#http-and-https-proxies) while troubleshooting these settings.
 
 Here is a basic example:
 
@@ -122,7 +122,7 @@ pc.list_indexes()
 
 ### Using proxies with self-signed certificates
 
-By default the Pinecone Python client will perform SSL certificate verification 
+By default the Pinecone Python client will perform SSL certificate verification
 using the CA bundle maintained by Mozilla in the [certifi](https://pypi.org/project/certifi/) package.
 
 If your proxy server is using a self-signed certificate, you will need to pass the path to the certificate in PEM format using the `ssl_ca_certs` parameter.
@@ -143,7 +143,7 @@ pc.list_indexes()
 
 ### Disabling SSL verification
 
-If you would like to disable SSL verification, you can pass the `ssl_verify` 
+If you would like to disable SSL verification, you can pass the `ssl_verify`
 parameter with a value of `False`. We do not recommend going to production with SSL verification disabled.
 
 ```python
@@ -185,9 +185,8 @@ index.query(vector=[...], top_key=10)
 
 ### Create a serverless index
 
-> [!WARNING]  
-> Serverless indexes are in **public preview** and are available only on AWS in the
-> `us-west-2` region. Check the [current limitations](https://docs.pinecone.io/docs/limits#serverless-index-limitations) and test thoroughly before using it in production.
+The following example creates a serverless index in the `us-west-2`
+region of AWS.
 
 ```python
 from pinecone import Pinecone, ServerlessSpec
@@ -416,9 +415,9 @@ update_response = index.update(
 
 ## List vectors
 
-The `list` and `list_paginated` methods can be used to list vector ids matching a particular id prefix. 
+The `list` and `list_paginated` methods can be used to list vector ids matching a particular id prefix.
 With clever assignment of vector ids, this can be used to help model hierarchical relationships between
-different vectors such as when there are embeddings for multiple chunks or fragments related to the 
+different vectors such as when there are embeddings for multiple chunks or fragments related to the
 same document.
 
 The `list` method returns a generator that handles pagination on your behalf.


### PR DESCRIPTION
## Problem
The serverless public preview warnings from January are still in documentation. Since we've expanded the number of regions available, we should tweak these callouts.

## Solution
Update the "Create serverless index" example in the README. There were also some md auto-formatting bits that got pulled in here.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
CI, run the client reference action after merging to main to update reference docs.
