### PR TITLE
Improve output from list/describe actions on indexes and collections

### DIFF
--- a/pinecone/control/__init__.py
+++ b/pinecone/control/__init__.py
@@ -1,4 +1,5 @@
 from .pinecone import Pinecone
 
 from .repr_overrides import install_repr_overrides
+
 install_repr_overrides()

--- a/pinecone/control/__init__.py
+++ b/pinecone/control/__init__.py
@@ -1,1 +1,4 @@
 from .pinecone import Pinecone
+
+from .repr_overrides import install_repr_overrides
+install_repr_overrides()

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -39,6 +39,7 @@ from pinecone_plugin_interface import load_and_install as install_plugins
 
 logger = logging.getLogger(__name__)
 
+
 class Pinecone:
     def __init__(
         self,

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -39,7 +39,6 @@ from pinecone_plugin_interface import load_and_install as install_plugins
 
 logger = logging.getLogger(__name__)
 
-
 class Pinecone:
     def __init__(
         self,

--- a/pinecone/control/repr_overrides.py
+++ b/pinecone/control/repr_overrides.py
@@ -1,0 +1,16 @@
+from pinecone.models.index_model import IndexModel
+from pinecone.core.openapi.control.models import CollectionModel
+
+import json
+
+def install_repr_overrides():
+    """
+    The generator code uses pprint.pformat to format the repr output
+    which looks really poor when printing a list of large objects
+    in a notebook setting. We override it here for a few select models
+    instead of modifying the generator code because the more compact output
+    from pprint.pformat seems better for data plane objects such as lists of 
+    query results.
+    """
+    for model in [IndexModel, CollectionModel]:
+        model.__repr__ = lambda self: json.dumps(self.to_dict(), indent=4, sort_keys=False)

--- a/pinecone/control/repr_overrides.py
+++ b/pinecone/control/repr_overrides.py
@@ -3,13 +3,14 @@ from pinecone.core.openapi.control.models import CollectionModel
 
 import json
 
+
 def install_repr_overrides():
     """
     The generator code uses pprint.pformat to format the repr output
     which looks really poor when printing a list of large objects
     in a notebook setting. We override it here for a few select models
     instead of modifying the generator code because the more compact output
-    from pprint.pformat seems better for data plane objects such as lists of 
+    from pprint.pformat seems better for data plane objects such as lists of
     query results.
     """
     for model in [IndexModel, CollectionModel]:

--- a/pinecone/models/collection_list.py
+++ b/pinecone/models/collection_list.py
@@ -1,7 +1,7 @@
+import json
 from pinecone.core.openapi.control.models import (
     CollectionList as OpenAPICollectionList,
 )
-
 
 class CollectionList:
     """
@@ -28,7 +28,7 @@ class CollectionList:
         return str(self.collection_list)
 
     def __repr__(self):
-        return repr(self.collection_list)
+        return json.dumps([c.to_dict() for c in self.collection_list.collections], indent=4)
 
     def __getattr__(self, attr):
         return getattr(self.collection_list, attr)

--- a/pinecone/models/collection_list.py
+++ b/pinecone/models/collection_list.py
@@ -3,6 +3,7 @@ from pinecone.core.openapi.control.models import (
     CollectionList as OpenAPICollectionList,
 )
 
+
 class CollectionList:
     """
     A list of collections.

--- a/pinecone/models/index_list.py
+++ b/pinecone/models/index_list.py
@@ -1,3 +1,4 @@
+import json
 from pinecone.core.openapi.control.models import IndexList as OpenAPIIndexList
 from .index_model import IndexModel
 
@@ -21,10 +22,10 @@ class IndexList:
         return iter(self.indexes)
 
     def __str__(self):
-        return str(self.index_list)
+        return str(self.indexes)
 
     def __repr__(self):
-        return repr(self.index_list)
+        return json.dumps([i.to_dict() for i in self.indexes], indent=4)
 
     def __getattr__(self, attr):
         return getattr(self.index_list, attr)

--- a/pinecone/models/index_model.py
+++ b/pinecone/models/index_model.py
@@ -9,9 +9,6 @@ class IndexModel:
     def __str__(self):
         return str(self.index)
 
-    def __repr__(self):
-        return repr(self.index)
-
     def __getattr__(self, attr):
         return getattr(self.index, attr)
 

--- a/pinecone/models/index_model.py
+++ b/pinecone/models/index_model.py
@@ -17,3 +17,6 @@ class IndexModel:
 
     def __getitem__(self, key):
         return self.__getattr__(key)
+    
+    def to_dict(self):
+        return self.index.to_dict()

--- a/pinecone/models/index_model.py
+++ b/pinecone/models/index_model.py
@@ -14,6 +14,6 @@ class IndexModel:
 
     def __getitem__(self, key):
         return self.__getattr__(key)
-    
+
     def to_dict(self):
         return self.index.to_dict()


### PR DESCRIPTION
## Problem

When running in notebooks, output from the `list_indexes` and `list_collections` commands created confusion because the `__repr__` representation for these objects showed an object with a top-level key that implied the response should be interacted with like a dictionary. This expectation contradicts with the way the `__iter__` implementations on these results objects are set up to enable iterating over results without drilling down. 

The origin of the complexity here is that the backing APIs used to return simple arrays of names that could be easily iterated over, and earlier this year they become more fleshed out responses. Returning more data is useful in some situations, but in trying to smooth out the impact of the API change and maintain a similar way of interacting with the results, we accidentally opened up this inconsistency in the experience.

## Solution

- For these actions, migrate from output by `pprint.pformat` to `json.dumps`. For deeply nested objects, this produces a result that is easier to read.
- Stop sorting keys alphabetically. The way they are returned from the API makes the most sense (name first).
- Remove top-level keys from the printed output, which created wrong expectations about how to interact with the results object. Now list_indexes looks like an array, and you index into it like an array. Ditto for collections.

### Before

<img alt="Screenshot 2024-08-28 at 1 38 27 PM" src="https://github.com/user-attachments/assets/a7931ebe-ffd9-4197-be26-aa030592e62d">

![Collections output](https://github.com/user-attachments/assets/466d7a75-69c6-41d9-b75c-bbcc797ef315)

### After

<img width="706" alt="Screenshot 2024-08-28 at 1 29 00 PM" src="https://github.com/user-attachments/assets/5c47e1db-19d3-44e7-bed9-bed27f823d02">

![Screenshot 2024-08-28 at 1 42 05 PM](https://github.com/user-attachments/assets/fb8eee8e-6b7c-442e-878e-ddaad635d317)

![Screenshot 2024-08-28 at 3 28 44 PM](https://github.com/user-attachments/assets/e33b1858-0718-4e36-8e7d-af41b6457784)



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [X] None of the above: UX improvement, but should be no functional change
