### PR TITLE
Fix dataframe column name in doc strings

### DIFF
--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -227,7 +227,7 @@ class Index:
         """Upserts a dataframe into the index.
 
         Args:
-            df: A pandas dataframe with the following columns: id, vector, sparse_values, and metadata.
+            df: A pandas dataframe with the following columns: id, values, sparse_values, and metadata.
             namespace: The namespace to upsert into.
             batch_size: The number of rows to upsert in a single batch.
             show_progress: Whether to show a progress bar.

--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -187,7 +187,7 @@ class GRPCIndex(GRPCIndexBase):
         """Upserts a dataframe into the index.
 
         Args:
-            df: A pandas dataframe with the following columns: id, vector, and metadata.
+            df: A pandas dataframe with the following columns: id, values, sparse_values, and metadata.
             namespace: The namespace to upsert into.
             batch_size: The number of rows to upsert in a single batch.
             use_async_requests: Whether to upsert multiple requests at the same time using asynchronous request mechanism.


### PR DESCRIPTION
## Problem

The dataframe column is `values`, not `vectors`.

```
from pinecone import Pinecone, ServerlessSpec
from pinecone_datasets import list_datasets, load_dataset

pc = Pinecone(api_key="xxx")

dataset = load_dataset("quora_all-MiniLM-L6-bm25")

print(dataset.head())
```

```
  id                                             values  \
0  1  [0.06814987, -0.039664183, -0.06096721, 0.0074...
1  2  [0.08983771, -0.03493085, -0.057357617, 0.0222...
2  3  [-0.046798065, 0.1551149, -0.03920019, 0.04878...
3  4  [-0.077349104, 0.14786911, -0.0128817065, -0.0...
4  5  [-0.028324936, 0.037209604, -0.00040033547, 0....

                                       sparse_values metadata  \
0  {'indices': [7096, 8508, 13677, 23041, 24734, ...     None
1  {'indices': [7096, 8508, 13677, 24734, 26026, ...     None
2  {'indices': [6065, 13677, 17109, 20780, 24734,...     None
3  {'indices': [2408, 6065, 7582, 12225, 17109, 2...     None
4  {'indices': [5388, 12812, 18181, 19960, 20780,...     None

                                                blob
0  {'text': ' What is the step by step guide to i...
1  {'text': ' What is the step by step guide to i...
2  {'text': ' What is the story of Kohinoor (Koh-...
3  {'text': ' What would happen if the Indian gov...
4  {'text': ' How can I increase the speed of my ...
```

## Solution

Fixed the column name.

Closes: https://github.com/pinecone-io/pinecone-python-client/issues/374

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207978471789144