### PR TITLE
Define enum classes with control plane configuration options

### DIFF
--- a/pinecone/__init__.py
+++ b/pinecone/__init__.py
@@ -14,6 +14,7 @@ from .exceptions import *
 from .control import *
 from .data import *
 from .models import *
+from .enums import *
 
 from .utils import __version__
 

--- a/pinecone/control/pinecone_interface.py
+++ b/pinecone/control/pinecone_interface.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from typing import Optional, Dict, Union, Literal
+from typing import Optional, Dict, Union
 
 
 from pinecone.config import Config
@@ -9,6 +9,7 @@ from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexe
 
 
 from pinecone.models import ServerlessSpec, PodSpec, IndexList, CollectionList
+from pinecone.enums import Metric, VectorType, DeletionProtection, PodType
 
 
 class PineconeDBControlInterface(ABC):
@@ -177,10 +178,10 @@ class PineconeDBControlInterface(ABC):
         name: str,
         spec: Union[Dict, ServerlessSpec, PodSpec],
         dimension: Optional[int],
-        metric: Optional[Literal["cosine", "euclidean", "dotproduct"]] = "cosine",
+        metric: Optional[Union[Metric, str]] = Metric.COSINE,
         timeout: Optional[int] = None,
-        deletion_protection: Optional[Literal["enabled", "disabled"]] = "disabled",
-        vector_type: Optional[Literal["dense", "sparse"]] = "dense",
+        deletion_protection: Optional[Union[DeletionProtection, str]] = DeletionProtection.DISABLED,
+        vector_type: Optional[Union[VectorType, str]] = VectorType.DENSE,
     ):
         """Creates a Pinecone index.
 
@@ -377,8 +378,8 @@ class PineconeDBControlInterface(ABC):
         self,
         name: str,
         replicas: Optional[int] = None,
-        pod_type: Optional[str] = None,
-        deletion_protection: Optional[Literal["enabled", "disabled"]] = None,
+        pod_type: Optional[Union[PodType, str]] = None,
+        deletion_protection: Optional[Union[DeletionProtection, str]] = None,
         tags: Optional[Dict[str, str]] = None,
     ):
         """This method is used to scale configuration fields for your pod-based Pinecone index.

--- a/pinecone/enums/__init__.py
+++ b/pinecone/enums/__init__.py
@@ -1,0 +1,18 @@
+from .clouds import CloudProvider, AwsRegion, GcpRegion, AzureRegion
+from .deletion_protection import DeletionProtection
+from .metric import Metric
+from .pod_index_environment import PodIndexEnvironment
+from .pod_type import PodType
+from .vector_type import VectorType
+
+__all__ = [
+    "CloudProvider",
+    "AwsRegion",
+    "GcpRegion",
+    "AzureRegion",
+    "DeletionProtection",
+    "Metric",
+    "PodIndexEnvironment",
+    "PodType",
+    "VectorType",
+]

--- a/pinecone/enums/clouds.py
+++ b/pinecone/enums/clouds.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+
+class CloudProvider(Enum):
+    AWS = "aws"
+    GCP = "gcp"
+    AZURE = "azure"
+
+
+class AwsRegion(Enum):
+    US_EAST_1 = "us-east-1"
+    US_WEST_2 = "us-west-2"
+    EU_WEST_1 = "eu-west-1"
+
+
+class GcpRegion(Enum):
+    US_CENTRAL1 = "us-central1"
+    EUROPE_WEST4 = "europe-west4"
+
+
+class AzureRegion(Enum):
+    EAST_US = "eastus2"

--- a/pinecone/enums/clouds.py
+++ b/pinecone/enums/clouds.py
@@ -2,21 +2,29 @@ from enum import Enum
 
 
 class CloudProvider(Enum):
+    """Cloud providers available for use with Pinecone serverless indexes"""
+
     AWS = "aws"
     GCP = "gcp"
     AZURE = "azure"
 
 
 class AwsRegion(Enum):
+    """AWS (Amazon Web Services) regions available for use with Pinecone serverless indexes"""
+
     US_EAST_1 = "us-east-1"
     US_WEST_2 = "us-west-2"
     EU_WEST_1 = "eu-west-1"
 
 
 class GcpRegion(Enum):
+    """GCP (Google Cloud Platform) regions available for use with Pinecone serverless indexes"""
+
     US_CENTRAL1 = "us-central1"
     EUROPE_WEST4 = "europe-west4"
 
 
 class AzureRegion(Enum):
+    """Azure regions available for use with Pinecone serverless indexes"""
+
     EAST_US = "eastus2"

--- a/pinecone/enums/deletion_protection.py
+++ b/pinecone/enums/deletion_protection.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class DeletionProtection(Enum):
+    ENABLED = "enabled"
+    DISABLED = "disabled"

--- a/pinecone/enums/deletion_protection.py
+++ b/pinecone/enums/deletion_protection.py
@@ -2,5 +2,14 @@ from enum import Enum
 
 
 class DeletionProtection(Enum):
+    """The DeletionProtection setting of an index indicates whether the index
+    can be  the index cannot be deleted using the delete_index() method.
+
+    If disabled, the index can be deleted. If enabled, calling delete_index()
+    will raise an error.
+
+    This setting can be changed using the configure_index() method.
+    """
+
     ENABLED = "enabled"
     DISABLED = "disabled"

--- a/pinecone/enums/metric.py
+++ b/pinecone/enums/metric.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class Metric(Enum):
+    """
+    The metric specifies how Pinecone should calculate the distance between vectors when querying an index.
+    """
+
+    COSINE = "cosine"
+    EUCLIDEAN = "euclidean"
+    DOTPRODUCT = "dotproduct"

--- a/pinecone/enums/pod_index_environment.py
+++ b/pinecone/enums/pod_index_environment.py
@@ -1,28 +1,11 @@
 from enum import Enum
 
 
-class CloudProvider(Enum):
-    AWS = "aws"
-    GCP = "gcp"
-    AZURE = "azure"
-
-
-class AwsRegion(Enum):
-    US_EAST_1 = "us-east-1"
-    US_WEST_2 = "us-west-2"
-    EU_WEST_1 = "eu-west-1"
-
-
-class GcpRegion(Enum):
-    US_CENTRAL1 = "us-central1"
-    EUROPE_WEST4 = "europe-west4"
-
-
-class AzureRegion(Enum):
-    EAST_US = "eastus2"
-
-
 class PodIndexEnvironment(Enum):
+    """
+    These environment strings are used to specify where a pod index should be deployed.
+    """
+
     US_WEST1_GCP = "us-west1-gcp"
     US_CENTRAL1_GCP = "us-central1-gcp"
     US_WEST4_GCP = "us-west4-gcp"

--- a/pinecone/enums/pod_type.py
+++ b/pinecone/enums/pod_type.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+
+class PodType(Enum):
+    """
+    PodType represents the available pod types for a pod index.
+    """
+
+    P1_X1 = "p1.x1"
+    P1_X2 = "p1.x2"
+    P1_X4 = "p1.x4"
+    P1_X8 = "p1.x8"
+    S1_X1 = "s1.x1"
+    S1_X2 = "s1.x2"
+    S1_X4 = "s1.x4"
+    S1_X8 = "s1.x8"
+    P2_X1 = "p2.x1"
+    P2_X2 = "p2.x2"
+    P2_X4 = "p2.x4"
+    P2_X8 = "p2.x8"

--- a/pinecone/enums/vector_type.py
+++ b/pinecone/enums/vector_type.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class VectorType(Enum):
+    """
+    VectorType is used to specifiy the type of vector you will store in the index.
+
+    Dense vectors are used to store dense embeddings, which are vectors with non-zero values in most of the dimensions.
+
+    Sparse vectors are used to store sparse embeddings, which allow vectors with zero values in most of the dimensions to be represented concisely.
+    """
+
+    DENSE = "dense"
+    SPARSE = "sparse"

--- a/pinecone/models/__init__.py
+++ b/pinecone/models/__init__.py
@@ -5,6 +5,7 @@ from .pod_spec import PodSpec
 from .index_list import IndexList
 from .collection_list import CollectionList
 from .index_model import IndexModel
+from .clouds import CloudProvider, AwsRegion, GcpRegion, AzureRegion, PodIndexEnvironment
 
 __all__ = [
     "CollectionDescription",
@@ -15,4 +16,9 @@ __all__ = [
     "IndexList",
     "CollectionList",
     "IndexModel",
+    "CloudProvider",
+    "AwsRegion",
+    "GcpRegion",
+    "AzureRegion",
+    "PodIndexEnvironment",
 ]

--- a/pinecone/models/__init__.py
+++ b/pinecone/models/__init__.py
@@ -1,11 +1,11 @@
 from .index_description import ServerlessSpecDefinition, PodSpecDefinition
 from .collection_description import CollectionDescription
 from .serverless_spec import ServerlessSpec
-from .pod_spec import PodSpec
+from .pod_spec import PodSpec, PodType
 from .index_list import IndexList
 from .collection_list import CollectionList
 from .index_model import IndexModel
-from .clouds import CloudProvider, AwsRegion, GcpRegion, AzureRegion, PodIndexEnvironment
+from ..enums.metric import Metric
 
 __all__ = [
     "CollectionDescription",
@@ -16,9 +16,4 @@ __all__ = [
     "IndexList",
     "CollectionList",
     "IndexModel",
-    "CloudProvider",
-    "AwsRegion",
-    "GcpRegion",
-    "AzureRegion",
-    "PodIndexEnvironment",
 ]

--- a/pinecone/models/clouds.py
+++ b/pinecone/models/clouds.py
@@ -1,0 +1,37 @@
+from enum import Enum
+
+
+class CloudProvider(Enum):
+    AWS = "aws"
+    GCP = "gcp"
+    AZURE = "azure"
+
+
+class AwsRegion(Enum):
+    US_EAST_1 = "us-east-1"
+    US_WEST_2 = "us-west-2"
+    EU_WEST_1 = "eu-west-1"
+
+
+class GcpRegion(Enum):
+    US_CENTRAL1 = "us-central1"
+    EUROPE_WEST4 = "europe-west4"
+
+
+class AzureRegion(Enum):
+    EAST_US = "eastus2"
+
+
+class PodIndexEnvironment(Enum):
+    US_WEST1_GCP = "us-west1-gcp"
+    US_CENTRAL1_GCP = "us-central1-gcp"
+    US_WEST4_GCP = "us-west4-gcp"
+    US_EAST4_GCP = "us-east4-gcp"
+    NORTHAMERICA_NORTHEAST1_GCP = "northamerica-northeast1-gcp"
+    ASIA_NORTHEAST1_GCP = "asia-northeast1-gcp"
+    ASIA_SOUTHEAST1_GCP = "asia-southeast1-gcp"
+    US_EAST1_GCP = "us-east1-gcp"
+    EU_WEST1_GCP = "eu-west1-gcp"
+    EU_WEST4_GCP = "eu-west4-gcp"
+    US_EAST1_AWS = "us-east-1-aws"
+    EASTUS_AZURE = "eastus-azure"

--- a/pinecone/models/serverless_spec.py
+++ b/pinecone/models/serverless_spec.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Union
 from enum import Enum
 
-from .clouds import CloudProvider, AwsRegion, GcpRegion, AzureRegion
+from ..enums import CloudProvider, AwsRegion, GcpRegion, AzureRegion
 
 
 @dataclass(frozen=True)

--- a/pinecone/models/serverless_spec.py
+++ b/pinecone/models/serverless_spec.py
@@ -1,9 +1,25 @@
-from typing import NamedTuple
+from dataclasses import dataclass
+from typing import Union
+from enum import Enum
+
+from .clouds import CloudProvider, AwsRegion, GcpRegion, AzureRegion
 
 
-class ServerlessSpec(NamedTuple):
+@dataclass(frozen=True)
+class ServerlessSpec:
     cloud: str
     region: str
 
+    def __init__(
+        self,
+        cloud: Union[CloudProvider, str],
+        region: Union[AwsRegion, GcpRegion, AzureRegion, str],
+    ):
+        # Convert Enums to their string values if necessary
+        object.__setattr__(self, "cloud", cloud.value if isinstance(cloud, Enum) else str(cloud))
+        object.__setattr__(
+            self, "region", region.value if isinstance(region, Enum) else str(region)
+        )
+
     def asdict(self):
-        return {"serverless": self._asdict()}
+        return {"serverless": {"cloud": self.cloud, "region": self.region}}

--- a/tests/integration/control/serverless/conftest.py
+++ b/tests/integration/control/serverless/conftest.py
@@ -1,8 +1,11 @@
 import pytest
 import random
 import time
+import logging
 from pinecone import Pinecone, NotFoundException, PineconeApiException
 from ...helpers import generate_index_name, get_environment_var
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture()
@@ -101,6 +104,7 @@ def cleanup(client, index_name):
     yield
 
     try:
+        logger.debug("Attempting to delete index with name: " + index_name)
         client.delete_index(index_name, -1)
     except Exception:
         pass

--- a/tests/integration/control/serverless/test_configure_index_deletion_protection.py
+++ b/tests/integration/control/serverless/test_configure_index_deletion_protection.py
@@ -1,10 +1,15 @@
 import pytest
+from pinecone import DeletionProtection
 
 
 class TestDeletionProtection:
-    def test_deletion_protection(self, client, create_sl_index_params):
+    @pytest.mark.parametrize(
+        "dp_enabled,dp_disabled",
+        [("enabled", "disabled"), (DeletionProtection.ENABLED, DeletionProtection.DISABLED)],
+    )
+    def test_deletion_protection(self, client, create_sl_index_params, dp_enabled, dp_disabled):
         name = create_sl_index_params["name"]
-        client.create_index(**create_sl_index_params, deletion_protection="enabled")
+        client.create_index(**create_sl_index_params, deletion_protection=dp_enabled)
         desc = client.describe_index(name)
         assert desc.deletion_protection == "enabled"
 
@@ -12,7 +17,7 @@ class TestDeletionProtection:
             client.delete_index(name)
         assert "Deletion protection is enabled for this index" in str(e.value)
 
-        client.configure_index(name, deletion_protection="disabled")
+        client.configure_index(name, deletion_protection=dp_disabled)
         desc = client.describe_index(name)
         assert desc.deletion_protection == "disabled"
 

--- a/tests/integration/control/serverless/test_create_index_sl_happy_path.py
+++ b/tests/integration/control/serverless/test_create_index_sl_happy_path.py
@@ -1,5 +1,12 @@
 import pytest
-from pinecone import Metric, VectorType
+from pinecone import (
+    Metric,
+    VectorType,
+    DeletionProtection,
+    ServerlessSpec,
+    CloudProvider,
+    AwsRegion,
+)
 
 
 class TestCreateSLIndexHappyPath:
@@ -14,16 +21,41 @@ class TestCreateSLIndexHappyPath:
         assert desc.deletion_protection == "disabled"  # default value
         assert desc.vector_type == "dense"  # default value
 
-    @pytest.mark.parametrize(
-        "metric",
-        ["cosine", "euclidean", "dotproduct", Metric.COSINE, Metric.EUCLIDEAN, Metric.DOTPRODUCT],
-    )
+    @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
     def test_create_default_index_with_metric(self, client, create_sl_index_params, metric):
         create_sl_index_params["metric"] = metric
         client.create_index(**create_sl_index_params)
         desc = client.describe_index(create_sl_index_params["name"])
         assert desc.metric == metric
         assert desc.vector_type == "dense"
+
+    @pytest.mark.parametrize(
+        "metric_enum,vector_type_enum,dim",
+        [
+            (Metric.COSINE, VectorType.DENSE, 10),
+            (Metric.EUCLIDEAN, VectorType.DENSE, 10),
+            (Metric.DOTPRODUCT, VectorType.SPARSE, None),
+        ],
+    )
+    def test_create_with_enum_values(self, client, index_name, metric_enum, vector_type_enum, dim):
+        args = {
+            "name": index_name,
+            "metric": metric_enum,
+            "vector_type": vector_type_enum,
+            "deletion_protection": DeletionProtection.DISABLED,
+            "spec": ServerlessSpec(cloud=CloudProvider.AWS, region=AwsRegion.US_EAST_1),
+        }
+        if dim is not None:
+            args["dimension"] = dim
+        client.create_index(**args)
+        desc = client.describe_index(index_name)
+        assert desc.metric == metric_enum.value
+        assert desc.vector_type == vector_type_enum.value
+        assert desc.dimension == dim
+        assert desc.deletion_protection == DeletionProtection.DISABLED.value
+        assert desc.name == index_name
+        assert desc.spec.serverless.cloud == "aws"
+        assert desc.spec.serverless.region == "us-east-1"
 
     @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
     def test_create_dense_index_with_metric(self, client, create_sl_index_params, metric):

--- a/tests/integration/control/serverless/test_create_index_sl_happy_path.py
+++ b/tests/integration/control/serverless/test_create_index_sl_happy_path.py
@@ -1,4 +1,5 @@
 import pytest
+from pinecone import Metric, VectorType
 
 
 class TestCreateSLIndexHappyPath:
@@ -13,7 +14,10 @@ class TestCreateSLIndexHappyPath:
         assert desc.deletion_protection == "disabled"  # default value
         assert desc.vector_type == "dense"  # default value
 
-    @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
+    @pytest.mark.parametrize(
+        "metric",
+        ["cosine", "euclidean", "dotproduct", Metric.COSINE, Metric.EUCLIDEAN, Metric.DOTPRODUCT],
+    )
     def test_create_default_index_with_metric(self, client, create_sl_index_params, metric):
         create_sl_index_params["metric"] = metric
         client.create_index(**create_sl_index_params)
@@ -24,7 +28,7 @@ class TestCreateSLIndexHappyPath:
     @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
     def test_create_dense_index_with_metric(self, client, create_sl_index_params, metric):
         create_sl_index_params["metric"] = metric
-        create_sl_index_params["vector_type"] = "dense"
+        create_sl_index_params["vector_type"] = VectorType.DENSE
         client.create_index(**create_sl_index_params)
         desc = client.describe_index(create_sl_index_params["name"])
         assert desc.metric == metric

--- a/tests/unit/models/test_index_model.py
+++ b/tests/unit/models/test_index_model.py
@@ -6,6 +6,7 @@ from pinecone.core.openapi.db_control.models import (
     DeletionProtection,
 )
 from pinecone.models import IndexModel
+from pinecone import CloudProvider, AwsRegion
 
 
 class TestIndexModel:
@@ -17,7 +18,11 @@ class TestIndexModel:
             host="https://test-index-1.pinecone.io",
             status=IndexModelStatus(ready=True, state="Ready"),
             deletion_protection=DeletionProtection("enabled"),
-            spec=IndexModelSpec(serverless=ServerlessSpec(cloud="aws", region="us-west-1")),
+            spec=IndexModelSpec(
+                serverless=ServerlessSpec(
+                    cloud=CloudProvider.AWS.value, region=AwsRegion.US_EAST_1.value
+                )
+            ),
         )
 
         wrapped = IndexModel(openapi_model)

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -1,7 +1,15 @@
 import pytest
 import re
 from unittest.mock import patch, MagicMock
-from pinecone import ConfigBuilder, Pinecone, PodSpec, ServerlessSpec
+from pinecone import (
+    ConfigBuilder,
+    Pinecone,
+    PodSpec,
+    ServerlessSpec,
+    CloudProvider,
+    AwsRegion,
+    GcpRegion,
+)
 from pinecone.core.openapi.db_control.models import IndexList, IndexModel, DeletionProtection
 from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
 
@@ -150,8 +158,15 @@ class TestControl:
     @pytest.mark.parametrize(
         "index_spec",
         [
+            ServerlessSpec(cloud="aws", region="us-west-2"),
+            ServerlessSpec(cloud=CloudProvider.AWS, region=AwsRegion.US_WEST_2),
+            ServerlessSpec(cloud=CloudProvider.AWS, region="us-west-2"),
+            ServerlessSpec(cloud="aws", region="us-west-2"),
+            ServerlessSpec(cloud="aws", region="unknown-region"),
+            ServerlessSpec(cloud=CloudProvider.GCP, region=GcpRegion.US_CENTRAL1),
             {"serverless": {"cloud": "aws", "region": "us-west1"}},
             {"serverless": {"cloud": "aws", "region": "us-west1", "uknown_key": "value"}},
+            PodSpec(environment="us-west1-gcp", pod_type="p1.x1"),
             {"pod": {"environment": "us-west1-gcp", "pod_type": "p1.x1"}},
             {"pod": {"environment": "us-west1-gcp", "pod_type": "p1.x1", "unknown_key": "value"}},
             {

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -9,6 +9,8 @@ from pinecone import (
     CloudProvider,
     AwsRegion,
     GcpRegion,
+    PodIndexEnvironment,
+    PodType,
 )
 from pinecone.core.openapi.db_control.models import IndexList, IndexModel, DeletionProtection
 from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
@@ -167,6 +169,10 @@ class TestControl:
             {"serverless": {"cloud": "aws", "region": "us-west1"}},
             {"serverless": {"cloud": "aws", "region": "us-west1", "uknown_key": "value"}},
             PodSpec(environment="us-west1-gcp", pod_type="p1.x1"),
+            PodSpec(environment=PodIndexEnvironment.US_WEST1_GCP, pod_type=PodType.P2_X2),
+            PodSpec(environment=PodIndexEnvironment.US_WEST1_GCP, pod_type="s1.x4"),
+            PodSpec(environment=PodIndexEnvironment.US_EAST1_AWS, pod_type="unknown-pod-type"),
+            PodSpec(environment="us-west1-gcp", pod_type="p1.x1", pods=2, replicas=1, shards=1),
             {"pod": {"environment": "us-west1-gcp", "pod_type": "p1.x1"}},
             {"pod": {"environment": "us-west1-gcp", "pod_type": "p1.x1", "unknown_key": "value"}},
             {


### PR DESCRIPTION
## Problem

Many configuration fields take string inputs even though there is a limited range of accepted values. It's poor UX having to go into documentation or examples in order to know which string values are available. This also means support via type hints from code editors are not available to keep people moving quickly.

## Solution

- Create Enum classes for control plane configuration fields under `pinecone.enum`:
  - General index configs: `Metric`, `VectorType`, `DeletionProtection`
  - Serverless spec: `CloudProvider`, `AwsRegion`, `GcpRegion`, `AzureRegion`
  - Pod spec: `PodIndexEnvironment`, `PodType`

kwargs that accept these values are loosely typed as the union of the enum type and string. This should prevent unnecessary breaking changes and maintain flexibility to accept new values that may not be avaialble or known at the time this SDK release is published. For example, if in the future pinecone can deploy to more Azure regions, this loose typing would allow a person to pass that configuration as region without necessarily having to update their SDK to satisfy to a type check.

## Usage: Serverless

```python
# Old way, which still works but requires you to know what values are available
from pinecone import Pinecone, ServerlessSpec

pc = Pinecone(api_key='key')

pc.create_index(
    name="my-index",
    dimension=1024,
    metric="cosine",
    spec=ServerlessSpec(
        cloud="aws", 
        region="us-west-2"
    ),
    vector_type="sparse"
)
```

```python
# New way, using enum types
from pinecone import (
    Pinecone, 
    ServerlessSpec, 
    Metric, 
    VectorType, 
    CloudProvider, 
    AwsRegion
)

pc = Pinecone(api_key='key')

pc.create_index(
    name="my-index",
    dimension=1024,
    metric=Metric.COSINE,
    spec=ServerlessSpec(
        cloud=CloudProvider.AWS, 
        region=AwsRegion.US_WEST_2
    ),
    vector_type=VectorType.SPARSE
)

```

## Usage: Pods

```python
# old way, you have to know all the magic strings

from pinecone import Pinecone, PodSpec

pc = Pinecone(api_key='key')

pc.create_index(
    name="my-index",
    dimension=1024,
    spec=PodSpec(
        pod_type='s1.x4'
        environment="us-east1-gcp"
    ),
)

# Later, when scaling
pc.configure_index(
    name="my-index",
    pod_type="s1.x8"
)
```

```python
# New way, using enum types
from pinecone import (
    Pinecone, 
    PodSpec, 
    PodIndexEnvironment,
    PodType
)

pc = Pinecone(api_key='key')

pc.create_index(
    name="my-index",
    dimension=1024,
    spec=PodSpec(
        environment=PodIndexEnvironment.US_EAST1_GCP,
        pod_type=PodType.S1_X4
    )
)

# Later, when scaling
pc.configure_index(
    name="my-index",
    pod_type=PodType.S1_X8
)
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

