### PR TITLE
[CI] Publish doc updates after each release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,3 +44,9 @@ jobs:
     secrets:
       PYPI_USERNAME: __token__
       PYPI_PASSWORD: ${{ secrets.PROD_PYPI_PUBLISH_TOKEN }}
+
+  docs-publish:
+    uses: './.github/workflows/build-and-publish-docs.yaml'
+    secrets: inherit
+    needs: 
+      - pypi


### PR DESCRIPTION
## Problem

We want documentation to automatically stay up to date after every release

## Solution

Trigger the docs publish workflow after a new artifact is released to pypi

## Type of Change

- [x] Infrastructure change (CI configs, etc)
