### PR TITLE
[Chore] Improve test flakes

### DIFF
--- a/.github/actions/cleanup-all/action.yml
+++ b/.github/actions/cleanup-all/action.yml
@@ -5,12 +5,16 @@ inputs:
   PINECONE_API_KEY:
     description: 'The Pinecone API key'
     required: true
+  DELETE_ALL:
+    description: 'Delete all indexes and collections'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Setup Poetry
@@ -20,3 +24,4 @@ runs:
       run: poetry run python3 scripts/cleanup-all.py
       env:
         PINECONE_API_KEY: ${{ inputs.PINECONE_API_KEY }}
+        DELETE_ALL: ${{ inputs.DELETE_ALL }}

--- a/tests/dependency/grpc/test_sanity.py
+++ b/tests/dependency/grpc/test_sanity.py
@@ -36,7 +36,7 @@ class TestSanityRest:
         # Check the vector count reflects some data has been upserted
         description = idx.describe_index_stats()
         assert description.dimension == 2
-        assert description.total_vector_count == 3
+        assert description.total_vector_count >= 3
 
         # Query for results
         query_results = idx.query(id="1", top_k=10, include_values=True)

--- a/tests/dependency/rest/test_sanity.py
+++ b/tests/dependency/rest/test_sanity.py
@@ -36,7 +36,7 @@ class TestSanityRest:
         # Check the vector count reflects some data has been upserted
         description = idx.describe_index_stats()
         assert description.dimension == 2
-        assert description.total_vector_count == 3
+        assert description.total_vector_count >= 3
 
         # Query for results
         query_results = idx.query(id="1", top_k=10, include_values=True)

--- a/tests/integration/control/pod/conftest.py
+++ b/tests/integration/control/pod/conftest.py
@@ -127,7 +127,7 @@ def attempt_delete_collection(client, collection_name):
         time.sleep(5)
         try:
             print(f"Attempting delete of collection {collection_name}")
-            client.delete_collection(collection_name, -1)
+            client.delete_collection(collection_name)
             print(f"Deleted collection {collection_name}")
             break
         except Exception as e:

--- a/tests/integration/control/pod/test_deletion_protection.py
+++ b/tests/integration/control/pod/test_deletion_protection.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 from pinecone import PodSpec
 
 
@@ -46,6 +47,16 @@ class TestDeletionProtection:
         desc = client.describe_index(index_name)
         assert desc.spec.pod.replicas == 3
         assert desc.deletion_protection == "disabled"
+
+        # Wait up to 30*2 seconds for the index to be ready before attempting to delete
+        for t in range(1, 30):
+            delta = 2
+            desc = client.describe_index(index_name)
+            if desc.status.ready:
+                print(f"Index {index_name} is ready after {(t-1)*delta} seconds")
+                break
+            print("Index is not ready yet. Waiting for 2 seconds.")
+            time.sleep(delta)
 
         # Cleanup
         client.delete_index(index_name)

--- a/tests/integration/control/pod/test_deletion_protection.py
+++ b/tests/integration/control/pod/test_deletion_protection.py
@@ -52,7 +52,7 @@ class TestDeletionProtection:
         for t in range(1, 30):
             delta = 2
             desc = client.describe_index(index_name)
-            if desc.status.ready:
+            if desc.status.state == "Ready":
                 print(f"Index {index_name} is ready after {(t-1)*delta} seconds")
                 break
             print("Index is not ready yet. Waiting for 2 seconds.")

--- a/tests/integration/control/pod/test_deletion_protection.py
+++ b/tests/integration/control/pod/test_deletion_protection.py
@@ -58,5 +58,14 @@ class TestDeletionProtection:
             print("Index is not ready yet. Waiting for 2 seconds.")
             time.sleep(delta)
 
-        # Cleanup
-        client.delete_index(index_name)
+        attempts = 0
+        while attempts < 12:
+            try:
+                client.delete_index(index_name)
+                break
+            except Exception as e:
+                attempts += 1
+                print(f"Failed to delete index {index_name} on attempt {attempts}.")
+                print(f"Error: {e}")
+                client.describe_index(index_name)
+                time.sleep(10)

--- a/tests/integration/control/serverless/test_create_index_timeouts.py
+++ b/tests/integration/control/serverless/test_create_index_timeouts.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 class TestCreateIndexWithTimeout:
     def test_create_index_default_timeout(self, client, create_sl_index_params):
         create_sl_index_params["timeout"] = None
@@ -16,11 +13,6 @@ class TestCreateIndexWithTimeout:
         client.create_index(**create_sl_index_params)
         desc = client.describe_index(create_sl_index_params["name"])
         assert desc.status.ready == True
-
-    def test_create_index_when_timeout_error(self, client, create_sl_index_params):
-        create_sl_index_params["timeout"] = 1
-        with pytest.raises(TimeoutError):
-            client.create_index(**create_sl_index_params)
 
     def test_create_index_with_negative_timeout(self, client, create_sl_index_params):
         create_sl_index_params["timeout"] = -1

--- a/tests/integration/control/serverless/test_describe_index.py
+++ b/tests/integration/control/serverless/test_describe_index.py
@@ -44,9 +44,3 @@ class TestDescribeIndex:
         assert isinstance(description.host, str)
         assert description.host != ""
         assert notready_sl_index in description.host
-
-        if description.status.state == "Ready":
-            assert description.status.ready == True
-        else:
-            assert description.status.ready == False
-            assert description.status.state == "Initializing"

--- a/tests/integration/control/serverless/test_describe_index.py
+++ b/tests/integration/control/serverless/test_describe_index.py
@@ -45,5 +45,8 @@ class TestDescribeIndex:
         assert description.host != ""
         assert notready_sl_index in description.host
 
-        assert description.status.ready == False
-        assert description.status.state in ["Ready", "Initializing"]
+        if description.status.state == "Ready":
+            assert description.status.ready == True
+        else:
+            assert description.status.ready == False
+            assert description.status.state == "Initializing"


### PR DESCRIPTION
## Problem

I frequently see recurring test flakes, most often at the cleanup stage of `test_configure_index_with_deletion_protection` because the index cannot be deleted while still in an "upgrading" state. The index is in that state while configuration changes are being applied.

## Solution

- In deletion protection test, wait for the index to be ready before attempting the delete.
- In dependency tests which do a basic sanity test, loosen the assertions. We're not really intending to test the backend functionality with these tests; we just want to make sure network calls are successfully made with a variety of different grpc / protobuff / etc dependency versions.
- Remove some assertions that rely on non-deterministic behavior on the backend. E.g. how long it takes for a serverless index to be considered ready.
- Check for deletion protection status before trying to delete.
- Don't fail the job when cleanup fails; even if we re-run the entire job, there will still be an orphaned index from a previous run that needs to be cleaned up. Best to just attempt to delete, then let the nightly cleanup job garbage collect anything left over.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)