### PR TITLE
Allow colon inside source tags

### DIFF
--- a/pinecone/utils/user_agent.py
+++ b/pinecone/utils/user_agent.py
@@ -11,7 +11,7 @@ def _build_source_tag_field(source_tag):
     # 3. Trim left/right whitespace
     # 4. Condense multiple spaces to one, and replace with underscore
     tag = source_tag.lower()
-    tag = re.sub(r'[^a-z0-9_ \:]', '', tag)
+    tag = re.sub(r'[^a-z0-9_ :]', '', tag)
     tag = tag.strip()
     tag = "_".join(tag.split())
     return f"{SOURCE_TAG}={tag}"

--- a/pinecone/utils/user_agent.py
+++ b/pinecone/utils/user_agent.py
@@ -11,7 +11,7 @@ def _build_source_tag_field(source_tag):
     # 3. Trim left/right whitespace
     # 4. Condense multiple spaces to one, and replace with underscore
     tag = source_tag.lower()
-    tag = re.sub(r'[^a-z0-9_ ]', '', tag)
+    tag = re.sub(r'[^a-z0-9_ \:]', '', tag)
     tag = tag.strip()
     tag = "_".join(tag.split())
     return f"{SOURCE_TAG}={tag}"

--- a/pinecone/utils/user_agent.py
+++ b/pinecone/utils/user_agent.py
@@ -7,7 +7,7 @@ import re
 def _build_source_tag_field(source_tag):
     # normalize source tag
     # 1. Lowercase
-    # 2. Limit charset to [a-z0-9_ ]
+    # 2. Limit charset to [a-z0-9_ :]
     # 3. Trim left/right whitespace
     # 4. Condense multiple spaces to one, and replace with underscore
     tag = source_tag.lower()

--- a/tests/unit/utils/test_user_agent.py
+++ b/tests/unit/utils/test_user_agent.py
@@ -33,6 +33,10 @@ class TestUserAgent():
         useragent = get_user_agent(config)
         assert re.search(r"source_tag=my_source_tag_123", useragent) is not None
 
+        config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host", source_tag="colon:allowed")
+        useragent = get_user_agent(config)
+        assert re.search(r"source_tag=colon:allowed", useragent) is not None
+
     def test_user_agent_grpc(self):
         config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host")
         useragent = get_user_agent_grpc(config)


### PR DESCRIPTION
## Problem

Some partners have requested that colon, `:`, be added to the set of allowed characters inside source tags.

## Solution

Add colon to the set of allowed characters.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Unit tests updated to reflect new allowed character.