### PR TITLE
do not override port if defined in host

### DIFF
--- a/pinecone/grpc/base.py
+++ b/pinecone/grpc/base.py
@@ -84,8 +84,10 @@ class GRPCIndexBase(ABC):
         pass
 
     def _endpoint(self):
-        grpcHost = self.config.host.replace("https://", "")
-        return self._endpoint_override if self._endpoint_override else f"{grpcHost}:443"
+        grpc_host = self.config.host.replace("https://", "")
+        if ":" not in grpc_host:
+            grpc_host = f"{grpc_host}:443"
+        return self._endpoint_override if self._endpoint_override else grpc_host
 
     def _gen_channel(self, options=None):
         target = self._endpoint()

--- a/tests/unit_grpc/test_grpc_index_initialization.py
+++ b/tests/unit_grpc/test_grpc_index_initialization.py
@@ -85,6 +85,24 @@ class TestGRPCIndexInitialization:
         assert index.grpc_client_config.reuse_channel == True
         assert index.grpc_client_config.conn_timeout == 1
 
+        # Endpoint port defaults to 443
+        assert index._endpoint() == "myhost:443"
+
+    def test_config_passed_when_target_by_host_and_port(self):
+        pc = PineconeGRPC(api_key="YOUR_API_KEY")
+        config = GRPCClientConfig(timeout=5, secure=False)
+        index = pc.Index(host="myhost:4343", grpc_config=config)
+
+        assert index.grpc_client_config.timeout == 5
+        assert index.grpc_client_config.secure == False
+
+        # Unset fields still get default values
+        assert index.grpc_client_config.reuse_channel == True
+        assert index.grpc_client_config.conn_timeout == 1
+
+        # Endpoint calculation does not override port
+        assert index._endpoint() == "myhost:4343"
+
     def test_config_passes_source_tag_when_set(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY", source_tag="my_source_tag")
         index = pc.Index(name="my-index", host="host")


### PR DESCRIPTION
## Problem

For an Index gRPC connection, port 443 is blindly added to the configured host for setting up the endpoint. A user should be able to specify a port for connection.

## Solution

This PR will no longer append ":443" to the configured gRPC endpoint if a colon is already present in the host configuration.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Unit tests were updated for omitting and including a port in the host config. Verified that the client could connect to an Index on a port other than 443.