### PR TITLE
Detect plugins for Index and IndexGRPC classes

### DIFF
--- a/pinecone/grpc/base.py
+++ b/pinecone/grpc/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
+import logging
 import grpc
 from grpc._channel import Channel
 
@@ -9,6 +10,10 @@ from .channel_factory import GrpcChannelFactory
 from pinecone import Config
 from .config import GRPCClientConfig
 from .grpc_runner import GrpcRunner
+
+from pinecone_plugin_interface import load_and_install as install_plugins
+
+_logger = logging.getLogger(__name__)
 
 
 class GRPCIndexBase(ABC):
@@ -39,6 +44,19 @@ class GRPCIndexBase(ABC):
         )
         self._channel = channel or self._gen_channel()
         self.stub = self.stub_class(self._channel)
+
+        self._load_plugins()
+
+    def _load_plugins(self):
+        """@private"""
+        try:
+
+            def stub_openapi_client_builder(**kwargs):
+                pass
+
+            install_plugins(self, stub_openapi_client_builder)
+        except Exception as e:
+            _logger.error(f"Error loading plugins in GRPCIndex: {e}")
 
     @property
     @abstractmethod


### PR DESCRIPTION
## Problem

Plugins not detected for Index/IndexGRPC classes

## Solution

- Copy and modify installation method in pinecone.py used for `Pinecone` and `PineconeGRPC` classes.
- For IndexGRPC, pass in a stub function instead of 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

To really validate this will probably require making a dev build release and installing alongside some actual plugins.
