### PR TITLE
Add better error messages for mistaken `from_texts` and `from_documents`

### DIFF
--- a/pinecone/control/langchain_import_warnings.py
+++ b/pinecone/control/langchain_import_warnings.py
@@ -1,0 +1,8 @@
+from pinecone.utils import docslinks
+
+KB_ARTICLE = docslinks['LANGCHAIN_IMPORT_KB_ARTICLE']
+
+def _build_langchain_attribute_error_message(method_name: str):
+    return f"""{method_name} is not a top-level attribute of the Pinecone class provided by pinecone's official python package developed at https://github.com/pinecone-io/pinecone-python-client. You may have a name collision with an export from another dependency in your project that wraps Pinecone functionality and exports a similarly named class. Please refer to the following knowledge base article for more information: {KB_ARTICLE}
+"""
+

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -16,6 +16,7 @@ from pinecone.core.client.models import (
     ConfigureIndexRequestSpecPod
 )
 from pinecone.models import ServerlessSpec, PodSpec, IndexList, CollectionList
+from .langchain_import_warnings import _build_langchain_attribute_error_message
 
 from pinecone.data import Index
 
@@ -545,6 +546,13 @@ class Pinecone:
         response = api_instance.describe_index(name)
         return response["status"]
 
+    @staticmethod
+    def from_texts(*args, **kwargs):
+        raise AttributeError(_build_langchain_attribute_error_message("from_texts"))
+    
+    @staticmethod
+    def from_documents(*args, **kwargs):
+        raise AttributeError(_build_langchain_attribute_error_message("from_documents"))
 
     def Index(self, name: str = '', host: str = '', **kwargs):
         """

--- a/pinecone/utils/__init__.py
+++ b/pinecone/utils/__init__.py
@@ -6,3 +6,4 @@ from .fix_tuple_length import fix_tuple_length
 from .convert_to_list import convert_to_list
 from .normalize_host import normalize_host
 from .setup_openapi_client import setup_openapi_client
+from .docslinks import docslinks

--- a/pinecone/utils/docslinks.py
+++ b/pinecone/utils/docslinks.py
@@ -1,0 +1,3 @@
+docslinks = {
+    'LANGCHAIN_IMPORT_KB_ARTICLE': "https://docs.pinecone.io/troubleshooting/pinecone-attribute-errors-with-langchain"
+}

--- a/tests/unit/test_langchain_helpful_errors.py
+++ b/tests/unit/test_langchain_helpful_errors.py
@@ -1,0 +1,19 @@
+import pytest
+from pinecone import Pinecone
+
+class TestLangchainErrorMessages():
+    def test_error_from_texts_positional_args(self):
+        with pytest.raises(AttributeError) as e:
+            Pinecone.from_texts("texts", "id")
+        assert "from_texts is not a top-level attribute of the Pinecone class" in str(e.value)
+
+    def test_error_from_texts_kwargs(self):
+        with pytest.raises(AttributeError) as e:
+            Pinecone.from_texts(foo="texts", bar="id", num_threads=1)
+        assert "from_texts is not a top-level attribute of the Pinecone class" in str(e.value)
+
+    def test_error_from_documents(self):
+        with pytest.raises(AttributeError) as e:
+            Pinecone.from_documents("documents", "id")
+        assert "from_documents is not a top-level attribute of the Pinecone class" in str(e.value)
+

--- a/tests/unit/utils/test_docs_links.py
+++ b/tests/unit/utils/test_docs_links.py
@@ -1,0 +1,10 @@
+import pytest
+import requests
+from pinecone.utils import docslinks
+
+urls = list(docslinks.values())
+
+@pytest.mark.parametrize("url", urls)
+def test_valid_links(url):
+        response = requests.get(url)
+        assert response.status_code == 200, f"Docs link is invalid: {url}"


### PR DESCRIPTION
## Problem

Sometimes people using Pinecone with Langchain accidentally try to invoke `from_texts` and `from_documents` methods on our `Pinecone` class even though these are not methods by us. This is mostly name-related confusion because Langchain used to have an export called `Pinecone` that later got renamed to the less ambiguous `PineconeVectorStore`.

## Solution

Add some stub methods to the `Pinecone` class to guide users in the right direction.

<img width="920" alt="Screenshot 2024-05-13 at 2 36 51 PM" src="https://github.com/pinecone-io/pinecone-python-client/assets/1326365/09bfa6bf-b307-43e9-8756-bcf807b0e3b0">

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Added unit tests. And also an integration test to verify the docs link resolves to a valid page.