### PR TITLE
Implement asyncio for db control plane

### DIFF
--- a/.github/workflows/testing-integration.yaml
+++ b/.github/workflows/testing-integration.yaml
@@ -3,7 +3,7 @@ name: "Integration Tests"
   workflow_call: {}
 
 jobs:
-  data-plane-serverless:
+  db-data-serverless:
     name: Data plane serverless integration tests
     runs-on: ubuntu-latest
     strategy:
@@ -11,26 +11,19 @@ jobs:
       matrix:
         python_version: [3.9, 3.12]
         use_grpc: [true, false]
-        metric:
-          - cosine
-          # - euclidean
-          # - dotproduct
-        spec:
-          - '{ "serverless": { "region": "us-west-2", "cloud": "aws" }}'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-data-plane
         with:
-          DATADOG_API_KEY: '${{ secrets.DATADOG_API_KEY }}'
           python_version: '${{ matrix.python_version }}'
           use_grpc: '${{ matrix.use_grpc }}'
-          metric: '${{ matrix.metric }}'
-          spec: '${{ matrix.spec }}'
+          metric: 'cosine'
+          spec: '{ "serverless": { "region": "us-west-2", "cloud": "aws" }}'
           PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
           freshness_timeout_seconds: 600
           skip_weird_id_tests: 'true'
 
-  test-asyncio:
+  db-data-asyncio:
     name: Data plane asyncio
     runs-on: ubuntu-latest
     strategy:
@@ -38,15 +31,13 @@ jobs:
       matrix:
         python_version: [3.9, 3.12]
         use_grpc: [false, true]
-        spec:
-          - '{ "serverless": { "region": "us-west-2", "cloud": "aws" }}'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/test-asyncio
         with:
           python_version: '${{ matrix.python_version }}'
           use_grpc: '${{ matrix.use_grpc }}'
-          spec: '${{ matrix.spec }}'
+          spec: '{ "serverless": { "region": "us-west-2", "cloud": "aws" }}'
           PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
           freshness_timeout_seconds: 600
 
@@ -112,13 +103,11 @@ jobs:
           DIMENSION: 10
           METRIC: 'cosine'
 
-  control-rest-serverless:
+  db-control-rest-serverless:
     name: control plane serverless
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pineconeEnv:
-          - prod
         testConfig:
           - python-version: 3.9 # Do one test run with 3.9 for sanity check
             pod: { environment: 'us-east1-gcp'}
@@ -136,21 +125,52 @@ jobs:
       - name: Setup Poetry
         uses: ./.github/actions/setup-poetry
       - name: 'Run integration tests (REST, prod)'
-        if: matrix.pineconeEnv == 'prod'
         run: poetry run pytest tests/integration/control/serverless -s -vv
         env:
           PINECONE_DEBUG_CURL: 'true'
           PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
-          GITHUB_BUILD_NUMBER: '${{ github.run_number }}-p-${{ matrix.testConfig.python-version}}'
           SERVERLESS_CLOUD: '${{ matrix.testConfig.serverless.cloud }}'
           SERVERLESS_REGION: '${{ matrix.testConfig.serverless.region }}'
-      - name: 'Run integration tests (REST, staging)'
-        if: matrix.pineconeEnv == 'staging'
-        run: poetry run pytest tests/integration/control/serverless -s -vv
+
+  db-control-asyncio:
+    name: db control asyncio
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version:
+          - 3.9
+          - 3.12
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Set up Python ${{ matrix.python_version }}'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python_version }}'
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+      - name: 'Run integration tests (asyncio, prod)'
+        run: poetry run pytest tests/integration/control_asyncio -s -vv
         env:
           PINECONE_DEBUG_CURL: 'true'
-          PINECONE_CONTROLLER_HOST: 'https://api-staging.pinecone.io'
-          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY_STAGING }}'
-          GITHUB_BUILD_NUMBER: '${{ github.run_number }}-s-${{ matrix.testConfig.python-version}}'
-          SERVERLESS_CLOUD: '${{ matrix.testConfig.serverless.cloud }}'
-          SERVERLESS_REGION: '${{ matrix.testConfig.serverless.region }}'
+          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
+
+  inference:
+    name: Inference tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: [3.9, 3.12]
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Set up Python ${{ matrix.python_version }}'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python_version }}'
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+      - name: 'Run integration tests'
+        run: poetry run pytest tests/integration/inference -s -vv
+        env:
+          PINECONE_DEBUG_CURL: 'true'
+          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'

--- a/pinecone/control/__init__.py
+++ b/pinecone/control/__init__.py
@@ -1,4 +1,5 @@
 from .pinecone import Pinecone
+from .pinecone_asyncio import PineconeAsyncio
 
 from .repr_overrides import install_repr_overrides
 

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -1,7 +1,6 @@
 import time
 import logging
-from typing import Optional, Dict, Any, Union
-from enum import Enum
+from typing import Optional, Dict, Union
 
 from .index_host_store import IndexHostStore
 from .pinecone_interface import PineconeDBControlInterface
@@ -12,27 +11,7 @@ from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexe
 from pinecone.openapi_support.api_client import ApiClient
 
 
-from pinecone.utils import (
-    normalize_host,
-    setup_openapi_client,
-    build_plugin_setup_client,
-    convert_enum_to_string,
-)
-from pinecone.core.openapi.db_control.models import (
-    CreateCollectionRequest,
-    CreateIndexForModelRequest,
-    CreateIndexForModelRequestEmbed,
-    CreateIndexRequest,
-    ConfigureIndexRequest,
-    ConfigureIndexRequestSpec,
-    ConfigureIndexRequestSpecPod,
-    DeletionProtection as DeletionProtectionModel,
-    IndexSpec,
-    IndexTags,
-    ServerlessSpec as ServerlessSpecModel,
-    PodSpec as PodSpecModel,
-    PodSpecMetadataConfig,
-)
+from pinecone.utils import normalize_host, setup_openapi_client, build_plugin_setup_client
 from pinecone.core.openapi.db_control import API_VERSION
 from pinecone.models import (
     ServerlessSpec,
@@ -43,7 +22,7 @@ from pinecone.models import (
     IndexEmbed,
 )
 from .langchain_import_warnings import _build_langchain_attribute_error_message
-from pinecone.utils import parse_non_empty_args, docslinks
+from pinecone.utils import docslinks
 
 from pinecone.data import _Index, _AsyncioIndex, _Inference
 from pinecone.enums import (
@@ -57,6 +36,7 @@ from pinecone.enums import (
     AzureRegion,
 )
 from .types import CreateIndexForModelEmbedTypedDict
+from .request_factory import PineconeDBControlRequestFactory
 
 from pinecone_plugin_interface import load_and_install as install_plugins
 
@@ -152,69 +132,6 @@ class Pinecone(PineconeDBControlInterface):
         except Exception as e:
             logger.error(f"Error loading plugins: {e}")
 
-    def __parse_tags(self, tags: Optional[Dict[str, str]]) -> IndexTags:
-        if tags is None:
-            return IndexTags()
-        else:
-            return IndexTags(**tags)
-
-    def __parse_deletion_protection(
-        self, deletion_protection: Union[DeletionProtection, str]
-    ) -> DeletionProtectionModel:
-        deletion_protection = convert_enum_to_string(deletion_protection)
-        if deletion_protection in ["enabled", "disabled"]:
-            return DeletionProtectionModel(deletion_protection)
-        else:
-            raise ValueError("deletion_protection must be either 'enabled' or 'disabled'")
-
-    def __parse_index_spec(self, spec: Union[Dict, ServerlessSpec, PodSpec]) -> IndexSpec:
-        if isinstance(spec, dict):
-            if "serverless" in spec:
-                index_spec = IndexSpec(serverless=ServerlessSpecModel(**spec["serverless"]))
-            elif "pod" in spec:
-                args_dict = parse_non_empty_args(
-                    [
-                        ("environment", spec["pod"].get("environment")),
-                        ("metadata_config", spec["pod"].get("metadata_config")),
-                        ("replicas", spec["pod"].get("replicas")),
-                        ("shards", spec["pod"].get("shards")),
-                        ("pods", spec["pod"].get("pods")),
-                        ("source_collection", spec["pod"].get("source_collection")),
-                    ]
-                )
-                if args_dict.get("metadata_config"):
-                    args_dict["metadata_config"] = PodSpecMetadataConfig(
-                        indexed=args_dict["metadata_config"].get("indexed", None)
-                    )
-                index_spec = IndexSpec(pod=PodSpecModel(**args_dict))
-            else:
-                raise ValueError("spec must contain either 'serverless' or 'pod' key")
-        elif isinstance(spec, ServerlessSpec):
-            index_spec = IndexSpec(
-                serverless=ServerlessSpecModel(cloud=spec.cloud, region=spec.region)
-            )
-        elif isinstance(spec, PodSpec):
-            args_dict = parse_non_empty_args(
-                [
-                    ("replicas", spec.replicas),
-                    ("shards", spec.shards),
-                    ("pods", spec.pods),
-                    ("source_collection", spec.source_collection),
-                ]
-            )
-            if spec.metadata_config:
-                args_dict["metadata_config"] = PodSpecMetadataConfig(
-                    indexed=spec.metadata_config.get("indexed", None)
-                )
-
-            index_spec = IndexSpec(
-                pod=PodSpecModel(environment=spec.environment, pod_type=spec.pod_type, **args_dict)
-            )
-        else:
-            raise TypeError("spec must be of type dict, ServerlessSpec, or PodSpec")
-
-        return index_spec
-
     def create_index(
         self,
         name: str,
@@ -226,34 +143,15 @@ class Pinecone(PineconeDBControlInterface):
         vector_type: Optional[Union[VectorType, str]] = VectorType.DENSE,
         tags: Optional[Dict[str, str]] = None,
     ) -> IndexModel:
-        if metric is not None:
-            metric = convert_enum_to_string(metric)
-        if vector_type is not None:
-            vector_type = convert_enum_to_string(vector_type)
-        if deletion_protection is not None:
-            dp = self.__parse_deletion_protection(deletion_protection)
-        else:
-            dp = None
-
-        tags_obj = self.__parse_tags(tags)
-        index_spec = self.__parse_index_spec(spec)
-
-        if vector_type == VectorType.SPARSE.value and dimension is not None:
-            raise ValueError("dimension should not be specified for sparse indexes")
-
-        args = parse_non_empty_args(
-            [
-                ("name", name),
-                ("dimension", dimension),
-                ("metric", metric),
-                ("spec", index_spec),
-                ("deletion_protection", dp),
-                ("vector_type", vector_type),
-                ("tags", tags_obj),
-            ]
+        req = PineconeDBControlRequestFactory.create_index_request(
+            name=name,
+            spec=spec,
+            dimension=dimension,
+            metric=metric,
+            deletion_protection=deletion_protection,
+            vector_type=vector_type,
+            tags=tags,
         )
-
-        req = CreateIndexRequest(**args)
         resp = self.index_api.create_index(create_index_request=req)
 
         if timeout == -1:
@@ -270,42 +168,14 @@ class Pinecone(PineconeDBControlInterface):
         deletion_protection: Optional[Union[DeletionProtection, str]] = DeletionProtection.DISABLED,
         timeout: Optional[int] = None,
     ) -> IndexModel:
-        cloud = convert_enum_to_string(cloud)
-        region = convert_enum_to_string(region)
-        if deletion_protection is not None:
-            dp = self.__parse_deletion_protection(deletion_protection)
-        else:
-            dp = None
-        tags_obj = self.__parse_tags(tags)
-
-        if isinstance(embed, IndexEmbed):
-            parsed_embed = embed.as_dict()
-        else:
-            # if dict, we need to parse enum values, if any, to string
-            # and verify required fields are present
-            required_fields = ["model", "field_map"]
-            for field in required_fields:
-                if field not in embed:
-                    raise ValueError(f"{field} is required in embed")
-            parsed_embed = {}
-            for key, value in embed.items():
-                if isinstance(value, Enum):
-                    parsed_embed[key] = convert_enum_to_string(value)
-                else:
-                    parsed_embed[key] = value
-
-        args = parse_non_empty_args(
-            [
-                ("name", name),
-                ("cloud", cloud),
-                ("region", region),
-                ("embed", CreateIndexForModelRequestEmbed(**parsed_embed)),
-                ("deletion_protection", dp),
-                ("tags", tags_obj),
-            ]
+        req = PineconeDBControlRequestFactory.create_index_for_model_request(
+            name=name,
+            cloud=cloud,
+            region=region,
+            embed=embed,
+            tags=tags,
+            deletion_protection=deletion_protection,
         )
-
-        req = CreateIndexForModelRequest(**args)
         resp = self.index_api.create_index_for_model(req)
 
         if timeout == -1:
@@ -405,68 +275,37 @@ class Pinecone(PineconeDBControlInterface):
         api_instance = self.index_api
         description = self.describe_index(name=name)
 
-        if deletion_protection is None:
-            dp = DeletionProtectionModel(description.deletion_protection)
-        elif isinstance(deletion_protection, DeletionProtection):
-            dp = DeletionProtectionModel(deletion_protection.value)
-        elif deletion_protection in ["enabled", "disabled"]:
-            dp = DeletionProtectionModel(deletion_protection)
-        else:
-            raise ValueError("deletion_protection must be either 'enabled' or 'disabled'")
-
-        fetched_tags = description.tags
-        if fetched_tags is None:
-            starting_tags = {}
-        else:
-            starting_tags = fetched_tags.to_dict()
-
-        if tags is None:
-            # Do not modify tags if none are provided
-            tags = starting_tags
-        else:
-            # Merge existing tags with new tags
-            tags = {**starting_tags, **tags}
-
-        pod_config_args: Dict[str, Any] = {}
-        if pod_type:
-            new_pod_type = pod_type.value if isinstance(pod_type, PodType) else pod_type
-            pod_config_args.update(pod_type=new_pod_type)
-        if replicas:
-            pod_config_args.update(replicas=replicas)
-
-        if pod_config_args != {}:
-            spec = ConfigureIndexRequestSpec(pod=ConfigureIndexRequestSpecPod(**pod_config_args))
-            req = ConfigureIndexRequest(deletion_protection=dp, spec=spec, tags=IndexTags(**tags))
-        else:
-            req = ConfigureIndexRequest(deletion_protection=dp, tags=IndexTags(**tags))
-
+        req = PineconeDBControlRequestFactory.configure_index_request(
+            description=description,
+            replicas=replicas,
+            pod_type=pod_type,
+            deletion_protection=deletion_protection,
+            tags=tags,
+        )
         api_instance.configure_index(name, configure_index_request=req)
 
     def create_collection(self, name: str, source: str):
-        api_instance = self.index_api
-        api_instance.create_collection(
-            create_collection_request=CreateCollectionRequest(name=name, source=source)
-        )
+        req = PineconeDBControlRequestFactory.create_collection_request(name=name, source=source)
+        self.index_api.create_collection(create_collection_request=req)
 
     def list_collections(self) -> CollectionList:
-        api_instance = self.index_api
-        response = api_instance.list_collections()
+        response = self.index_api.list_collections()
         return CollectionList(response)
 
     def delete_collection(self, name: str):
-        api_instance = self.index_api
-        api_instance.delete_collection(name)
+        self.index_api.delete_collection(name)
 
     def describe_collection(self, name: str):
-        api_instance = self.index_api
-        return api_instance.describe_collection(name).to_dict()
+        return self.index_api.describe_collection(name).to_dict()
 
     @staticmethod
     def from_texts(*args, **kwargs):
+        """@private"""
         raise AttributeError(_build_langchain_attribute_error_message("from_texts"))
 
     @staticmethod
     def from_documents(*args, **kwargs):
+        """@private"""
         raise AttributeError(_build_langchain_attribute_error_message("from_documents"))
 
     def Index(self, name: str = "", host: str = "", **kwargs):

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -106,13 +106,20 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
 
         self.load_plugins()
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.close()
+
+    async def close(self):
+        await self.index_api.api_client.close()
+
     @property
     def inference(self):
         """Dynamically create and cache the Inference instance."""
         if self._inference is None:
-            self._inference = _AsyncioInference(
-                config=self.config, openapi_config=self.openapi_config
-            )
+            self._inference = _AsyncioInference(api_client=self.index_api.api_client)
         return self._inference
 
     def load_plugins(self):

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -1,15 +1,13 @@
-import time
 import logging
+import asyncio
 from typing import Optional, Dict, Union
 
 from .index_host_store import IndexHostStore
-from .pinecone_interface import PineconeDBControlInterface
 
 from pinecone.config import PineconeConfig, Config, ConfigBuilder
 
-from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
-from pinecone.openapi_support.api_client import ApiClient
-
+from pinecone.core.openapi.db_control.api.manage_indexes_api import AsyncioManageIndexesApi
+from pinecone.openapi_support import AsyncioApiClient
 
 from pinecone.utils import normalize_host, setup_openapi_client, build_plugin_setup_client
 from pinecone.core.openapi.db_control import API_VERSION
@@ -21,10 +19,9 @@ from pinecone.models import (
     CollectionList,
     IndexEmbed,
 )
-from .langchain_import_warnings import _build_langchain_attribute_error_message
 from pinecone.utils import docslinks
 
-from pinecone.data import _Index, _Inference
+from pinecone.data import _AsyncioIndex, _AsyncioInference
 from pinecone.enums import (
     Metric,
     VectorType,
@@ -44,9 +41,9 @@ logger = logging.getLogger(__name__)
 """ @private """
 
 
-class Pinecone(PineconeDBControlInterface):
+class PineconeAsyncio:
     """
-    A client for interacting with Pinecone's vector database.
+    An asyncio client for interacting with Pinecone's vector database.
 
     This class implements methods for managing and interacting with Pinecone resources
     such as collections and indexes.
@@ -62,7 +59,6 @@ class Pinecone(PineconeDBControlInterface):
         ssl_verify: Optional[bool] = None,
         config: Optional[Config] = None,
         additional_headers: Optional[Dict[str, str]] = {},
-        pool_threads: Optional[int] = 1,
         **kwargs,
     ):
         if config:
@@ -88,16 +84,19 @@ class Pinecone(PineconeDBControlInterface):
             )
 
         self.openapi_config = ConfigBuilder.build_openapi_config(self.config, **kwargs)
-        self.pool_threads = pool_threads
+
+        # I am pretty sure these aren't used, but need to pass a
+        # value for now to satisfy the method signatures
+        self.pool_threads = 1
 
         self._inference = None  # Lazy initialization
 
         self.index_api = setup_openapi_client(
-            api_client_klass=ApiClient,
-            api_klass=ManageIndexesApi,
+            api_client_klass=AsyncioApiClient,
+            api_klass=AsyncioManageIndexesApi,
             config=self.config,
             openapi_config=self.openapi_config,
-            pool_threads=pool_threads,
+            pool_threads=self.pool_threads,
             api_version=API_VERSION,
         )
 
@@ -110,7 +109,9 @@ class Pinecone(PineconeDBControlInterface):
     def inference(self):
         """Dynamically create and cache the Inference instance."""
         if self._inference is None:
-            self._inference = _Inference(config=self.config, openapi_config=self.openapi_config)
+            self._inference = _AsyncioInference(
+                config=self.config, openapi_config=self.openapi_config
+            )
         return self._inference
 
     def load_plugins(self):
@@ -128,7 +129,7 @@ class Pinecone(PineconeDBControlInterface):
         except Exception as e:
             logger.error(f"Error loading plugins: {e}")
 
-    def create_index(
+    async def create_index(
         self,
         name: str,
         spec: Union[Dict, ServerlessSpec, PodSpec],
@@ -148,13 +149,13 @@ class Pinecone(PineconeDBControlInterface):
             vector_type=vector_type,
             tags=tags,
         )
-        resp = self.index_api.create_index(create_index_request=req)
+        resp = await self.index_api.create_index(create_index_request=req)
 
         if timeout == -1:
             return IndexModel(resp)
-        return self.__poll_describe_index_until_ready(name, timeout)
+        return await self.__poll_describe_index_until_ready(name, timeout)
 
-    def create_index_for_model(
+    async def create_index_for_model(
         self,
         name: str,
         cloud: Union[CloudProvider, str],
@@ -172,33 +173,33 @@ class Pinecone(PineconeDBControlInterface):
             tags=tags,
             deletion_protection=deletion_protection,
         )
-        resp = self.index_api.create_index_for_model(req)
+        resp = await self.index_api.create_index_for_model(req)
 
         if timeout == -1:
             return IndexModel(resp)
-        return self.__poll_describe_index_until_ready(name, timeout)
+        return await self.__poll_describe_index_until_ready(name, timeout)
 
-    def __poll_describe_index_until_ready(self, name: str, timeout: Optional[int] = None):
+    async def __poll_describe_index_until_ready(self, name: str, timeout: Optional[int] = None):
         description = None
 
-        def is_ready():
+        async def is_ready():
             nonlocal description
-            description = self.describe_index(name=name)
+            description = await self.describe_index(name=name)
             return description.status.ready
 
         total_wait_time = 0
         if timeout is None:
             # Wait indefinitely
-            while not is_ready():
+            while not await is_ready():
                 logger.debug(
                     f"Waiting for index {name} to be ready. Total wait time {total_wait_time} seconds."
                 )
                 total_wait_time += 5
-                time.sleep(5)
+                await asyncio.sleep(5)
 
         else:
             # Wait for a maximum of timeout seconds
-            while not is_ready():
+            while not await is_ready():
                 if timeout < 0:
                     logger.error(f"Index {name} is not ready. Timeout reached.")
                     link = docslinks["API_DESCRIBE_INDEX"]
@@ -211,27 +212,28 @@ class Pinecone(PineconeDBControlInterface):
                     f"Waiting for index {name} to be ready. Total wait time: {total_wait_time}"
                 )
                 total_wait_time += 5
-                time.sleep(5)
+                await asyncio.sleep(5)
                 timeout -= 5
 
         return description
 
-    def delete_index(self, name: str, timeout: Optional[int] = None):
-        self.index_api.delete_index(name)
+    async def delete_index(self, name: str, timeout: Optional[int] = None):
+        await self.index_api.delete_index(name)
         self.index_host_store.delete_host(self.config, name)
 
-        def get_remaining():
-            return name in self.list_indexes().names()
+        async def get_remaining():
+            available_indexes = await self.list_indexes()
+            return name in available_indexes.names()
 
         if timeout == -1:
             return
 
         if timeout is None:
-            while get_remaining():
-                time.sleep(5)
+            while await get_remaining():
+                await asyncio.sleep(5)
         else:
-            while get_remaining() and timeout >= 0:
-                time.sleep(5)
+            while await get_remaining() and timeout >= 0:
+                await asyncio.sleep(5)
                 timeout -= 5
         if timeout and timeout < 0:
             raise (
@@ -242,25 +244,24 @@ class Pinecone(PineconeDBControlInterface):
                 )
             )
 
-    def list_indexes(self) -> IndexList:
-        response = self.index_api.list_indexes()
+    async def list_indexes(self) -> IndexList:
+        response = await self.index_api.list_indexes()
         return IndexList(response)
 
-    def describe_index(self, name: str) -> IndexModel:
-        api_instance = self.index_api
-        description = api_instance.describe_index(name)
+    async def describe_index(self, name: str) -> IndexModel:
+        description = await self.index_api.describe_index(name)
         host = description.host
         self.index_host_store.set_host(self.config, name, host)
 
         return IndexModel(description)
 
-    def has_index(self, name: str) -> bool:
-        if name in self.list_indexes().names():
+    async def has_index(self, name: str) -> bool:
+        if name in await self.list_indexes().names():
             return True
         else:
             return False
 
-    def configure_index(
+    async def configure_index(
         self,
         name: str,
         replicas: Optional[int] = None,
@@ -268,8 +269,7 @@ class Pinecone(PineconeDBControlInterface):
         deletion_protection: Optional[Union[DeletionProtection, str]] = None,
         tags: Optional[Dict[str, str]] = None,
     ):
-        api_instance = self.index_api
-        description = self.describe_index(name=name)
+        description = await self.describe_index(name=name)
 
         req = PineconeDBControlRequestFactory.configure_index_request(
             description=description,
@@ -278,31 +278,21 @@ class Pinecone(PineconeDBControlInterface):
             deletion_protection=deletion_protection,
             tags=tags,
         )
-        api_instance.configure_index(name, configure_index_request=req)
+        await self.index_api.configure_index(name, configure_index_request=req)
 
-    def create_collection(self, name: str, source: str):
+    async def create_collection(self, name: str, source: str):
         req = PineconeDBControlRequestFactory.create_collection_request(name=name, source=source)
-        self.index_api.create_collection(create_collection_request=req)
+        await self.index_api.create_collection(create_collection_request=req)
 
-    def list_collections(self) -> CollectionList:
-        response = self.index_api.list_collections()
+    async def list_collections(self) -> CollectionList:
+        response = await self.index_api.list_collections()
         return CollectionList(response)
 
-    def delete_collection(self, name: str):
-        self.index_api.delete_collection(name)
+    async def delete_collection(self, name: str):
+        await self.index_api.delete_collection(name)
 
-    def describe_collection(self, name: str):
-        return self.index_api.describe_collection(name).to_dict()
-
-    @staticmethod
-    def from_texts(*args, **kwargs):
-        """@private"""
-        raise AttributeError(_build_langchain_attribute_error_message("from_texts"))
-
-    @staticmethod
-    def from_documents(*args, **kwargs):
-        """@private"""
-        raise AttributeError(_build_langchain_attribute_error_message("from_documents"))
+    async def describe_collection(self, name: str):
+        return await self.index_api.describe_collection(name).to_dict()
 
     def Index(self, name: str = "", host: str = "", **kwargs):
         if name == "" and host == "":
@@ -319,7 +309,7 @@ class Pinecone(PineconeDBControlInterface):
             # Otherwise, get host url from describe_index using the index name
             index_host = self.index_host_store.get_host(self.index_api, self.config, name)
 
-        return _Index(
+        return _AsyncioIndex(
             host=index_host,
             api_key=api_key,
             pool_threads=pt,

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -34,6 +34,7 @@ from pinecone.enums import (
 )
 from .types import CreateIndexForModelEmbedTypedDict
 from .request_factory import PineconeDBControlRequestFactory
+from .pinecone_interface_asyncio import PineconeAsyncioDBControlInterface
 
 from pinecone_plugin_interface import load_and_install as install_plugins
 
@@ -41,7 +42,7 @@ logger = logging.getLogger(__name__)
 """ @private """
 
 
-class PineconeAsyncio:
+class PineconeAsyncio(PineconeAsyncioDBControlInterface):
     """
     An asyncio client for interacting with Pinecone's vector database.
 

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -256,7 +256,8 @@ class PineconeAsyncio:
         return IndexModel(description)
 
     async def has_index(self, name: str) -> bool:
-        if name in await self.list_indexes().names():
+        available_indexes = await self.list_indexes()
+        if name in available_indexes.names():
             return True
         else:
             return False

--- a/pinecone/control/request_factory.py
+++ b/pinecone/control/request_factory.py
@@ -1,0 +1,246 @@
+import logging
+from typing import Optional, Dict, Any, Union
+from enum import Enum
+
+
+from pinecone.utils import convert_enum_to_string
+from pinecone.core.openapi.db_control.models import (
+    CreateCollectionRequest,
+    CreateIndexForModelRequest,
+    CreateIndexForModelRequestEmbed,
+    CreateIndexRequest,
+    ConfigureIndexRequest,
+    ConfigureIndexRequestSpec,
+    ConfigureIndexRequestSpecPod,
+    DeletionProtection as DeletionProtectionModel,
+    IndexSpec,
+    IndexTags,
+    ServerlessSpec as ServerlessSpecModel,
+    PodSpec as PodSpecModel,
+    PodSpecMetadataConfig,
+)
+from pinecone.models import ServerlessSpec, PodSpec, IndexModel, IndexEmbed
+from pinecone.utils import parse_non_empty_args
+
+from pinecone.enums import (
+    Metric,
+    VectorType,
+    DeletionProtection,
+    PodType,
+    CloudProvider,
+    AwsRegion,
+    GcpRegion,
+    AzureRegion,
+)
+from .types import CreateIndexForModelEmbedTypedDict
+
+
+logger = logging.getLogger(__name__)
+""" @private """
+
+
+class PineconeDBControlRequestFactory:
+    """
+    @private
+
+    This class facilitates translating user inputs into request objects.
+    """
+
+    @staticmethod
+    def __parse_tags(tags: Optional[Dict[str, str]]) -> IndexTags:
+        if tags is None:
+            return IndexTags()
+        else:
+            return IndexTags(**tags)
+
+    @staticmethod
+    def __parse_deletion_protection(
+        deletion_protection: Union[DeletionProtection, str],
+    ) -> DeletionProtectionModel:
+        deletion_protection = convert_enum_to_string(deletion_protection)
+        if deletion_protection in ["enabled", "disabled"]:
+            return DeletionProtectionModel(deletion_protection)
+        else:
+            raise ValueError("deletion_protection must be either 'enabled' or 'disabled'")
+
+    @staticmethod
+    def __parse_index_spec(spec: Union[Dict, ServerlessSpec, PodSpec]) -> IndexSpec:
+        if isinstance(spec, dict):
+            if "serverless" in spec:
+                index_spec = IndexSpec(serverless=ServerlessSpecModel(**spec["serverless"]))
+            elif "pod" in spec:
+                args_dict = parse_non_empty_args(
+                    [
+                        ("environment", spec["pod"].get("environment")),
+                        ("metadata_config", spec["pod"].get("metadata_config")),
+                        ("replicas", spec["pod"].get("replicas")),
+                        ("shards", spec["pod"].get("shards")),
+                        ("pods", spec["pod"].get("pods")),
+                        ("source_collection", spec["pod"].get("source_collection")),
+                    ]
+                )
+                if args_dict.get("metadata_config"):
+                    args_dict["metadata_config"] = PodSpecMetadataConfig(
+                        indexed=args_dict["metadata_config"].get("indexed", None)
+                    )
+                index_spec = IndexSpec(pod=PodSpecModel(**args_dict))
+            else:
+                raise ValueError("spec must contain either 'serverless' or 'pod' key")
+        elif isinstance(spec, ServerlessSpec):
+            index_spec = IndexSpec(
+                serverless=ServerlessSpecModel(cloud=spec.cloud, region=spec.region)
+            )
+        elif isinstance(spec, PodSpec):
+            args_dict = parse_non_empty_args(
+                [
+                    ("replicas", spec.replicas),
+                    ("shards", spec.shards),
+                    ("pods", spec.pods),
+                    ("source_collection", spec.source_collection),
+                ]
+            )
+            if spec.metadata_config:
+                args_dict["metadata_config"] = PodSpecMetadataConfig(
+                    indexed=spec.metadata_config.get("indexed", None)
+                )
+
+            index_spec = IndexSpec(
+                pod=PodSpecModel(environment=spec.environment, pod_type=spec.pod_type, **args_dict)
+            )
+        else:
+            raise TypeError("spec must be of type dict, ServerlessSpec, or PodSpec")
+
+        return index_spec
+
+    @staticmethod
+    def create_index_request(
+        name: str,
+        spec: Union[Dict, ServerlessSpec, PodSpec],
+        dimension: Optional[int] = None,
+        metric: Optional[Union[Metric, str]] = Metric.COSINE,
+        deletion_protection: Optional[Union[DeletionProtection, str]] = DeletionProtection.DISABLED,
+        vector_type: Optional[Union[VectorType, str]] = VectorType.DENSE,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> CreateIndexRequest:
+        if metric is not None:
+            metric = convert_enum_to_string(metric)
+        if vector_type is not None:
+            vector_type = convert_enum_to_string(vector_type)
+        if deletion_protection is not None:
+            dp = PineconeDBControlRequestFactory.__parse_deletion_protection(deletion_protection)
+        else:
+            dp = None
+
+        tags_obj = PineconeDBControlRequestFactory.__parse_tags(tags)
+        index_spec = PineconeDBControlRequestFactory.__parse_index_spec(spec)
+
+        if vector_type == VectorType.SPARSE.value and dimension is not None:
+            raise ValueError("dimension should not be specified for sparse indexes")
+
+        args = parse_non_empty_args(
+            [
+                ("name", name),
+                ("dimension", dimension),
+                ("metric", metric),
+                ("spec", index_spec),
+                ("deletion_protection", dp),
+                ("vector_type", vector_type),
+                ("tags", tags_obj),
+            ]
+        )
+
+        return CreateIndexRequest(**args)
+
+    def create_index_for_model_request(
+        name: str,
+        cloud: Union[CloudProvider, str],
+        region: Union[AwsRegion, GcpRegion, AzureRegion, str],
+        embed: Union[IndexEmbed, CreateIndexForModelEmbedTypedDict],
+        tags: Optional[Dict[str, str]] = None,
+        deletion_protection: Optional[Union[DeletionProtection, str]] = DeletionProtection.DISABLED,
+    ) -> CreateIndexForModelRequest:
+        cloud = convert_enum_to_string(cloud)
+        region = convert_enum_to_string(region)
+        if deletion_protection is not None:
+            dp = PineconeDBControlRequestFactory.__parse_deletion_protection(deletion_protection)
+        else:
+            dp = None
+        tags_obj = PineconeDBControlRequestFactory.__parse_tags(tags)
+
+        if isinstance(embed, IndexEmbed):
+            parsed_embed = embed.as_dict()
+        else:
+            # if dict, we need to parse enum values, if any, to string
+            # and verify required fields are present
+            required_fields = ["model", "field_map"]
+            for field in required_fields:
+                if field not in embed:
+                    raise ValueError(f"{field} is required in embed")
+            parsed_embed = {}
+            for key, value in embed.items():
+                if isinstance(value, Enum):
+                    parsed_embed[key] = convert_enum_to_string(value)
+                else:
+                    parsed_embed[key] = value
+
+        args = parse_non_empty_args(
+            [
+                ("name", name),
+                ("cloud", cloud),
+                ("region", region),
+                ("embed", CreateIndexForModelRequestEmbed(**parsed_embed)),
+                ("deletion_protection", dp),
+                ("tags", tags_obj),
+            ]
+        )
+
+        return CreateIndexForModelRequest(**args)
+
+    @staticmethod
+    def configure_index_request(
+        description: IndexModel,
+        replicas: Optional[int] = None,
+        pod_type: Optional[Union[PodType, str]] = None,
+        deletion_protection: Optional[Union[DeletionProtection, str]] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ):
+        if deletion_protection is None:
+            dp = DeletionProtectionModel(description.deletion_protection)
+        elif isinstance(deletion_protection, DeletionProtection):
+            dp = DeletionProtectionModel(deletion_protection.value)
+        elif deletion_protection in ["enabled", "disabled"]:
+            dp = DeletionProtectionModel(deletion_protection)
+        else:
+            raise ValueError("deletion_protection must be either 'enabled' or 'disabled'")
+
+        fetched_tags = description.tags
+        if fetched_tags is None:
+            starting_tags = {}
+        else:
+            starting_tags = fetched_tags.to_dict()
+
+        if tags is None:
+            # Do not modify tags if none are provided
+            tags = starting_tags
+        else:
+            # Merge existing tags with new tags
+            tags = {**starting_tags, **tags}
+
+        pod_config_args: Dict[str, Any] = {}
+        if pod_type:
+            new_pod_type = convert_enum_to_string(pod_type)
+            pod_config_args.update(pod_type=new_pod_type)
+        if replicas:
+            pod_config_args.update(replicas=replicas)
+
+        if pod_config_args != {}:
+            spec = ConfigureIndexRequestSpec(pod=ConfigureIndexRequestSpecPod(**pod_config_args))
+            req = ConfigureIndexRequest(deletion_protection=dp, spec=spec, tags=IndexTags(**tags))
+        else:
+            req = ConfigureIndexRequest(deletion_protection=dp, tags=IndexTags(**tags))
+
+        return req
+
+    @staticmethod
+    def create_collection_request(name: str, source: str) -> CreateCollectionRequest:
+        return CreateCollectionRequest(name=name, source=source)

--- a/pinecone/control/request_factory.py
+++ b/pinecone/control/request_factory.py
@@ -155,6 +155,7 @@ class PineconeDBControlRequestFactory:
 
         return CreateIndexRequest(**args)
 
+    @staticmethod
     def create_index_for_model_request(
         name: str,
         cloud: Union[CloudProvider, str],

--- a/pinecone/control/request_factory.py
+++ b/pinecone/control/request_factory.py
@@ -67,8 +67,12 @@ class PineconeDBControlRequestFactory:
     def __parse_index_spec(spec: Union[Dict, ServerlessSpec, PodSpec]) -> IndexSpec:
         if isinstance(spec, dict):
             if "serverless" in spec:
+                spec["serverless"]["cloud"] = convert_enum_to_string(spec["serverless"]["cloud"])
+                spec["serverless"]["region"] = convert_enum_to_string(spec["serverless"]["region"])
+
                 index_spec = IndexSpec(serverless=ServerlessSpecModel(**spec["serverless"]))
             elif "pod" in spec:
+                spec["pod"]["environment"] = convert_enum_to_string(spec["pod"]["environment"])
                 args_dict = parse_non_empty_args(
                     [
                         ("environment", spec["pod"].get("environment")),

--- a/pinecone/data/__init__.py
+++ b/pinecone/data/__init__.py
@@ -26,4 +26,9 @@ from .errors import (
 )
 
 from .features.bulk_import import ImportErrorMode
-from .features.inference import Inference as _Inference, RerankModel, EmbedModel
+from .features.inference import (
+    Inference as _Inference,
+    AsyncioInference as _AsyncioInference,
+    RerankModel,
+    EmbedModel,
+)

--- a/pinecone/data/features/bulk_import/bulk_import.py
+++ b/pinecone/data/features/bulk_import/bulk_import.py
@@ -1,11 +1,8 @@
 from typing import Optional, Literal, Iterator, List
 
-from pinecone.config.config import ConfigBuilder
-from pinecone.openapi_support import ApiClient
 from pinecone.core.openapi.db_data.api.bulk_operations_api import BulkOperationsApi
-from pinecone.core.openapi.db_data import API_VERSION
 
-from pinecone.utils import install_json_repr_override, setup_openapi_client
+from pinecone.utils import install_json_repr_override
 
 from pinecone.core.openapi.db_data.models import (
     StartImportResponse,
@@ -20,23 +17,8 @@ for m in [StartImportResponse, ListImportsResponse, ImportModel]:
 
 
 class ImportFeatureMixin:
-    def __init__(self, **kwargs):
-        config = ConfigBuilder.build(**kwargs)
-        openapi_config = ConfigBuilder.build_openapi_config(
-            config, kwargs.get("openapi_config", None)
-        )
-
-        if kwargs.get("__import_operations_api", None):
-            self.__import_operations_api = kwargs.get("__import_operations_api")
-        else:
-            self.__import_operations_api = setup_openapi_client(
-                api_client_klass=ApiClient,
-                api_klass=BulkOperationsApi,
-                config=config,
-                openapi_config=openapi_config,
-                pool_threads=kwargs.get("pool_threads", 1),
-                api_version=API_VERSION,
-            )
+    def __init__(self, api_client, **kwargs):
+        self.__import_operations_api = BulkOperationsApi(api_client)
 
     def start_import(
         self,

--- a/pinecone/data/features/bulk_import/bulk_import_asyncio.py
+++ b/pinecone/data/features/bulk_import/bulk_import_asyncio.py
@@ -1,11 +1,8 @@
 from typing import Optional, Literal, AsyncIterator, List
 
-from pinecone.config.config import ConfigBuilder
-from pinecone.openapi_support import AsyncioApiClient
 from pinecone.core.openapi.db_data.api.bulk_operations_api import AsyncioBulkOperationsApi
-from pinecone.core.openapi.db_data import API_VERSION
 
-from pinecone.utils import install_json_repr_override, setup_openapi_client
+from pinecone.utils import install_json_repr_override
 
 from pinecone.core.openapi.db_data.models import (
     StartImportResponse,
@@ -20,23 +17,8 @@ for m in [StartImportResponse, ListImportsResponse, ImportModel]:
 
 
 class ImportFeatureMixinAsyncio:
-    def __init__(self, **kwargs):
-        config = ConfigBuilder.build(**kwargs)
-        openapi_config = ConfigBuilder.build_openapi_config(
-            config, kwargs.get("openapi_config", None)
-        )
-
-        if kwargs.get("__import_operations_api", None):
-            self.__import_operations_api = kwargs.get("__import_operations_api")
-        else:
-            self.__import_operations_api = setup_openapi_client(
-                api_client_klass=AsyncioApiClient,
-                api_klass=AsyncioBulkOperationsApi,
-                config=config,
-                openapi_config=openapi_config,
-                pool_threads=kwargs.get("pool_threads", 1),
-                api_version=API_VERSION,
-            )
+    def __init__(self, api_client, **kwargs):
+        self.__import_operations_api = AsyncioBulkOperationsApi(api_client)
 
     async def start_import(
         self,

--- a/pinecone/data/features/inference/inference_asyncio.py
+++ b/pinecone/data/features/inference/inference_asyncio.py
@@ -6,7 +6,11 @@ from pinecone.core.openapi.inference.models import EmbeddingsList, RerankResult
 from pinecone.core.openapi.inference import API_VERSION
 from pinecone.utils import setup_openapi_client
 
-from .inference_request_builder import InferenceRequestBuilder
+from .inference_request_builder import (
+    InferenceRequestBuilder,
+    EmbedModel as EmbedModelEnum,
+    RerankModel as RerankModelEnum,
+)
 
 
 class AsyncioInference:
@@ -17,6 +21,9 @@ class AsyncioInference:
     :param config: A `pinecone.config.Config` object, configured and built in the Pinecone class.
     :type config: `pinecone.config.Config`, required
     """
+
+    EmbedModel = EmbedModelEnum
+    RerankModel = RerankModelEnum
 
     def __init__(self, config, openapi_config, **kwargs):
         self.config = config

--- a/pinecone/data/features/inference/inference_asyncio.py
+++ b/pinecone/data/features/inference/inference_asyncio.py
@@ -1,10 +1,7 @@
 from typing import Optional, Dict, List, Union, Any
 
-from pinecone.openapi_support import AsyncioApiClient
 from pinecone.core.openapi.inference.api.inference_api import AsyncioInferenceApi
 from pinecone.core.openapi.inference.models import EmbeddingsList, RerankResult
-from pinecone.core.openapi.inference import API_VERSION
-from pinecone.utils import setup_openapi_client
 
 from .inference_request_builder import (
     InferenceRequestBuilder,
@@ -25,17 +22,9 @@ class AsyncioInference:
     EmbedModel = EmbedModelEnum
     RerankModel = RerankModelEnum
 
-    def __init__(self, config, openapi_config, **kwargs):
-        self.config = config
-
-        self.__inference_api = setup_openapi_client(
-            api_client_klass=AsyncioApiClient,
-            api_klass=AsyncioInferenceApi,
-            config=config,
-            openapi_config=openapi_config,
-            pool_threads=kwargs.get("pool_threads", 1),
-            api_version=API_VERSION,
-        )
+    def __init__(self, api_client, **kwargs):
+        self.api_client = api_client
+        self.__inference_api = AsyncioInferenceApi(api_client)
 
     async def embed(
         self,

--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -67,15 +67,6 @@ class Index(IndexInterface, ImportFeatureMixin):
         openapi_config=None,
         **kwargs,
     ):
-        super().__init__(
-            api_key=api_key,
-            host=host,
-            pool_threads=pool_threads,
-            additional_headers=additional_headers,
-            openapi_config=openapi_config,
-            **kwargs,
-        )
-
         self.config = ConfigBuilder.build(
             api_key=api_key, host=host, additional_headers=additional_headers, **kwargs
         )
@@ -93,6 +84,11 @@ class Index(IndexInterface, ImportFeatureMixin):
             pool_threads=pool_threads,
             api_version=API_VERSION,
         )
+
+        self._api_client = self._vector_api.api_client
+
+        # Pass the same api_client to the ImportFeatureMixin
+        super().__init__(api_client=self._api_client)
 
         self._load_plugins()
 
@@ -118,6 +114,9 @@ class Index(IndexInterface, ImportFeatureMixin):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        self._vector_api.api_client.close()
+
+    def close(self):
         self._vector_api.api_client.close()
 
     @validate_and_convert_errors

--- a/pinecone/openapi_support/rest_aiohttp.py
+++ b/pinecone/openapi_support/rest_aiohttp.py
@@ -1,5 +1,3 @@
-import weakref
-import asyncio
 import json
 from .rest_utils import RestClientInterface, RESTResponse, raise_exceptions_or_return
 
@@ -10,16 +8,10 @@ class AiohttpRestClient(RestClientInterface):
 
         conn = aiohttp.TCPConnector()
         self._session = aiohttp.ClientSession(connector=conn)
-        self._finalizer = weakref.finalize(self, self._cleanup)
 
-    async def _cleanup(self):
-        if not self._session.closed:
-            await self._session.close()
-
-    def __del__(self):
-        """Ensure the session is closed if the object is garbage collected."""
-        if not self._session.closed:
-            asyncio.run(self._cleanup())
+    # async def _cleanup(self):
+    #     if not self._session.closed:
+    #         await self._session.close()
 
     async def close(self):
         await self._session.close()

--- a/tests/integration/control/serverless/test_sparse_index.py
+++ b/tests/integration/control/serverless/test_sparse_index.py
@@ -70,4 +70,4 @@ class TestSparseIndexErrorCases:
 
         with pytest.raises(PineconeApiException) as e:
             client.create_index(**create_sl_index_params)
-        assert "Sparse vector indexes must use dotproduct" in str(e.value)
+        assert "Sparse vector indexes must use the metric dotproduct." in str(e.value)

--- a/tests/integration/control_asyncio/conftest.py
+++ b/tests/integration/control_asyncio/conftest.py
@@ -1,0 +1,212 @@
+import pytest
+import time
+import random
+import asyncio
+from ..helpers import get_environment_var, generate_index_name
+import logging
+from typing import Callable, Optional, Awaitable, Union
+
+from pinecone import (
+    CloudProvider,
+    AwsRegion,
+    ServerlessSpec,
+    PineconeApiException,
+    NotFoundException,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def api_key():
+    return get_environment_var("PINECONE_API_KEY")
+
+
+def build_client():
+    config = {"api_key": api_key()}
+
+    from pinecone import PineconeAsyncio
+
+    return PineconeAsyncio(**config)
+
+
+@pytest.fixture(scope="session")
+def client():
+    # This returns the sync client. Not for use in tests
+    # but can be used to help with cleanup after test runs
+    from pinecone import Pinecone
+
+    return Pinecone(api_key=api_key())
+
+
+@pytest.fixture(scope="session")
+def build_pc():
+    return build_client
+
+
+@pytest.fixture(scope="session")
+def api_key_fixture():
+    return api_key()
+
+
+async def poll_for_freshness(asyncio_idx, target_namespace, target_vector_count):
+    max_wait_time = 60 * 3  # 3 minutes
+    time_waited = 0
+    wait_per_iteration = 5
+
+    while True:
+        stats = await asyncio_idx.describe_index_stats()
+        logger.debug(
+            "Polling for freshness on index %s. Current vector count: %s. Waiting for: %s",
+            asyncio_idx,
+            stats.total_vector_count,
+            target_vector_count,
+        )
+        if target_namespace == "":
+            if stats.total_vector_count >= target_vector_count:
+                break
+        else:
+            if (
+                target_namespace in stats.namespaces
+                and stats.namespaces[target_namespace].vector_count >= target_vector_count
+            ):
+                break
+        time_waited += wait_per_iteration
+        if time_waited >= max_wait_time:
+            raise TimeoutError(
+                "Timeout waiting for index to have expected vector count of {}".format(
+                    target_vector_count
+                )
+            )
+        await asyncio.sleep(wait_per_iteration)
+
+    return stats
+
+
+async def wait_until(
+    condition: Union[Callable[[], bool], Callable[[], Awaitable[bool]]],
+    timeout: Optional[float] = None,
+    interval: float = 0.1,
+) -> None:
+    """
+    Waits asynchronously until the given (async or sync) condition returns True or times out.
+
+    Args:
+        condition: A callable that returns a boolean or an awaitable boolean, indicating if the wait is over.
+        timeout: Maximum time in seconds to wait for the condition to become True. If None, wait indefinitely.
+        interval: Time in seconds between checks of the condition.
+
+    Raises:
+        asyncio.TimeoutError: If the condition is not met within the timeout period.
+    """
+    start_time = asyncio.get_event_loop().time()
+
+    while True:
+        result = await condition() if asyncio.iscoroutinefunction(condition) else condition()
+        if result:
+            return
+
+        if timeout is not None and (asyncio.get_event_loop().time() - start_time) > timeout:
+            raise asyncio.TimeoutError("Condition not met within the timeout period.")
+
+        logger.debug(
+            "Condition not met yet. Waiting for %.2f seconds. Timeout in %.2f seconds.",
+            interval,
+            (start_time + timeout) - asyncio.get_event_loop().time(),
+        )
+        await asyncio.sleep(interval)
+
+
+@pytest.fixture()
+def serverless_cloud():
+    return get_environment_var("SERVERLESS_CLOUD", "aws")
+
+
+@pytest.fixture()
+def serverless_region():
+    return get_environment_var("SERVERLESS_REGION", "us-west-2")
+
+
+@pytest.fixture()
+def spec1(serverless_cloud, serverless_region):
+    return {"serverless": {"cloud": serverless_cloud, "region": serverless_region}}
+
+
+@pytest.fixture()
+def spec2():
+    return ServerlessSpec(cloud=CloudProvider.AWS, region=AwsRegion.US_EAST_1)
+
+
+@pytest.fixture()
+def spec3():
+    return {"serverless": {"cloud": CloudProvider.AWS, "region": AwsRegion.US_EAST_1}}
+
+
+@pytest.fixture()
+def create_sl_index_params(index_name, serverless_cloud, serverless_region):
+    spec = {"serverless": {"cloud": serverless_cloud, "region": serverless_region}}
+    return dict(name=index_name, dimension=10, metric="cosine", spec=spec)
+
+
+@pytest.fixture()
+def random_vector():
+    return [random.uniform(0, 1) for _ in range(10)]
+
+
+@pytest.fixture()
+def index_name(request):
+    test_name = request.node.name
+    return generate_index_name(test_name)
+
+
+@pytest.fixture()
+def ready_sl_index(client, index_name, create_sl_index_params):
+    create_sl_index_params["timeout"] = None
+    client.create_index(**create_sl_index_params)
+    yield index_name
+    client.delete_index(index_name, -1)
+
+
+@pytest.fixture()
+def notready_sl_index(client, index_name, create_sl_index_params):
+    client.create_index(**create_sl_index_params, timeout=-1)
+    yield index_name
+
+
+def delete_with_retry(client, index_name, retries=0, sleep_interval=5):
+    print(
+        "Deleting index "
+        + index_name
+        + ", retry "
+        + str(retries)
+        + ", next sleep interval "
+        + str(sleep_interval)
+    )
+    try:
+        client.delete_index(index_name, -1)
+    except NotFoundException:
+        pass
+    except PineconeApiException as e:
+        if e.error.code == "PRECONDITON_FAILED":
+            if retries > 5:
+                raise "Unable to delete index " + index_name
+            time.sleep(sleep_interval)
+            delete_with_retry(client, index_name, retries + 1, sleep_interval * 2)
+        else:
+            print(e.__class__)
+            print(e)
+            raise "Unable to delete index " + index_name
+    except Exception as e:
+        print(e.__class__)
+        print(e)
+        raise "Unable to delete index " + index_name
+
+
+@pytest.fixture(autouse=True)
+def cleanup(client, index_name):
+    yield
+
+    try:
+        logger.debug("Attempting to delete index with name: " + index_name)
+        client.delete_index(index_name, -1)
+    except Exception:
+        pass

--- a/tests/integration/control_asyncio/conftest.py
+++ b/tests/integration/control_asyncio/conftest.py
@@ -17,16 +17,10 @@ from pinecone import (
 logger = logging.getLogger(__name__)
 
 
-def api_key():
-    return get_environment_var("PINECONE_API_KEY")
-
-
 def build_client():
-    config = {"api_key": api_key()}
-
     from pinecone import PineconeAsyncio
 
-    return PineconeAsyncio(**config)
+    return PineconeAsyncio()
 
 
 @pytest.fixture(scope="session")
@@ -35,17 +29,12 @@ def client():
     # but can be used to help with cleanup after test runs
     from pinecone import Pinecone
 
-    return Pinecone(api_key=api_key())
+    return Pinecone()
 
 
 @pytest.fixture(scope="session")
 def build_pc():
     return build_client
-
-
-@pytest.fixture(scope="session")
-def api_key_fixture():
-    return api_key()
 
 
 async def poll_for_freshness(asyncio_idx, target_namespace, target_vector_count):

--- a/tests/integration/control_asyncio/test_configure_index_deletion_protection.py
+++ b/tests/integration/control_asyncio/test_configure_index_deletion_protection.py
@@ -1,0 +1,43 @@
+import pytest
+from pinecone import DeletionProtection
+
+
+@pytest.mark.asyncio
+class TestDeletionProtection:
+    @pytest.mark.parametrize(
+        "dp_enabled,dp_disabled",
+        [("enabled", "disabled"), (DeletionProtection.ENABLED, DeletionProtection.DISABLED)],
+    )
+    async def test_deletion_protection(
+        self, client, create_sl_index_params, dp_enabled, dp_disabled
+    ):
+        name = create_sl_index_params["name"]
+        client.create_index(**create_sl_index_params, deletion_protection=dp_enabled)
+        desc = client.describe_index(name)
+        assert desc.deletion_protection == "enabled"
+
+        with pytest.raises(Exception) as e:
+            client.delete_index(name)
+        assert "Deletion protection is enabled for this index" in str(e.value)
+
+        client.configure_index(name, deletion_protection=dp_disabled)
+        desc = client.describe_index(name)
+        assert desc.deletion_protection == "disabled"
+
+        client.delete_index(name)
+
+    @pytest.mark.parametrize("deletion_protection", ["invalid"])
+    def test_deletion_protection_invalid_options(
+        self, client, create_sl_index_params, deletion_protection
+    ):
+        with pytest.raises(Exception) as e:
+            client.create_index(**create_sl_index_params, deletion_protection=deletion_protection)
+        assert "deletion_protection must be either 'enabled' or 'disabled'" in str(e.value)
+
+    @pytest.mark.parametrize("deletion_protection", ["invalid"])
+    def test_configure_deletion_protection_invalid_options(
+        self, client, create_sl_index_params, deletion_protection
+    ):
+        with pytest.raises(Exception) as e:
+            client.create_index(**create_sl_index_params, deletion_protection=deletion_protection)
+        assert "deletion_protection must be either 'enabled' or 'disabled'" in str(e.value)

--- a/tests/integration/control_asyncio/test_configure_index_tags.py
+++ b/tests/integration/control_asyncio/test_configure_index_tags.py
@@ -10,6 +10,7 @@ class TestIndexTags:
         await pc.describe_index(name=ready_sl_index)
         desc = await pc.describe_index(name=ready_sl_index)
         assert desc.tags is None
+        await pc.close()
 
     async def test_add_index_tags(self, ready_sl_index):
         pc = PineconeAsyncio()
@@ -17,6 +18,7 @@ class TestIndexTags:
         await pc.configure_index(name=ready_sl_index, tags={"foo": "FOO", "bar": "BAR"})
         desc = await pc.describe_index(name=ready_sl_index)
         assert desc.tags.to_dict() == {"foo": "FOO", "bar": "BAR"}
+        await pc.close()
 
     async def test_remove_tags_by_setting_empty_value_for_key(self, ready_sl_index):
         pc = PineconeAsyncio()
@@ -30,6 +32,7 @@ class TestIndexTags:
         await pc.configure_index(name=ready_sl_index, tags={"foo": ""})
         desc2 = await pc.describe_index(name=ready_sl_index)
         assert desc2.tags.to_dict() == {"bar": "BAR"}
+        await pc.close()
 
     async def test_merge_new_tags_with_existing_tags(self, ready_sl_index):
         pc = PineconeAsyncio()
@@ -38,6 +41,7 @@ class TestIndexTags:
         await pc.configure_index(name=ready_sl_index, tags={"baz": "BAZ"})
         desc = await pc.describe_index(name=ready_sl_index)
         assert desc.tags.to_dict() == {"foo": "FOO", "bar": "BAR", "baz": "BAZ"}
+        await pc.close()
 
     @pytest.mark.skip(reason="Backend bug filed")
     async def test_remove_all_tags(self, ready_sl_index):
@@ -46,3 +50,4 @@ class TestIndexTags:
         await pc.configure_index(name=ready_sl_index, tags={"foo": "", "bar": ""})
         desc = await pc.describe_index(name=ready_sl_index)
         assert desc.tags is None
+        await pc.close()

--- a/tests/integration/control_asyncio/test_configure_index_tags.py
+++ b/tests/integration/control_asyncio/test_configure_index_tags.py
@@ -4,24 +4,22 @@ from pinecone import PineconeAsyncio
 
 @pytest.mark.asyncio
 class TestIndexTags:
-    async def test_index_tags_none_by_default(self, api_key_fixture, ready_sl_index):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_index_tags_none_by_default(self, ready_sl_index):
+        pc = PineconeAsyncio()
 
         await pc.describe_index(name=ready_sl_index)
         desc = await pc.describe_index(name=ready_sl_index)
         assert desc.tags is None
 
-    async def test_add_index_tags(self, api_key_fixture, ready_sl_index):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_add_index_tags(self, ready_sl_index):
+        pc = PineconeAsyncio()
 
         await pc.configure_index(name=ready_sl_index, tags={"foo": "FOO", "bar": "BAR"})
         desc = await pc.describe_index(name=ready_sl_index)
         assert desc.tags.to_dict() == {"foo": "FOO", "bar": "BAR"}
 
-    async def test_remove_tags_by_setting_empty_value_for_key(
-        self, api_key_fixture, ready_sl_index
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_remove_tags_by_setting_empty_value_for_key(self, ready_sl_index):
+        pc = PineconeAsyncio()
 
         await pc.configure_index(name=ready_sl_index, tags={"foo": "FOO", "bar": "BAR"})
         await pc.configure_index(name=ready_sl_index, tags={})
@@ -33,8 +31,8 @@ class TestIndexTags:
         desc2 = await pc.describe_index(name=ready_sl_index)
         assert desc2.tags.to_dict() == {"bar": "BAR"}
 
-    async def test_merge_new_tags_with_existing_tags(self, api_key_fixture, ready_sl_index):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_merge_new_tags_with_existing_tags(self, ready_sl_index):
+        pc = PineconeAsyncio()
 
         await pc.configure_index(name=ready_sl_index, tags={"foo": "FOO", "bar": "BAR"})
         await pc.configure_index(name=ready_sl_index, tags={"baz": "BAZ"})
@@ -42,8 +40,8 @@ class TestIndexTags:
         assert desc.tags.to_dict() == {"foo": "FOO", "bar": "BAR", "baz": "BAZ"}
 
     @pytest.mark.skip(reason="Backend bug filed")
-    async def test_remove_all_tags(self, api_key_fixture, ready_sl_index):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_remove_all_tags(self, ready_sl_index):
+        pc = PineconeAsyncio()
         await pc.configure_index(name=ready_sl_index, tags={"foo": "FOO", "bar": "BAR"})
         await pc.configure_index(name=ready_sl_index, tags={"foo": "", "bar": ""})
         desc = await pc.describe_index(name=ready_sl_index)

--- a/tests/integration/control_asyncio/test_create_index.py
+++ b/tests/integration/control_asyncio/test_create_index.py
@@ -1,0 +1,156 @@
+import pytest
+from pinecone import (
+    PineconeAsyncio,
+    Metric,
+    VectorType,
+    DeletionProtection,
+    ServerlessSpec,
+    CloudProvider,
+    AwsRegion,
+)
+
+
+@pytest.mark.asyncio
+class TestAsyncioCreateIndex:
+    @pytest.mark.parametrize("spec_fixture", ("spec1", "spec2", "spec3"))
+    async def test_create_index(self, api_key_fixture, index_name, request, spec_fixture):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        spec = request.getfixturevalue(spec_fixture)
+
+        resp = await pc.create_index(name=index_name, dimension=10, spec=spec)
+
+        assert resp.name == index_name
+        assert resp.dimension == 10
+        assert resp.metric == "cosine"  # default value
+        assert resp.vector_type == "dense"  # default value
+        assert resp.deletion_protection == "disabled"  # default value
+
+        desc = await pc.describe_index(name=index_name)
+        assert desc.name == index_name
+        assert desc.dimension == 10
+        assert desc.metric == "cosine"
+        assert desc.deletion_protection == "disabled"  # default value
+        assert desc.vector_type == "dense"  # default value
+
+    async def test_create_skip_wait(self, api_key_fixture, index_name, spec1):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        resp = await pc.create_index(name=index_name, dimension=10, spec=spec1, timeout=-1)
+        assert resp.name == index_name
+        assert resp.dimension == 10
+        assert resp.metric == "cosine"
+
+    async def test_create_infinite_wait(self, api_key_fixture, index_name, spec1):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        resp = await pc.create_index(name=index_name, dimension=10, spec=spec1, timeout=None)
+        assert resp.name == index_name
+        assert resp.dimension == 10
+        assert resp.metric == "cosine"
+
+    @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
+    async def test_create_default_index_with_metric(
+        self, api_key_fixture, index_name, metric, spec1
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        await pc.create_index(name=index_name, dimension=10, spec=spec1, metric=metric)
+        desc = await pc.describe_index(index_name)
+        if isinstance(metric, str):
+            assert desc.metric == metric
+        else:
+            assert desc.metric == metric.value
+        assert desc.vector_type == "dense"
+
+    @pytest.mark.parametrize(
+        "metric_enum,vector_type_enum,dim,tags",
+        [
+            (Metric.COSINE, VectorType.DENSE, 10, None),
+            (Metric.EUCLIDEAN, VectorType.DENSE, 10, {"env": "prod"}),
+            (Metric.DOTPRODUCT, VectorType.SPARSE, None, {"env": "dev"}),
+        ],
+    )
+    async def test_create_with_enum_values_and_tags(
+        self, api_key_fixture, index_name, metric_enum, vector_type_enum, dim, tags
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        args = {
+            "name": index_name,
+            "metric": metric_enum,
+            "vector_type": vector_type_enum,
+            "deletion_protection": DeletionProtection.DISABLED,
+            "spec": ServerlessSpec(cloud=CloudProvider.AWS, region=AwsRegion.US_EAST_1),
+            "tags": tags,
+        }
+        if dim is not None:
+            args["dimension"] = dim
+
+        await pc.create_index(**args)
+
+        desc = await pc.describe_index(index_name)
+        assert desc.metric == metric_enum.value
+        assert desc.vector_type == vector_type_enum.value
+        assert desc.dimension == dim
+        assert desc.deletion_protection == DeletionProtection.DISABLED.value
+        assert desc.name == index_name
+        assert desc.spec.serverless.cloud == "aws"
+        assert desc.spec.serverless.region == "us-east-1"
+        if tags:
+            assert desc.tags.to_dict() == tags
+
+    @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
+    async def test_create_dense_index_with_metric(self, api_key_fixture, index_name, spec1, metric):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        await pc.create_index(
+            name=index_name, dimension=10, spec=spec1, metric=metric, vector_type=VectorType.DENSE
+        )
+
+        desc = await pc.describe_index(index_name)
+        assert desc.metric == metric
+        assert desc.vector_type == "dense"
+
+    async def test_create_with_optional_tags(self, api_key_fixture, index_name, spec1):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        tags = {"foo": "FOO", "bar": "BAR"}
+
+        await pc.create_index(name=index_name, dimension=10, spec=spec1, tags=tags)
+
+        desc = await pc.describe_index(index_name)
+        assert desc.tags.to_dict() == tags
+
+    async def test_create_sparse_index(self, api_key_fixture, index_name, spec1):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        await pc.create_index(
+            name=index_name, spec=spec1, metric=Metric.DOTPRODUCT, vector_type=VectorType.SPARSE
+        )
+
+        desc = await pc.describe_index(index_name)
+        assert desc.vector_type == "sparse"
+        assert desc.dimension is None
+        assert desc.vector_type == "sparse"
+        assert desc.metric == "dotproduct"
+
+    async def test_create_with_deletion_protection(self, api_key_fixture, index_name, spec1):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        await pc.create_index(
+            name=index_name,
+            spec=spec1,
+            metric=Metric.DOTPRODUCT,
+            vector_type=VectorType.SPARSE,
+            deletion_protection=DeletionProtection.ENABLED,
+        )
+
+        desc = await pc.describe_index(index_name)
+        assert desc.deletion_protection == "enabled"
+        assert desc.metric == "dotproduct"
+        assert desc.vector_type == "sparse"
+        assert desc.dimension is None
+
+        with pytest.raises(Exception):
+            await pc.delete_index(index_name)
+
+        await pc.configure_index(index_name, deletion_protection=DeletionProtection.DISABLED)
+
+        desc2 = await pc.describe_index(index_name)
+        assert desc2.deletion_protection == "disabled"

--- a/tests/integration/control_asyncio/test_create_index.py
+++ b/tests/integration/control_asyncio/test_create_index.py
@@ -13,8 +13,8 @@ from pinecone import (
 @pytest.mark.asyncio
 class TestAsyncioCreateIndex:
     @pytest.mark.parametrize("spec_fixture", ("spec1", "spec2", "spec3"))
-    async def test_create_index(self, api_key_fixture, index_name, request, spec_fixture):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index(self, index_name, request, spec_fixture):
+        pc = PineconeAsyncio()
         spec = request.getfixturevalue(spec_fixture)
 
         resp = await pc.create_index(name=index_name, dimension=10, spec=spec)
@@ -32,25 +32,23 @@ class TestAsyncioCreateIndex:
         assert desc.deletion_protection == "disabled"  # default value
         assert desc.vector_type == "dense"  # default value
 
-    async def test_create_skip_wait(self, api_key_fixture, index_name, spec1):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_skip_wait(self, index_name, spec1):
+        pc = PineconeAsyncio()
         resp = await pc.create_index(name=index_name, dimension=10, spec=spec1, timeout=-1)
         assert resp.name == index_name
         assert resp.dimension == 10
         assert resp.metric == "cosine"
 
-    async def test_create_infinite_wait(self, api_key_fixture, index_name, spec1):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_infinite_wait(self, index_name, spec1):
+        pc = PineconeAsyncio()
         resp = await pc.create_index(name=index_name, dimension=10, spec=spec1, timeout=None)
         assert resp.name == index_name
         assert resp.dimension == 10
         assert resp.metric == "cosine"
 
     @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
-    async def test_create_default_index_with_metric(
-        self, api_key_fixture, index_name, metric, spec1
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_default_index_with_metric(self, index_name, metric, spec1):
+        pc = PineconeAsyncio()
 
         await pc.create_index(name=index_name, dimension=10, spec=spec1, metric=metric)
         desc = await pc.describe_index(index_name)
@@ -69,9 +67,9 @@ class TestAsyncioCreateIndex:
         ],
     )
     async def test_create_with_enum_values_and_tags(
-        self, api_key_fixture, index_name, metric_enum, vector_type_enum, dim, tags
+        self, index_name, metric_enum, vector_type_enum, dim, tags
     ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+        pc = PineconeAsyncio()
         args = {
             "name": index_name,
             "metric": metric_enum,
@@ -97,8 +95,8 @@ class TestAsyncioCreateIndex:
             assert desc.tags.to_dict() == tags
 
     @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
-    async def test_create_dense_index_with_metric(self, api_key_fixture, index_name, spec1, metric):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_dense_index_with_metric(self, index_name, spec1, metric):
+        pc = PineconeAsyncio()
 
         await pc.create_index(
             name=index_name, dimension=10, spec=spec1, metric=metric, vector_type=VectorType.DENSE
@@ -108,8 +106,8 @@ class TestAsyncioCreateIndex:
         assert desc.metric == metric
         assert desc.vector_type == "dense"
 
-    async def test_create_with_optional_tags(self, api_key_fixture, index_name, spec1):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_with_optional_tags(self, index_name, spec1):
+        pc = PineconeAsyncio()
         tags = {"foo": "FOO", "bar": "BAR"}
 
         await pc.create_index(name=index_name, dimension=10, spec=spec1, tags=tags)
@@ -117,8 +115,8 @@ class TestAsyncioCreateIndex:
         desc = await pc.describe_index(index_name)
         assert desc.tags.to_dict() == tags
 
-    async def test_create_sparse_index(self, api_key_fixture, index_name, spec1):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_sparse_index(self, index_name, spec1):
+        pc = PineconeAsyncio()
 
         await pc.create_index(
             name=index_name, spec=spec1, metric=Metric.DOTPRODUCT, vector_type=VectorType.SPARSE
@@ -130,8 +128,8 @@ class TestAsyncioCreateIndex:
         assert desc.vector_type == "sparse"
         assert desc.metric == "dotproduct"
 
-    async def test_create_with_deletion_protection(self, api_key_fixture, index_name, spec1):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_with_deletion_protection(self, index_name, spec1):
+        pc = PineconeAsyncio()
 
         await pc.create_index(
             name=index_name,

--- a/tests/integration/control_asyncio/test_create_index.py
+++ b/tests/integration/control_asyncio/test_create_index.py
@@ -31,6 +31,7 @@ class TestAsyncioCreateIndex:
         assert desc.metric == "cosine"
         assert desc.deletion_protection == "disabled"  # default value
         assert desc.vector_type == "dense"  # default value
+        await pc.close()
 
     async def test_create_skip_wait(self, index_name, spec1):
         pc = PineconeAsyncio()
@@ -38,13 +39,14 @@ class TestAsyncioCreateIndex:
         assert resp.name == index_name
         assert resp.dimension == 10
         assert resp.metric == "cosine"
+        await pc.close()
 
     async def test_create_infinite_wait(self, index_name, spec1):
-        pc = PineconeAsyncio()
-        resp = await pc.create_index(name=index_name, dimension=10, spec=spec1, timeout=None)
-        assert resp.name == index_name
-        assert resp.dimension == 10
-        assert resp.metric == "cosine"
+        async with PineconeAsyncio() as pc:
+            resp = await pc.create_index(name=index_name, dimension=10, spec=spec1, timeout=None)
+            assert resp.name == index_name
+            assert resp.dimension == 10
+            assert resp.metric == "cosine"
 
     @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
     async def test_create_default_index_with_metric(self, index_name, metric, spec1):
@@ -57,6 +59,7 @@ class TestAsyncioCreateIndex:
         else:
             assert desc.metric == metric.value
         assert desc.vector_type == "dense"
+        await pc.close()
 
     @pytest.mark.parametrize(
         "metric_enum,vector_type_enum,dim,tags",
@@ -93,6 +96,7 @@ class TestAsyncioCreateIndex:
         assert desc.spec.serverless.region == "us-east-1"
         if tags:
             assert desc.tags.to_dict() == tags
+        await pc.close()
 
     @pytest.mark.parametrize("metric", ["cosine", "euclidean", "dotproduct"])
     async def test_create_dense_index_with_metric(self, index_name, spec1, metric):
@@ -105,6 +109,7 @@ class TestAsyncioCreateIndex:
         desc = await pc.describe_index(index_name)
         assert desc.metric == metric
         assert desc.vector_type == "dense"
+        await pc.close()
 
     async def test_create_with_optional_tags(self, index_name, spec1):
         pc = PineconeAsyncio()
@@ -114,6 +119,7 @@ class TestAsyncioCreateIndex:
 
         desc = await pc.describe_index(index_name)
         assert desc.tags.to_dict() == tags
+        await pc.close()
 
     async def test_create_sparse_index(self, index_name, spec1):
         pc = PineconeAsyncio()
@@ -127,6 +133,7 @@ class TestAsyncioCreateIndex:
         assert desc.dimension is None
         assert desc.vector_type == "sparse"
         assert desc.metric == "dotproduct"
+        await pc.close()
 
     async def test_create_with_deletion_protection(self, index_name, spec1):
         pc = PineconeAsyncio()
@@ -152,3 +159,4 @@ class TestAsyncioCreateIndex:
 
         desc2 = await pc.describe_index(index_name)
         assert desc2.deletion_protection == "disabled"
+        await pc.close()

--- a/tests/integration/control_asyncio/test_create_index_api_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_api_errors.py
@@ -9,30 +9,33 @@ class TestCreateIndexApiErrorCases:
         create_sl_index_params["name"] = "Invalid-name"
         with pytest.raises(PineconeApiException):
             await pc.create_index(**create_sl_index_params)
+        await pc.close()
 
     async def test_create_index_invalid_metric(self, create_sl_index_params):
         pc = PineconeAsyncio()
         create_sl_index_params["metric"] = "invalid"
         with pytest.raises(PineconeApiValueError):
             await pc.create_index(**create_sl_index_params)
+        await pc.close()
 
     async def test_create_index_with_invalid_neg_dimension(self, create_sl_index_params):
         pc = PineconeAsyncio()
         create_sl_index_params["dimension"] = -1
         with pytest.raises(PineconeApiValueError):
             await pc.create_index(**create_sl_index_params)
+        await pc.close()
 
     async def test_create_index_that_already_exists(self, create_sl_index_params):
-        pc = PineconeAsyncio()
-        await pc.create_index(**create_sl_index_params)
-        with pytest.raises(PineconeApiException):
+        async with PineconeAsyncio() as pc:
             await pc.create_index(**create_sl_index_params)
+            with pytest.raises(PineconeApiException):
+                await pc.create_index(**create_sl_index_params)
 
     @pytest.mark.skip(reason="Bug filed https://app.asana.com/0/1205078872348810/1205917627868143")
     async def test_create_index_w_incompatible_options(self, create_sl_index_params):
-        pc = PineconeAsyncio()
-        create_sl_index_params["pod_type"] = "p1.x2"
-        create_sl_index_params["environment"] = "us-east1-gcp"
-        create_sl_index_params["replicas"] = 2
-        with pytest.raises(PineconeApiException):
-            await pc.create_index(**create_sl_index_params)
+        async with PineconeAsyncio() as pc:
+            create_sl_index_params["pod_type"] = "p1.x2"
+            create_sl_index_params["environment"] = "us-east1-gcp"
+            create_sl_index_params["replicas"] = 2
+            with pytest.raises(PineconeApiException):
+                await pc.create_index(**create_sl_index_params)

--- a/tests/integration/control_asyncio/test_create_index_api_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_api_errors.py
@@ -1,0 +1,42 @@
+import pytest
+from pinecone import PineconeApiException, PineconeApiValueError, PineconeAsyncio
+
+
+@pytest.mark.asyncio
+class TestCreateIndexApiErrorCases:
+    async def test_create_index_with_invalid_name(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        create_sl_index_params["name"] = "Invalid-name"
+        with pytest.raises(PineconeApiException):
+            await pc.create_index(**create_sl_index_params)
+
+    async def test_create_index_invalid_metric(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        create_sl_index_params["metric"] = "invalid"
+        with pytest.raises(PineconeApiValueError):
+            await pc.create_index(**create_sl_index_params)
+
+    async def test_create_index_with_invalid_neg_dimension(
+        self, api_key_fixture, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        create_sl_index_params["dimension"] = -1
+        with pytest.raises(PineconeApiValueError):
+            await pc.create_index(**create_sl_index_params)
+
+    async def test_create_index_that_already_exists(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        await pc.create_index(**create_sl_index_params)
+        with pytest.raises(PineconeApiException):
+            await pc.create_index(**create_sl_index_params)
+
+    @pytest.mark.skip(reason="Bug filed https://app.asana.com/0/1205078872348810/1205917627868143")
+    async def test_create_index_w_incompatible_options(
+        self, api_key_fixture, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        create_sl_index_params["pod_type"] = "p1.x2"
+        create_sl_index_params["environment"] = "us-east1-gcp"
+        create_sl_index_params["replicas"] = 2
+        with pytest.raises(PineconeApiException):
+            await pc.create_index(**create_sl_index_params)

--- a/tests/integration/control_asyncio/test_create_index_api_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_api_errors.py
@@ -4,37 +4,33 @@ from pinecone import PineconeApiException, PineconeApiValueError, PineconeAsynci
 
 @pytest.mark.asyncio
 class TestCreateIndexApiErrorCases:
-    async def test_create_index_with_invalid_name(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_with_invalid_name(self, create_sl_index_params):
+        pc = PineconeAsyncio()
         create_sl_index_params["name"] = "Invalid-name"
         with pytest.raises(PineconeApiException):
             await pc.create_index(**create_sl_index_params)
 
-    async def test_create_index_invalid_metric(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_invalid_metric(self, create_sl_index_params):
+        pc = PineconeAsyncio()
         create_sl_index_params["metric"] = "invalid"
         with pytest.raises(PineconeApiValueError):
             await pc.create_index(**create_sl_index_params)
 
-    async def test_create_index_with_invalid_neg_dimension(
-        self, api_key_fixture, create_sl_index_params
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_with_invalid_neg_dimension(self, create_sl_index_params):
+        pc = PineconeAsyncio()
         create_sl_index_params["dimension"] = -1
         with pytest.raises(PineconeApiValueError):
             await pc.create_index(**create_sl_index_params)
 
-    async def test_create_index_that_already_exists(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_that_already_exists(self, create_sl_index_params):
+        pc = PineconeAsyncio()
         await pc.create_index(**create_sl_index_params)
         with pytest.raises(PineconeApiException):
             await pc.create_index(**create_sl_index_params)
 
     @pytest.mark.skip(reason="Bug filed https://app.asana.com/0/1205078872348810/1205917627868143")
-    async def test_create_index_w_incompatible_options(
-        self, api_key_fixture, create_sl_index_params
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_w_incompatible_options(self, create_sl_index_params):
+        pc = PineconeAsyncio()
         create_sl_index_params["pod_type"] = "p1.x2"
         create_sl_index_params["environment"] = "us-east1-gcp"
         create_sl_index_params["replicas"] = 2

--- a/tests/integration/control_asyncio/test_create_index_for_model.py
+++ b/tests/integration/control_asyncio/test_create_index_for_model.py
@@ -1,0 +1,77 @@
+import pytest
+from pinecone import PineconeAsyncio, EmbedModel, CloudProvider, AwsRegion, IndexEmbed, Metric
+
+
+@pytest.mark.asyncio
+class TestCreateIndexForModel:
+    @pytest.mark.parametrize(
+        "model_val,cloud_val,region_val",
+        [
+            ("multilingual-e5-large", "aws", "us-east-1"),
+            (EmbedModel.Multilingual_E5_Large, CloudProvider.AWS, AwsRegion.US_EAST_1),
+            (EmbedModel.Pinecone_Sparse_English_V0, CloudProvider.AWS, AwsRegion.US_EAST_1),
+        ],
+    )
+    async def test_create_index_for_model(
+        self, api_key_fixture, model_val, index_name, cloud_val, region_val
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        field_map = {"text": "my-sample-text"}
+        index = await pc.create_index_for_model(
+            name=index_name,
+            cloud=cloud_val,
+            region=region_val,
+            embed={"model": model_val, "field_map": field_map},
+            timeout=-1,
+        )
+        assert index.name == index_name
+        assert index.spec.serverless.cloud == "aws"
+        assert index.spec.serverless.region == "us-east-1"
+        assert index.embed.field_map == field_map
+        if isinstance(model_val, EmbedModel):
+            assert index.embed.model == model_val.value
+        else:
+            assert index.embed.model == model_val
+
+    async def test_create_index_for_model_with_index_embed_obj(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        field_map = {"text": "my-sample-text"}
+        index = await pc.create_index_for_model(
+            name=index_name,
+            cloud=CloudProvider.AWS,
+            region=AwsRegion.US_EAST_1,
+            embed=IndexEmbed(
+                metric=Metric.COSINE, model=EmbedModel.Multilingual_E5_Large, field_map=field_map
+            ),
+            timeout=-1,
+        )
+        assert index.name == index_name
+        assert index.spec.serverless.cloud == "aws"
+        assert index.spec.serverless.region == "us-east-1"
+        assert index.embed.field_map == field_map
+        assert index.embed.model == EmbedModel.Multilingual_E5_Large.value
+
+    @pytest.mark.parametrize(
+        "model_val,metric_val",
+        [(EmbedModel.Multilingual_E5_Large, Metric.COSINE), ("multilingual-e5-large", "cosine")],
+    )
+    async def test_create_index_for_model_with_index_embed_dict(
+        self, api_key_fixture, index_name, model_val, metric_val
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        field_map = {"text": "my-sample-text"}
+        index = await pc.create_index_for_model(
+            name=index_name,
+            cloud=CloudProvider.AWS,
+            region=AwsRegion.US_EAST_1,
+            embed={"metric": metric_val, "field_map": field_map, "model": model_val},
+            timeout=-1,
+        )
+        assert index.name == index_name
+        assert index.spec.serverless.cloud == "aws"
+        assert index.spec.serverless.region == "us-east-1"
+        assert index.embed.field_map == field_map
+        assert index.embed.model == EmbedModel.Multilingual_E5_Large.value

--- a/tests/integration/control_asyncio/test_create_index_for_model.py
+++ b/tests/integration/control_asyncio/test_create_index_for_model.py
@@ -12,10 +12,8 @@ class TestCreateIndexForModel:
             (EmbedModel.Pinecone_Sparse_English_V0, CloudProvider.AWS, AwsRegion.US_EAST_1),
         ],
     )
-    async def test_create_index_for_model(
-        self, api_key_fixture, model_val, index_name, cloud_val, region_val
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_for_model(self, model_val, index_name, cloud_val, region_val):
+        pc = PineconeAsyncio()
 
         field_map = {"text": "my-sample-text"}
         index = await pc.create_index_for_model(
@@ -34,8 +32,8 @@ class TestCreateIndexForModel:
         else:
             assert index.embed.model == model_val
 
-    async def test_create_index_for_model_with_index_embed_obj(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_for_model_with_index_embed_obj(self, index_name):
+        pc = PineconeAsyncio()
 
         field_map = {"text": "my-sample-text"}
         index = await pc.create_index_for_model(
@@ -58,9 +56,9 @@ class TestCreateIndexForModel:
         [(EmbedModel.Multilingual_E5_Large, Metric.COSINE), ("multilingual-e5-large", "cosine")],
     )
     async def test_create_index_for_model_with_index_embed_dict(
-        self, api_key_fixture, index_name, model_val, metric_val
+        self, index_name, model_val, metric_val
     ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+        pc = PineconeAsyncio()
 
         field_map = {"text": "my-sample-text"}
         index = await pc.create_index_for_model(

--- a/tests/integration/control_asyncio/test_create_index_for_model.py
+++ b/tests/integration/control_asyncio/test_create_index_for_model.py
@@ -31,6 +31,7 @@ class TestCreateIndexForModel:
             assert index.embed.model == model_val.value
         else:
             assert index.embed.model == model_val
+        await pc.close()
 
     async def test_create_index_for_model_with_index_embed_obj(self, index_name):
         pc = PineconeAsyncio()
@@ -50,6 +51,7 @@ class TestCreateIndexForModel:
         assert index.spec.serverless.region == "us-east-1"
         assert index.embed.field_map == field_map
         assert index.embed.model == EmbedModel.Multilingual_E5_Large.value
+        await pc.close()
 
     @pytest.mark.parametrize(
         "model_val,metric_val",
@@ -73,3 +75,4 @@ class TestCreateIndexForModel:
         assert index.spec.serverless.region == "us-east-1"
         assert index.embed.field_map == field_map
         assert index.embed.model == EmbedModel.Multilingual_E5_Large.value
+        await pc.close()

--- a/tests/integration/control_asyncio/test_create_index_for_model_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_for_model_errors.py
@@ -12,8 +12,8 @@ from pinecone import (
 
 @pytest.mark.asyncio
 class TestCreateIndexForModelErrors:
-    async def test_create_index_for_model_with_invalid_model(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_for_model_with_invalid_model(self, index_name):
+        pc = PineconeAsyncio()
 
         with pytest.raises(PineconeApiException) as e:
             await pc.create_index_for_model(
@@ -29,8 +29,8 @@ class TestCreateIndexForModelErrors:
             )
         assert "Model invalid-model not found." in str(e.value)
 
-    async def test_invalid_cloud(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_invalid_cloud(self, index_name):
+        pc = PineconeAsyncio()
 
         with pytest.raises(PineconeApiValueError) as e:
             await pc.create_index_for_model(
@@ -46,8 +46,8 @@ class TestCreateIndexForModelErrors:
             )
         assert "Invalid value for `cloud`" in str(e.value)
 
-    async def test_invalid_region(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_invalid_region(self, index_name):
+        pc = PineconeAsyncio()
 
         with pytest.raises(PineconeApiException) as e:
             await pc.create_index_for_model(
@@ -63,8 +63,8 @@ class TestCreateIndexForModelErrors:
             )
         assert "invalid-region not found" in str(e.value)
 
-    async def test_create_index_for_model_with_invalid_field_map(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_for_model_with_invalid_field_map(self, index_name):
+        pc = PineconeAsyncio()
 
         with pytest.raises(PineconeApiException) as e:
             await pc.create_index_for_model(
@@ -80,8 +80,8 @@ class TestCreateIndexForModelErrors:
             )
         assert "Missing required key 'text'" in str(e.value)
 
-    async def test_create_index_for_model_with_invalid_metric(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_for_model_with_invalid_metric(self, index_name):
+        pc = PineconeAsyncio()
 
         with pytest.raises(PineconeApiValueError) as e:
             await pc.create_index_for_model(
@@ -97,8 +97,8 @@ class TestCreateIndexForModelErrors:
             )
         assert "Invalid value for `metric`" in str(e.value)
 
-    async def test_create_index_for_model_with_missing_name(self, api_key_fixture):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_for_model_with_missing_name(self):
+        pc = PineconeAsyncio()
 
         with pytest.raises(TypeError) as e:
             await pc.create_index_for_model(
@@ -113,8 +113,8 @@ class TestCreateIndexForModelErrors:
             )
         assert "name" in str(e.value)
 
-    async def test_create_index_with_missing_model(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_with_missing_model(self, index_name):
+        pc = PineconeAsyncio()
 
         with pytest.raises(ValueError) as e:
             await pc.create_index_for_model(
@@ -126,8 +126,8 @@ class TestCreateIndexForModelErrors:
             )
         assert "model is required" in str(e.value)
 
-    async def test_create_index_with_missing_field_map(self, api_key_fixture, index_name):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_with_missing_field_map(self, index_name):
+        pc = PineconeAsyncio()
 
         with pytest.raises(ValueError) as e:
             await pc.create_index_for_model(

--- a/tests/integration/control_asyncio/test_create_index_for_model_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_for_model_errors.py
@@ -1,0 +1,140 @@
+import pytest
+from pinecone import (
+    EmbedModel,
+    CloudProvider,
+    AwsRegion,
+    Metric,
+    PineconeApiException,
+    PineconeApiValueError,
+    PineconeAsyncio,
+)
+
+
+@pytest.mark.asyncio
+class TestCreateIndexForModelErrors:
+    async def test_create_index_for_model_with_invalid_model(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(PineconeApiException) as e:
+            await pc.create_index_for_model(
+                name=index_name,
+                cloud=CloudProvider.AWS,
+                region=AwsRegion.US_EAST_1,
+                embed={
+                    "model": "invalid-model",
+                    "field_map": {"text": "my-sample-text"},
+                    "metric": Metric.COSINE,
+                },
+                timeout=-1,
+            )
+        assert "Model invalid-model not found." in str(e.value)
+
+    async def test_invalid_cloud(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(PineconeApiValueError) as e:
+            await pc.create_index_for_model(
+                name=index_name,
+                cloud="invalid-cloud",
+                region=AwsRegion.US_EAST_1,
+                embed={
+                    "model": EmbedModel.Multilingual_E5_Large,
+                    "field_map": {"text": "my-sample-text"},
+                    "metric": Metric.COSINE,
+                },
+                timeout=-1,
+            )
+        assert "Invalid value for `cloud`" in str(e.value)
+
+    async def test_invalid_region(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(PineconeApiException) as e:
+            await pc.create_index_for_model(
+                name=index_name,
+                cloud=CloudProvider.AWS,
+                region="invalid-region",
+                embed={
+                    "model": EmbedModel.Multilingual_E5_Large,
+                    "field_map": {"text": "my-sample-text"},
+                    "metric": Metric.COSINE,
+                },
+                timeout=-1,
+            )
+        assert "invalid-region not found" in str(e.value)
+
+    async def test_create_index_for_model_with_invalid_field_map(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(PineconeApiException) as e:
+            await pc.create_index_for_model(
+                name=index_name,
+                cloud=CloudProvider.AWS,
+                region=AwsRegion.US_EAST_1,
+                embed={
+                    "model": EmbedModel.Multilingual_E5_Large,
+                    "field_map": {"invalid_field": "my-sample-text"},
+                    "metric": Metric.COSINE,
+                },
+                timeout=-1,
+            )
+        assert "Missing required key 'text'" in str(e.value)
+
+    async def test_create_index_for_model_with_invalid_metric(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(PineconeApiValueError) as e:
+            await pc.create_index_for_model(
+                name=index_name,
+                cloud=CloudProvider.AWS,
+                region=AwsRegion.US_EAST_1,
+                embed={
+                    "model": EmbedModel.Multilingual_E5_Large,
+                    "field_map": {"text": "my-sample-text"},
+                    "metric": "invalid-metric",
+                },
+                timeout=-1,
+            )
+        assert "Invalid value for `metric`" in str(e.value)
+
+    async def test_create_index_for_model_with_missing_name(self, api_key_fixture):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(TypeError) as e:
+            await pc.create_index_for_model(
+                cloud=CloudProvider.AWS,
+                region=AwsRegion.US_EAST_1,
+                embed={
+                    "model": EmbedModel.Multilingual_E5_Large,
+                    "field_map": {"text": "my-sample-text"},
+                    "metric": Metric.EUCLIDEAN,
+                },
+                timeout=-1,
+            )
+        assert "name" in str(e.value)
+
+    async def test_create_index_with_missing_model(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(ValueError) as e:
+            await pc.create_index_for_model(
+                name=index_name,
+                cloud=CloudProvider.AWS,
+                region=AwsRegion.US_EAST_1,
+                embed={"field_map": {"text": "my-sample-text"}, "metric": Metric.COSINE},
+                timeout=-1,
+            )
+        assert "model is required" in str(e.value)
+
+    async def test_create_index_with_missing_field_map(self, api_key_fixture, index_name):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        with pytest.raises(ValueError) as e:
+            await pc.create_index_for_model(
+                name=index_name,
+                cloud=CloudProvider.AWS,
+                region=AwsRegion.US_EAST_1,
+                embed={"model": EmbedModel.Multilingual_E5_Large, "metric": Metric.COSINE},
+                timeout=-1,
+            )
+        assert "field_map is required" in str(e.value)

--- a/tests/integration/control_asyncio/test_create_index_for_model_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_for_model_errors.py
@@ -28,6 +28,7 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "Model invalid-model not found." in str(e.value)
+        await pc.close()
 
     async def test_invalid_cloud(self, index_name):
         pc = PineconeAsyncio()
@@ -45,6 +46,7 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "Invalid value for `cloud`" in str(e.value)
+        await pc.close()
 
     async def test_invalid_region(self, index_name):
         pc = PineconeAsyncio()
@@ -62,6 +64,7 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "invalid-region not found" in str(e.value)
+        await pc.close()
 
     async def test_create_index_for_model_with_invalid_field_map(self, index_name):
         pc = PineconeAsyncio()
@@ -79,6 +82,7 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "Missing required key 'text'" in str(e.value)
+        await pc.close()
 
     async def test_create_index_for_model_with_invalid_metric(self, index_name):
         pc = PineconeAsyncio()
@@ -96,6 +100,7 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "Invalid value for `metric`" in str(e.value)
+        await pc.close()
 
     async def test_create_index_for_model_with_missing_name(self):
         pc = PineconeAsyncio()
@@ -112,6 +117,7 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "name" in str(e.value)
+        await pc.close()
 
     async def test_create_index_with_missing_model(self, index_name):
         pc = PineconeAsyncio()
@@ -125,6 +131,7 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "model is required" in str(e.value)
+        await pc.close()
 
     async def test_create_index_with_missing_field_map(self, index_name):
         pc = PineconeAsyncio()
@@ -138,3 +145,4 @@ class TestCreateIndexForModelErrors:
                 timeout=-1,
             )
         assert "field_map is required" in str(e.value)
+        await pc.close()

--- a/tests/integration/control_asyncio/test_create_index_timeouts.py
+++ b/tests/integration/control_asyncio/test_create_index_timeouts.py
@@ -4,8 +4,8 @@ import pytest
 
 @pytest.mark.asyncio
 class TestCreateIndexWithTimeout:
-    async def test_create_index_default_timeout(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_default_timeout(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["timeout"] = None
         await pc.create_index(**create_sl_index_params)
@@ -13,8 +13,8 @@ class TestCreateIndexWithTimeout:
         desc = await pc.describe_index(create_sl_index_params["name"])
         assert desc.status.ready == True
 
-    async def test_create_index_when_timeout_set(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_when_timeout_set(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["timeout"] = (
             1000  # effectively infinite, but different code path from None
@@ -23,10 +23,8 @@ class TestCreateIndexWithTimeout:
         desc = await pc.describe_index(create_sl_index_params["name"])
         assert desc.status.ready == True
 
-    async def test_create_index_with_negative_timeout(
-        self, api_key_fixture, create_sl_index_params
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_with_negative_timeout(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["timeout"] = -1
         await pc.create_index(**create_sl_index_params)

--- a/tests/integration/control_asyncio/test_create_index_timeouts.py
+++ b/tests/integration/control_asyncio/test_create_index_timeouts.py
@@ -12,6 +12,7 @@ class TestCreateIndexWithTimeout:
         # Waits infinitely for index to be ready
         desc = await pc.describe_index(create_sl_index_params["name"])
         assert desc.status.ready == True
+        await pc.close()
 
     async def test_create_index_when_timeout_set(self, create_sl_index_params):
         pc = PineconeAsyncio()
@@ -22,6 +23,7 @@ class TestCreateIndexWithTimeout:
         await pc.create_index(**create_sl_index_params)
         desc = await pc.describe_index(create_sl_index_params["name"])
         assert desc.status.ready == True
+        await pc.close()
 
     async def test_create_index_with_negative_timeout(self, create_sl_index_params):
         pc = PineconeAsyncio()
@@ -31,3 +33,4 @@ class TestCreateIndexWithTimeout:
         desc = await pc.describe_index(create_sl_index_params["name"])
         # Returns immediately without waiting for index to be ready
         assert desc.status.ready in [False, True]
+        await pc.close()

--- a/tests/integration/control_asyncio/test_create_index_timeouts.py
+++ b/tests/integration/control_asyncio/test_create_index_timeouts.py
@@ -1,0 +1,35 @@
+from pinecone import PineconeAsyncio
+import pytest
+
+
+@pytest.mark.asyncio
+class TestCreateIndexWithTimeout:
+    async def test_create_index_default_timeout(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["timeout"] = None
+        await pc.create_index(**create_sl_index_params)
+        # Waits infinitely for index to be ready
+        desc = await pc.describe_index(create_sl_index_params["name"])
+        assert desc.status.ready == True
+
+    async def test_create_index_when_timeout_set(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["timeout"] = (
+            1000  # effectively infinite, but different code path from None
+        )
+        await pc.create_index(**create_sl_index_params)
+        desc = await pc.describe_index(create_sl_index_params["name"])
+        assert desc.status.ready == True
+
+    async def test_create_index_with_negative_timeout(
+        self, api_key_fixture, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["timeout"] = -1
+        await pc.create_index(**create_sl_index_params)
+        desc = await pc.describe_index(create_sl_index_params["name"])
+        # Returns immediately without waiting for index to be ready
+        assert desc.status.ready in [False, True]

--- a/tests/integration/control_asyncio/test_create_index_type_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_type_errors.py
@@ -4,19 +4,15 @@ from pinecone import PineconeApiException, PineconeApiTypeError, PineconeAsyncio
 
 @pytest.mark.asyncio
 class TestCreateIndexTypeErrorCases:
-    async def test_create_index_with_invalid_str_dimension(
-        self, api_key_fixture, create_sl_index_params
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_with_invalid_str_dimension(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["dimension"] = "10"
         with pytest.raises(PineconeApiTypeError):
             await pc.create_index(**create_sl_index_params)
 
-    async def test_create_index_with_missing_dimension(
-        self, api_key_fixture, create_sl_index_params
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_index_with_missing_dimension(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         del create_sl_index_params["dimension"]
         with pytest.raises(PineconeApiException):

--- a/tests/integration/control_asyncio/test_create_index_type_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_type_errors.py
@@ -1,0 +1,23 @@
+import pytest
+from pinecone import PineconeApiException, PineconeApiTypeError, PineconeAsyncio
+
+
+@pytest.mark.asyncio
+class TestCreateIndexTypeErrorCases:
+    async def test_create_index_with_invalid_str_dimension(
+        self, api_key_fixture, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["dimension"] = "10"
+        with pytest.raises(PineconeApiTypeError):
+            await pc.create_index(**create_sl_index_params)
+
+    async def test_create_index_with_missing_dimension(
+        self, api_key_fixture, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        del create_sl_index_params["dimension"]
+        with pytest.raises(PineconeApiException):
+            await pc.create_index(**create_sl_index_params)

--- a/tests/integration/control_asyncio/test_create_index_type_errors.py
+++ b/tests/integration/control_asyncio/test_create_index_type_errors.py
@@ -10,6 +10,7 @@ class TestCreateIndexTypeErrorCases:
         create_sl_index_params["dimension"] = "10"
         with pytest.raises(PineconeApiTypeError):
             await pc.create_index(**create_sl_index_params)
+        await pc.close()
 
     async def test_create_index_with_missing_dimension(self, create_sl_index_params):
         pc = PineconeAsyncio()
@@ -17,3 +18,4 @@ class TestCreateIndexTypeErrorCases:
         del create_sl_index_params["dimension"]
         with pytest.raises(PineconeApiException):
             await pc.create_index(**create_sl_index_params)
+        await pc.close()

--- a/tests/integration/control_asyncio/test_describe_index.py
+++ b/tests/integration/control_asyncio/test_describe_index.py
@@ -4,10 +4,8 @@ from pinecone import IndexModel, PineconeAsyncio
 
 @pytest.mark.asyncio
 class TestDescribeIndex:
-    async def test_describe_index_when_ready(
-        self, api_key_fixture, ready_sl_index, create_sl_index_params
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_describe_index_when_ready(self, ready_sl_index, create_sl_index_params):
+        pc = PineconeAsyncio()
         description = await pc.describe_index(ready_sl_index)
 
         assert isinstance(description, IndexModel)
@@ -30,10 +28,8 @@ class TestDescribeIndex:
         assert description.status.state == "Ready"
         assert description.status.ready == True
 
-    async def test_describe_index_when_not_ready(
-        self, api_key_fixture, notready_sl_index, create_sl_index_params
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_describe_index_when_not_ready(self, notready_sl_index, create_sl_index_params):
+        pc = PineconeAsyncio()
         description = await pc.describe_index(notready_sl_index)
 
         assert isinstance(description, IndexModel)

--- a/tests/integration/control_asyncio/test_describe_index.py
+++ b/tests/integration/control_asyncio/test_describe_index.py
@@ -27,6 +27,7 @@ class TestDescribeIndex:
 
         assert description.status.state == "Ready"
         assert description.status.ready == True
+        await pc.close()
 
     async def test_describe_index_when_not_ready(self, notready_sl_index, create_sl_index_params):
         pc = PineconeAsyncio()
@@ -48,3 +49,4 @@ class TestDescribeIndex:
         assert isinstance(description.host, str)
         assert description.host != ""
         assert notready_sl_index in description.host
+        await pc.close()

--- a/tests/integration/control_asyncio/test_describe_index.py
+++ b/tests/integration/control_asyncio/test_describe_index.py
@@ -1,0 +1,54 @@
+import pytest
+from pinecone import IndexModel, PineconeAsyncio
+
+
+@pytest.mark.asyncio
+class TestDescribeIndex:
+    async def test_describe_index_when_ready(
+        self, api_key_fixture, ready_sl_index, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        description = await pc.describe_index(ready_sl_index)
+
+        assert isinstance(description, IndexModel)
+        assert description.name == ready_sl_index
+        assert description.dimension == create_sl_index_params["dimension"]
+        assert description.metric == create_sl_index_params["metric"]
+        assert (
+            description.spec.serverless["cloud"]
+            == create_sl_index_params["spec"]["serverless"]["cloud"]
+        )
+        assert (
+            description.spec.serverless["region"]
+            == create_sl_index_params["spec"]["serverless"]["region"]
+        )
+
+        assert isinstance(description.host, str)
+        assert description.host != ""
+        assert ready_sl_index in description.host
+
+        assert description.status.state == "Ready"
+        assert description.status.ready == True
+
+    async def test_describe_index_when_not_ready(
+        self, api_key_fixture, notready_sl_index, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+        description = await pc.describe_index(notready_sl_index)
+
+        assert isinstance(description, IndexModel)
+        assert description.name == notready_sl_index
+        assert description.dimension == create_sl_index_params["dimension"]
+        assert description.metric == create_sl_index_params["metric"]
+        assert (
+            description.spec.serverless["cloud"]
+            == create_sl_index_params["spec"]["serverless"]["cloud"]
+        )
+        assert (
+            description.spec.serverless["region"]
+            == create_sl_index_params["spec"]["serverless"]["region"]
+        )
+
+        assert isinstance(description.host, str)
+        assert description.host != ""
+        assert notready_sl_index in description.host

--- a/tests/integration/control_asyncio/test_has_index.py
+++ b/tests/integration/control_asyncio/test_has_index.py
@@ -1,0 +1,27 @@
+import pytest
+from tests.integration.helpers import random_string
+from pinecone import PineconeAsyncio
+
+
+@pytest.mark.asyncio
+class TestHasIndex:
+    async def test_index_exists_success(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        name = create_sl_index_params["name"]
+        await pc.create_index(**create_sl_index_params)
+        has_index = await pc.has_index(name)
+        assert has_index == True
+
+    async def test_index_does_not_exist(self, api_key_fixture):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        name = random_string(8)
+        has_index = await pc.has_index(name)
+        assert has_index == False
+
+    async def test_has_index_with_null_index_name(self, api_key_fixture):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        has_index = await pc.has_index("")
+        assert has_index == False

--- a/tests/integration/control_asyncio/test_has_index.py
+++ b/tests/integration/control_asyncio/test_has_index.py
@@ -12,6 +12,7 @@ class TestHasIndex:
         await pc.create_index(**create_sl_index_params)
         has_index = await pc.has_index(name)
         assert has_index == True
+        await pc.close()
 
     async def test_index_does_not_exist(self):
         pc = PineconeAsyncio()
@@ -19,9 +20,11 @@ class TestHasIndex:
         name = random_string(8)
         has_index = await pc.has_index(name)
         assert has_index == False
+        await pc.close()
 
     async def test_has_index_with_null_index_name(self):
         pc = PineconeAsyncio()
 
         has_index = await pc.has_index("")
         assert has_index == False
+        await pc.close()

--- a/tests/integration/control_asyncio/test_has_index.py
+++ b/tests/integration/control_asyncio/test_has_index.py
@@ -5,23 +5,23 @@ from pinecone import PineconeAsyncio
 
 @pytest.mark.asyncio
 class TestHasIndex:
-    async def test_index_exists_success(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_index_exists_success(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         name = create_sl_index_params["name"]
         await pc.create_index(**create_sl_index_params)
         has_index = await pc.has_index(name)
         assert has_index == True
 
-    async def test_index_does_not_exist(self, api_key_fixture):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_index_does_not_exist(self):
+        pc = PineconeAsyncio()
 
         name = random_string(8)
         has_index = await pc.has_index(name)
         assert has_index == False
 
-    async def test_has_index_with_null_index_name(self, api_key_fixture):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_has_index_with_null_index_name(self):
+        pc = PineconeAsyncio()
 
         has_index = await pc.has_index("")
         assert has_index == False

--- a/tests/integration/control_asyncio/test_list_indexes.py
+++ b/tests/integration/control_asyncio/test_list_indexes.py
@@ -5,9 +5,9 @@ from pinecone import IndexModel, PineconeAsyncio
 @pytest.mark.asyncio
 class TestListIndexes:
     async def test_list_indexes_includes_ready_indexes(
-        self, api_key_fixture, ready_sl_index, create_sl_index_params
+        self, ready_sl_index, create_sl_index_params
     ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+        pc = PineconeAsyncio()
 
         list_response = await pc.list_indexes()
         assert len(list_response.indexes) != 0
@@ -21,10 +21,8 @@ class TestListIndexes:
         assert created_index.metric == create_sl_index_params["metric"]
         assert ready_sl_index in created_index.host
 
-    async def test_list_indexes_includes_not_ready_indexes(
-        self, api_key_fixture, notready_sl_index
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_list_indexes_includes_not_ready_indexes(self, notready_sl_index):
+        pc = PineconeAsyncio()
 
         list_response = await pc.list_indexes()
         assert len(list_response.indexes) != 0

--- a/tests/integration/control_asyncio/test_list_indexes.py
+++ b/tests/integration/control_asyncio/test_list_indexes.py
@@ -1,0 +1,37 @@
+import pytest
+from pinecone import IndexModel, PineconeAsyncio
+
+
+@pytest.mark.asyncio
+class TestListIndexes:
+    async def test_list_indexes_includes_ready_indexes(
+        self, api_key_fixture, ready_sl_index, create_sl_index_params
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        list_response = await pc.list_indexes()
+        assert len(list_response.indexes) != 0
+        assert isinstance(list_response.indexes[0], IndexModel)
+
+        created_index = [index for index in list_response.indexes if index.name == ready_sl_index][
+            0
+        ]
+        assert created_index.name == ready_sl_index
+        assert created_index.dimension == create_sl_index_params["dimension"]
+        assert created_index.metric == create_sl_index_params["metric"]
+        assert ready_sl_index in created_index.host
+
+    async def test_list_indexes_includes_not_ready_indexes(
+        self, api_key_fixture, notready_sl_index
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        list_response = await pc.list_indexes()
+        assert len(list_response.indexes) != 0
+        assert isinstance(list_response.indexes[0], IndexModel)
+
+        created_index = [
+            index for index in list_response.indexes if index.name == notready_sl_index
+        ][0]
+        assert created_index.name == notready_sl_index
+        assert notready_sl_index in created_index.name

--- a/tests/integration/control_asyncio/test_list_indexes.py
+++ b/tests/integration/control_asyncio/test_list_indexes.py
@@ -20,6 +20,7 @@ class TestListIndexes:
         assert created_index.dimension == create_sl_index_params["dimension"]
         assert created_index.metric == create_sl_index_params["metric"]
         assert ready_sl_index in created_index.host
+        await pc.close()
 
     async def test_list_indexes_includes_not_ready_indexes(self, notready_sl_index):
         pc = PineconeAsyncio()
@@ -33,3 +34,4 @@ class TestListIndexes:
         ][0]
         assert created_index.name == notready_sl_index
         assert notready_sl_index in created_index.name
+        await pc.close()

--- a/tests/integration/control_asyncio/test_sparse_index.py
+++ b/tests/integration/control_asyncio/test_sparse_index.py
@@ -1,0 +1,86 @@
+import pytest
+from pinecone.exceptions import PineconeApiException
+from pinecone import PineconeAsyncio
+
+
+@pytest.mark.asyncio
+class TestSparseIndex:
+    async def test_create_sparse_index_with_metric(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["metric"] = "dotproduct"
+
+        create_sl_index_params["vector_type"] = "sparse"
+        del create_sl_index_params["dimension"]
+
+        await pc.create_index(**create_sl_index_params)
+        desc = await pc.describe_index(create_sl_index_params["name"])
+        assert desc.metric == "dotproduct"
+        assert desc.vector_type == "sparse"
+        assert desc.dimension is None
+        assert desc.deletion_protection == "disabled"  # default value
+
+        for i in await pc.list_indexes():
+            if i.name == create_sl_index_params["name"]:
+                assert i.metric == "dotproduct"
+                assert i.vector_type == "sparse"
+                assert i.dimension is None
+                assert i.deletion_protection == "disabled"
+                break
+            else:
+                assert i.vector_type is not None
+
+    async def test_sparse_index_deletion_protection(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["metric"] = "dotproduct"
+        create_sl_index_params["vector_type"] = "sparse"
+        create_sl_index_params["deletion_protection"] = "enabled"
+        del create_sl_index_params["dimension"]
+
+        await pc.create_index(**create_sl_index_params)
+
+        desc = await pc.describe_index(create_sl_index_params["name"])
+        assert desc.metric == "dotproduct"
+        assert desc.vector_type == "sparse"
+        assert desc.dimension is None
+        assert desc.deletion_protection == "enabled"
+
+        with pytest.raises(PineconeApiException) as e:
+            await pc.delete_index(create_sl_index_params["name"], -1)
+        assert "Deletion protection is enabled for this index" in str(e.value)
+
+        await pc.configure_index(create_sl_index_params["name"], deletion_protection="disabled")
+
+        desc2 = await pc.describe_index(create_sl_index_params["name"])
+        assert desc2.deletion_protection == "disabled"
+
+        await pc.delete_index(create_sl_index_params["name"], -1)
+
+
+@pytest.mark.asyncio
+class TestSparseIndexErrorCases:
+    async def test_exception_when_passing_dimension(self, api_key_fixture, create_sl_index_params):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["metric"] = "dotproduct"
+        create_sl_index_params["dimension"] = 10
+        create_sl_index_params["vector_type"] = "sparse"
+
+        with pytest.raises(ValueError) as e:
+            await pc.create_index(**create_sl_index_params)
+        assert "dimension should not be specified for sparse indexes" in str(e.value)
+
+    @pytest.mark.parametrize("metric", ["cosine", "euclidean"])
+    async def test_sparse_only_supports_dotproduct(
+        self, api_key_fixture, create_sl_index_params, metric
+    ):
+        pc = PineconeAsyncio(api_key=api_key_fixture)
+
+        create_sl_index_params["metric"] = metric
+        create_sl_index_params["vector_type"] = "sparse"
+        del create_sl_index_params["dimension"]
+
+        with pytest.raises(PineconeApiException) as e:
+            await pc.create_index(**create_sl_index_params)
+        assert "Sparse vector indexes must use the metric dotproduct." in str(e.value)

--- a/tests/integration/control_asyncio/test_sparse_index.py
+++ b/tests/integration/control_asyncio/test_sparse_index.py
@@ -5,8 +5,8 @@ from pinecone import PineconeAsyncio
 
 @pytest.mark.asyncio
 class TestSparseIndex:
-    async def test_create_sparse_index_with_metric(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_create_sparse_index_with_metric(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["metric"] = "dotproduct"
 
@@ -30,8 +30,8 @@ class TestSparseIndex:
             else:
                 assert i.vector_type is not None
 
-    async def test_sparse_index_deletion_protection(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_sparse_index_deletion_protection(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["metric"] = "dotproduct"
         create_sl_index_params["vector_type"] = "sparse"
@@ -60,8 +60,8 @@ class TestSparseIndex:
 
 @pytest.mark.asyncio
 class TestSparseIndexErrorCases:
-    async def test_exception_when_passing_dimension(self, api_key_fixture, create_sl_index_params):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_exception_when_passing_dimension(self, create_sl_index_params):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["metric"] = "dotproduct"
         create_sl_index_params["dimension"] = 10
@@ -72,10 +72,8 @@ class TestSparseIndexErrorCases:
         assert "dimension should not be specified for sparse indexes" in str(e.value)
 
     @pytest.mark.parametrize("metric", ["cosine", "euclidean"])
-    async def test_sparse_only_supports_dotproduct(
-        self, api_key_fixture, create_sl_index_params, metric
-    ):
-        pc = PineconeAsyncio(api_key=api_key_fixture)
+    async def test_sparse_only_supports_dotproduct(self, create_sl_index_params, metric):
+        pc = PineconeAsyncio()
 
         create_sl_index_params["metric"] = metric
         create_sl_index_params["vector_type"] = "sparse"

--- a/tests/integration/control_asyncio/test_sparse_index.py
+++ b/tests/integration/control_asyncio/test_sparse_index.py
@@ -29,6 +29,7 @@ class TestSparseIndex:
                 break
             else:
                 assert i.vector_type is not None
+        await pc.close()
 
     async def test_sparse_index_deletion_protection(self, create_sl_index_params):
         pc = PineconeAsyncio()
@@ -56,6 +57,7 @@ class TestSparseIndex:
         assert desc2.deletion_protection == "disabled"
 
         await pc.delete_index(create_sl_index_params["name"], -1)
+        await pc.close()
 
 
 @pytest.mark.asyncio
@@ -70,6 +72,7 @@ class TestSparseIndexErrorCases:
         with pytest.raises(ValueError) as e:
             await pc.create_index(**create_sl_index_params)
         assert "dimension should not be specified for sparse indexes" in str(e.value)
+        await pc.close()
 
     @pytest.mark.parametrize("metric", ["cosine", "euclidean"])
     async def test_sparse_only_supports_dotproduct(self, create_sl_index_params, metric):
@@ -82,3 +85,4 @@ class TestSparseIndexErrorCases:
         with pytest.raises(PineconeApiException) as e:
             await pc.create_index(**create_sl_index_params)
         assert "Sparse vector indexes must use the metric dotproduct." in str(e.value)
+        await pc.close()

--- a/tests/integration/data_asyncio/test_list.py
+++ b/tests/integration/data_asyncio/test_list.py
@@ -6,8 +6,8 @@ from ..helpers import random_string, embedding_values
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("target_namespace", [random_string(20)])
-async def test_list(pc, index_host, dimension, target_namespace):
-    asyncio_idx = build_asyncioindex_client(pc, index_host)
+async def test_list(index_host, dimension, target_namespace):
+    asyncio_idx = build_asyncioindex_client(index_host)
 
     await asyncio_idx.upsert(
         vectors=[

--- a/tests/integration/data_asyncio/test_query.py
+++ b/tests/integration/data_asyncio/test_query.py
@@ -7,8 +7,8 @@ from ..helpers import random_string, embedding_values
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("target_namespace", [random_string(20)])
-async def test_query(pc, index_host, dimension, target_namespace):
-    asyncio_idx = build_asyncioindex_client(pc, index_host)
+async def test_query(index_host, dimension, target_namespace):
+    asyncio_idx = build_asyncioindex_client(index_host)
 
     def emb():
         return embedding_values(dimension)

--- a/tests/integration/data_asyncio/test_query_namespaces.py
+++ b/tests/integration/data_asyncio/test_query_namespaces.py
@@ -7,8 +7,8 @@ from pinecone import Vector
 
 @pytest.mark.asyncio
 class TestQueryNamespacesRest:
-    async def test_query_namespaces(self, pc, index_host, metric):
-        asyncio_idx = build_asyncioindex_client(pc, index_host)
+    async def test_query_namespaces(self, index_host, metric):
+        asyncio_idx = build_asyncioindex_client(index_host)
 
         ns_prefix = random_string(5)
         ns1 = f"{ns_prefix}-ns1"
@@ -151,8 +151,8 @@ class TestQueryNamespacesRest:
         assert len(results6.matches) == 0
         assert results6.usage.read_units > 0
 
-    async def test_single_result_per_namespace(self, pc, index_host):
-        asyncio_idx = build_asyncioindex_client(pc, index_host)
+    async def test_single_result_per_namespace(self, index_host):
+        asyncio_idx = build_asyncioindex_client(index_host)
 
         ns_prefix = random_string(5)
         ns1 = f"{ns_prefix}-ns1"
@@ -191,8 +191,8 @@ class TestQueryNamespacesRest:
         assert results.matches[1].id == "id5"
         assert results.matches[1].namespace == ns2
 
-    async def test_missing_namespaces(self, pc, index_host):
-        asyncio_idx = build_asyncioindex_client(pc, index_host)
+    async def test_missing_namespaces(self, index_host):
+        asyncio_idx = build_asyncioindex_client(index_host)
 
         with pytest.raises(ValueError) as e:
             await asyncio_idx.query_namespaces(
@@ -218,8 +218,8 @@ class TestQueryNamespacesRest:
             )
         assert str(e.value) == "At least one namespace must be specified"
 
-    async def test_missing_metric(self, pc, index_host):
-        asyncio_idx = build_asyncioindex_client(pc, index_host)
+    async def test_missing_metric(self, index_host):
+        asyncio_idx = build_asyncioindex_client(index_host)
 
         with pytest.raises(TypeError) as e:
             await asyncio_idx.query_namespaces(

--- a/tests/integration/data_asyncio/test_query_namespaces_sparse.py
+++ b/tests/integration/data_asyncio/test_query_namespaces_sparse.py
@@ -7,8 +7,8 @@ from pinecone import Vector, SparseValues
 
 @pytest.mark.asyncio
 class TestQueryNamespacesRest_Sparse:
-    async def test_query_namespaces(self, pc, sparse_index_host):
-        asyncio_idx = build_asyncioindex_client(pc, sparse_index_host)
+    async def test_query_namespaces(self, sparse_index_host):
+        asyncio_idx = build_asyncioindex_client(sparse_index_host)
 
         ns_prefix = random_string(5)
         ns1 = f"{ns_prefix}-ns1"
@@ -200,8 +200,8 @@ class TestQueryNamespacesRest_Sparse:
         assert len(results6.matches) == 0
         assert results6.usage.read_units > 0
 
-    async def test_missing_namespaces(self, pc, sparse_index_host):
-        asyncio_idx = build_asyncioindex_client(pc, sparse_index_host)
+    async def test_missing_namespaces(self, sparse_index_host):
+        asyncio_idx = build_asyncioindex_client(sparse_index_host)
 
         with pytest.raises(ValueError) as e:
             await asyncio_idx.query_namespaces(

--- a/tests/integration/data_asyncio/test_query_sparse.py
+++ b/tests/integration/data_asyncio/test_query_sparse.py
@@ -7,8 +7,8 @@ from ..helpers import random_string, embedding_values
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("target_namespace", [random_string(20)])
-async def test_query_sparse(pc, sparse_index_host, target_namespace):
-    asyncio_sparse_idx = build_asyncioindex_client(pc, sparse_index_host)
+async def test_query_sparse(sparse_index_host, target_namespace):
+    asyncio_sparse_idx = build_asyncioindex_client(sparse_index_host)
 
     # Upsert with Vector objects containing sparse values dict
     await asyncio_sparse_idx.upsert(

--- a/tests/integration/data_asyncio/test_search_and_upsert_records.py
+++ b/tests/integration/data_asyncio/test_search_and_upsert_records.py
@@ -48,8 +48,8 @@ def records_to_upsert():
 
 @pytest.mark.asyncio
 class TestUpsertAndSearchRecords:
-    async def test_search_records(self, pc, model_index_host, records_to_upsert):
-        model_idx = build_asyncioindex_client(pc, model_index_host)
+    async def test_search_records(self, model_index_host, records_to_upsert):
+        model_idx = build_asyncioindex_client(model_index_host)
 
         target_namespace = random_string(10)
         await model_idx.upsert_records(namespace=target_namespace, records=records_to_upsert)
@@ -90,8 +90,8 @@ class TestUpsertAndSearchRecords:
             assert hit.fields.get("my_text_field") is None
             assert hit.fields.get("more_stuff") is not None
 
-    async def test_search_records_with_vector(self, pc, model_index_host, records_to_upsert):
-        model_idx = build_asyncioindex_client(pc, model_index_host)
+    async def test_search_records_with_vector(self, model_index_host, records_to_upsert):
+        model_idx = build_asyncioindex_client(model_index_host)
 
         target_namespace = random_string(10)
         await model_idx.upsert_records(namespace=target_namespace, records=records_to_upsert)
@@ -109,8 +109,8 @@ class TestUpsertAndSearchRecords:
         assert response == response2
 
     @pytest.mark.parametrize("rerank_model", ["bge-reranker-v2-m3", RerankModel.Bge_Reranker_V2_M3])
-    async def test_search_with_rerank(self, pc, model_index_host, records_to_upsert, rerank_model):
-        model_idx = build_asyncioindex_client(pc, model_index_host)
+    async def test_search_with_rerank(self, model_index_host, records_to_upsert, rerank_model):
+        model_idx = build_asyncioindex_client(model_index_host)
         target_namespace = random_string(10)
         await model_idx.upsert_records(namespace=target_namespace, records=records_to_upsert)
 
@@ -135,8 +135,8 @@ class TestUpsertAndSearchRecords:
             assert hit.fields.get("my_text_field") is not None
             assert hit.fields.get("more_stuff") is not None
 
-    async def test_search_with_rerank_query(self, pc, model_index_host, records_to_upsert):
-        model_idx = build_asyncioindex_client(pc, model_index_host)
+    async def test_search_with_rerank_query(self, model_index_host, records_to_upsert):
+        model_idx = build_asyncioindex_client(model_index_host)
         target_namespace = random_string(10)
         await model_idx.upsert_records(namespace=target_namespace, records=records_to_upsert)
 
@@ -161,9 +161,9 @@ class TestUpsertAndSearchRecords:
 @pytest.mark.asyncio
 class TestUpsertAndSearchRecordsErrorCases:
     async def test_search_with_rerank_nonexistent_model_error(
-        self, pc, model_index_host, records_to_upsert
+        self, model_index_host, records_to_upsert
     ):
-        model_idx = build_asyncioindex_client(pc, model_index_host)
+        model_idx = build_asyncioindex_client(model_index_host)
         target_namespace = random_string(10)
         await model_idx.upsert_records(namespace=target_namespace, records=records_to_upsert)
 
@@ -182,9 +182,9 @@ class TestUpsertAndSearchRecordsErrorCases:
 
     @pytest.mark.skip(reason="Possible bug in the API")
     async def test_search_with_rerank_empty_rank_fields_error(
-        self, pc, model_index_host, records_to_upsert
+        self, model_index_host, records_to_upsert
     ):
-        model_idx = build_asyncioindex_client(pc, model_index_host)
+        model_idx = build_asyncioindex_client(model_index_host)
         target_namespace = random_string(10)
         await model_idx.upsert_records(namespace=target_namespace, records=records_to_upsert)
 

--- a/tests/integration/data_asyncio/test_unauthorized_access.py
+++ b/tests/integration/data_asyncio/test_unauthorized_access.py
@@ -1,11 +1,11 @@
 import pytest
-from pinecone import Pinecone, ForbiddenException
+from pinecone import PineconeAsyncio, ForbiddenException
 
 
 @pytest.mark.asyncio
 async def test_unauthorized_requests_rejected(index_host):
-    pc = Pinecone(api_key="invalid_key")
-    asyncio_idx = pc.AsyncioIndex(host=index_host)
+    pc = PineconeAsyncio(api_key="invalid_key")
+    asyncio_idx = pc.Index(host=index_host)
 
     with pytest.raises(ForbiddenException) as e:
         await asyncio_idx.describe_index_stats()

--- a/tests/integration/data_asyncio/test_update.py
+++ b/tests/integration/data_asyncio/test_update.py
@@ -7,8 +7,8 @@ from ..helpers import random_string, embedding_values
 @pytest.mark.asyncio
 @pytest.mark.parametrize("target_namespace", [random_string(20)])
 class TestAsyncioUpdate:
-    async def test_update_values(self, pc, index_host, dimension, target_namespace):
-        asyncio_idx = build_asyncioindex_client(pc, index_host)
+    async def test_update_values(self, index_host, dimension, target_namespace):
+        asyncio_idx = build_asyncioindex_client(index_host)
 
         await asyncio_idx.upsert(
             vectors=[
@@ -37,8 +37,8 @@ class TestAsyncioUpdate:
         assert fetched_vec.vectors["1"].values[1] == pytest.approx(new_values[1], 0.01)
 
     @pytest.mark.skip(reason="Needs troubleshooting, possible bug")
-    async def test_update_metadata(self, pc, index_host, dimension, target_namespace):
-        asyncio_idx = build_asyncioindex_client(pc, index_host)
+    async def test_update_metadata(self, index_host, dimension, target_namespace):
+        asyncio_idx = build_asyncioindex_client(index_host)
 
         await asyncio_idx.upsert(
             vectors=[

--- a/tests/integration/data_asyncio/test_update_sparse.py
+++ b/tests/integration/data_asyncio/test_update_sparse.py
@@ -7,8 +7,8 @@ from ..helpers import random_string, embedding_values
 @pytest.mark.asyncio
 @pytest.mark.parametrize("target_namespace", [random_string(20)])
 class TestAsyncioUpdateSparse:
-    async def test_update_values(self, pc, sparse_index_host, target_namespace):
-        asyncio_idx = build_asyncioindex_client(pc, sparse_index_host)
+    async def test_update_values(self, sparse_index_host, target_namespace):
+        asyncio_idx = build_asyncioindex_client(sparse_index_host)
 
         await asyncio_idx.upsert(
             vectors=[
@@ -54,8 +54,8 @@ class TestAsyncioUpdateSparse:
         #     )
 
     @pytest.mark.skip(reason="Needs troubleshooting, possible bug")
-    async def test_update_metadata(self, pc, sparse_index_host, dimension, target_namespace):
-        asyncio_idx = build_asyncioindex_client(pc, sparse_index_host)
+    async def test_update_metadata(self, sparse_index_host, dimension, target_namespace):
+        asyncio_idx = build_asyncioindex_client(sparse_index_host)
 
         await asyncio_idx.upsert(
             vectors=[

--- a/tests/integration/data_asyncio/test_upsert.py
+++ b/tests/integration/data_asyncio/test_upsert.py
@@ -6,8 +6,8 @@ from ..helpers import random_string, embedding_values
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("target_namespace", [random_string(20)])
-async def test_upsert_with_batch_size_dense(pc, index_host, dimension, target_namespace):
-    asyncio_idx = build_asyncioindex_client(pc, index_host)
+async def test_upsert_with_batch_size_dense(index_host, dimension, target_namespace):
+    asyncio_idx = build_asyncioindex_client(index_host)
 
     await asyncio_idx.upsert(
         vectors=[Vector(id=str(i), values=embedding_values(dimension)) for i in range(100)],
@@ -18,8 +18,8 @@ async def test_upsert_with_batch_size_dense(pc, index_host, dimension, target_na
 
 
 @pytest.mark.asyncio
-async def test_upsert_dense_errors(pc, index_host, dimension):
-    asyncio_idx = build_asyncioindex_client(pc, index_host)
+async def test_upsert_dense_errors(index_host, dimension):
+    asyncio_idx = build_asyncioindex_client(index_host)
 
     # When upserting vectors with incorrect dimension
     with pytest.raises(PineconeApiException) as e:

--- a/tests/integration/data_asyncio/test_upsert_sparse.py
+++ b/tests/integration/data_asyncio/test_upsert_sparse.py
@@ -9,8 +9,8 @@ from ..helpers import random_string, embedding_values
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("target_namespace", [random_string(20)])
-async def test_upsert_with_batch_size_sparse(pc, sparse_index_host, target_namespace):
-    asyncio_sparse_idx = build_asyncioindex_client(pc, sparse_index_host)
+async def test_upsert_with_batch_size_sparse(sparse_index_host, target_namespace):
+    asyncio_sparse_idx = build_asyncioindex_client(sparse_index_host)
 
     await asyncio_sparse_idx.upsert(
         vectors=[

--- a/tests/integration/inference/test_asyncio_inference.py
+++ b/tests/integration/inference/test_asyncio_inference.py
@@ -36,6 +36,7 @@ class TestEmbedAsyncio:
         assert len(embeddings.get("data")[0]["values"]) == 1024
         assert len(embeddings.get("data")[1]["values"]) == 1024
         assert embeddings.get("model") == model_output
+        await pc.close()
 
     @pytest.mark.parametrize(
         "model_input,model_output",
@@ -54,6 +55,7 @@ class TestEmbedAsyncio:
         assert embeddings.vector_type == "sparse"
         assert embeddings.model == model_output
         assert len(embeddings.data) == 2
+        await pc.close()
 
     async def test_create_embeddings_input_objects(self):
         pc = PineconeAsyncio()
@@ -69,6 +71,7 @@ class TestEmbedAsyncio:
         assert len(embeddings.get("data")[0]["values"]) == 1024
         assert len(embeddings.get("data")[1]["values"]) == 1024
         assert embeddings.get("model") == "multilingual-e5-large"
+        await pc.close()
 
     async def test_create_embeddings_input_string(self):
         pc = PineconeAsyncio()
@@ -80,6 +83,7 @@ class TestEmbedAsyncio:
         assert len(embeddings.get("data")) == 1
         assert len(embeddings.get("data")[0]["values"]) == 1024
         assert embeddings.get("model") == "multilingual-e5-large"
+        await pc.close()
 
     async def test_create_embeddings_invalid_input_empty_list(self):
         pc = PineconeAsyncio()
@@ -91,6 +95,7 @@ class TestEmbedAsyncio:
                 parameters={"input_type": "query", "truncate": "END"},
             )
         assert str(excinfo.value).find("Invalid type") >= 0
+        await pc.close()
 
     async def test_create_embeddings_invalid_input(self):
         pc = PineconeAsyncio()
@@ -102,6 +107,7 @@ class TestEmbedAsyncio:
                 parameters={"input_type": "query", "truncate": "END"},
             )
         assert str(excinfo.value).find("INVALID_FIELD") >= 0
+        await pc.close()
 
     async def test_can_attempt_to_use_unknown_models(self):
         pc = PineconeAsyncio()
@@ -116,6 +122,7 @@ class TestEmbedAsyncio:
                 parameters={"input_type": "query", "truncate": "END"},
             )
         assert "Model 'unknown-model' not found" in str(excinfo.value)
+        await pc.close()
 
 
 @pytest.mark.asyncio
@@ -143,6 +150,7 @@ class TestRerankAsyncio:
         assert result.model == model_output
         assert isinstance(result.usage.rerank_units, int)
         assert result.usage.rerank_units == 1
+        await pc.close()
 
     async def test_rerank_basic_document_dicts(self):
         model = "bge-reranker-v2-m3"
@@ -164,6 +172,7 @@ class TestRerankAsyncio:
         assert result.model == model
         assert isinstance(result.usage.rerank_units, int)
         assert result.usage.rerank_units == 1
+        await pc.close()
 
     async def test_rerank_document_dicts_custom_field(self):
         model = "bge-reranker-v2-m3"
@@ -186,6 +195,7 @@ class TestRerankAsyncio:
         assert result.model == model
         assert isinstance(result.usage.rerank_units, int)
         assert result.usage.rerank_units == 1
+        await pc.close()
 
     async def test_rerank_basic_default_top_n(self):
         model = "bge-reranker-v2-m3"
@@ -202,6 +212,7 @@ class TestRerankAsyncio:
         assert result.model == model
         assert isinstance(result.usage.rerank_units, int)
         assert result.usage.rerank_units == 1
+        await pc.close()
 
     async def test_rerank_no_return_documents(self):
         pc = PineconeAsyncio()
@@ -218,6 +229,7 @@ class TestRerankAsyncio:
         assert result.model == model.value
         assert isinstance(result.usage.rerank_units, int)
         assert result.usage.rerank_units == 1
+        await pc.close()
 
     async def test_rerank_allows_unknown_models_to_be_passed(self):
         pc = PineconeAsyncio()
@@ -233,3 +245,4 @@ class TestRerankAsyncio:
                 return_documents=False,
             )
         assert "Model 'unknown-model' not found" in str(excinfo.value)
+        await pc.close()

--- a/tests/integration/inference/test_inference.py
+++ b/tests/integration/inference/test_inference.py
@@ -1,0 +1,233 @@
+import pytest
+from pinecone import Pinecone, PineconeApiException, RerankModel, EmbedModel
+
+
+class TestEmbed:
+    @pytest.mark.parametrize(
+        "model_input,model_output",
+        [
+            (EmbedModel.Multilingual_E5_Large, "multilingual-e5-large"),
+            ("multilingual-e5-large", "multilingual-e5-large"),
+        ],
+    )
+    def test_create_embeddings(self, model_input, model_output):
+        pc = Pinecone()
+        embeddings = pc.inference.embed(
+            model=model_input,
+            inputs=["The quick brown fox jumps over the lazy dog.", "lorem ipsum"],
+            parameters={"input_type": "query", "truncate": "END"},
+        )
+        assert embeddings.vector_type == "dense"
+        assert embeddings.model == model_output
+        assert len(embeddings.data) == 2
+        assert len(embeddings.data[0].values) == 1024
+        assert len(embeddings.data[1].values) == 1024
+
+        # Dict-style bracket accessors
+        assert embeddings["vector_type"] == "dense"
+        assert embeddings["model"] == model_output
+        assert len(embeddings["data"]) == 2
+
+        # Dict-style get accessors for embeddings
+        assert embeddings.get("vector_type") == "dense"
+        assert embeddings.get("model") == model_output
+        assert len(embeddings.get("data")) == 2
+        assert len(embeddings.get("data")[0]["values"]) == 1024
+        assert len(embeddings.get("data")[1]["values"]) == 1024
+        assert embeddings.get("model") == model_output
+
+    @pytest.mark.parametrize(
+        "model_input,model_output",
+        [
+            (EmbedModel.Pinecone_Sparse_English_V0, "pinecone-sparse-english-v0"),
+            ("pinecone-sparse-english-v0", "pinecone-sparse-english-v0"),
+        ],
+    )
+    def test_create_sparse_embeddings(self, model_input, model_output):
+        pc = Pinecone()
+        embeddings = pc.inference.embed(
+            model=model_input,
+            inputs=["The quick brown fox jumps over the lazy dog.", "lorem ipsum"],
+            parameters={"input_type": "query", "truncate": "END"},
+        )
+        assert embeddings.vector_type == "sparse"
+        assert embeddings.model == model_output
+        assert len(embeddings.data) == 2
+
+    def test_create_embeddings_input_objects(self):
+        pc = Pinecone()
+        embeddings = pc.inference.embed(
+            model=pc.inference.EmbedModel.Multilingual_E5_Large,
+            inputs=[
+                {"text": "The quick brown fox jumps over the lazy dog."},
+                {"text": "lorem ipsum"},
+            ],
+            parameters={"input_type": "query", "truncate": "END"},
+        )
+        assert len(embeddings.get("data")) == 2
+        assert len(embeddings.get("data")[0]["values"]) == 1024
+        assert len(embeddings.get("data")[1]["values"]) == 1024
+        assert embeddings.get("model") == "multilingual-e5-large"
+
+    def test_create_embeddings_input_string(self):
+        pc = Pinecone()
+        embeddings = pc.inference.embed(
+            model=EmbedModel.Multilingual_E5_Large,
+            inputs="The quick brown fox jumps over the lazy dog.",
+            parameters={"input_type": "query", "truncate": "END"},
+        )
+        assert len(embeddings.get("data")) == 1
+        assert len(embeddings.get("data")[0]["values"]) == 1024
+        assert embeddings.get("model") == "multilingual-e5-large"
+
+    def test_create_embeddings_invalid_input_empty_list(self):
+        pc = Pinecone()
+        embedding_model = "multilingual-e5-large"
+        with pytest.raises(Exception) as excinfo:
+            pc.inference.embed(
+                model=embedding_model,
+                inputs=[],
+                parameters={"input_type": "query", "truncate": "END"},
+            )
+        assert str(excinfo.value).find("Invalid type") >= 0
+
+    def test_create_embeddings_invalid_input(self):
+        pc = Pinecone()
+        embedding_model = "multilingual-e5-large"
+        with pytest.raises(Exception) as excinfo:
+            pc.inference.embed(
+                model=embedding_model,
+                inputs=[{"INVALID_FIELD": "this should be rejected"}],
+                parameters={"input_type": "query", "truncate": "END"},
+            )
+        assert str(excinfo.value).find("INVALID_FIELD") >= 0
+
+    def test_can_attempt_to_use_unknown_models(self):
+        pc = Pinecone()
+
+        # We don't want to reject these requests client side because we want
+        # to remain forwards compatible with any new models that become available
+        model = "unknown-model"
+        with pytest.raises(PineconeApiException) as excinfo:
+            pc.inference.embed(
+                model=model,
+                inputs="The quick brown fox jumps over the lazy dog.",
+                parameters={"input_type": "query", "truncate": "END"},
+            )
+        assert "Model 'unknown-model' not found" in str(excinfo.value)
+
+
+class TestRerank:
+    @pytest.mark.parametrize(
+        "model_input,model_output",
+        [
+            (RerankModel.Bge_Reranker_V2_M3, "bge-reranker-v2-m3"),
+            ("bge-reranker-v2-m3", "bge-reranker-v2-m3"),
+        ],
+    )
+    def test_rerank_basic(self, model_input, model_output):
+        # Rerank model can be passed as string or enum
+        pc = Pinecone()
+        result = pc.inference.rerank(
+            model=model_input,
+            query="i love dogs",
+            documents=["dogs are pretty cool", "everyone loves dogs", "I'm a cat person"],
+            top_n=1,
+            return_documents=True,
+        )
+        assert len(result.data) == 1
+        assert result.data[0].index == 1
+        assert result.data[0].document.text == "everyone loves dogs"
+        assert result.model == model_output
+        assert isinstance(result.usage.rerank_units, int)
+        assert result.usage.rerank_units == 1
+
+    def test_rerank_basic_document_dicts(self):
+        model = "bge-reranker-v2-m3"
+        pc = Pinecone()
+        result = pc.inference.rerank(
+            model="bge-reranker-v2-m3",
+            query="i love dogs",
+            documents=[
+                {"id": "123", "text": "dogs are pretty cool"},
+                {"id": "789", "text": "I'm a cat person"},
+                {"id": "456", "text": "everyone loves dogs"},
+            ],
+            top_n=1,
+            return_documents=True,
+        )
+        assert len(result.data) == 1
+        assert result.data[0].index == 2
+        assert result.data[0].document.text == "everyone loves dogs"
+        assert result.model == model
+        assert isinstance(result.usage.rerank_units, int)
+        assert result.usage.rerank_units == 1
+
+    def test_rerank_document_dicts_custom_field(self):
+        model = "bge-reranker-v2-m3"
+        pc = Pinecone()
+        result = pc.inference.rerank(
+            model="bge-reranker-v2-m3",
+            query="i love dogs",
+            documents=[
+                {"id": "123", "my_field": "dogs are pretty cool"},
+                {"id": "456", "my_field": "everyone loves dogs"},
+                {"id": "789", "my_field": "I'm a cat person"},
+            ],
+            rank_fields=["my_field"],
+            top_n=1,
+            return_documents=True,
+        )
+        assert len(result.data) == 1
+        assert result.data[0].index == 1
+        assert result.data[0].document.my_field == "everyone loves dogs"
+        assert result.model == model
+        assert isinstance(result.usage.rerank_units, int)
+        assert result.usage.rerank_units == 1
+
+    def test_rerank_basic_default_top_n(self):
+        model = "bge-reranker-v2-m3"
+        pc = Pinecone()
+        result = pc.inference.rerank(
+            model=model,
+            query="i love dogs",
+            documents=["dogs are pretty cool", "everyone loves dogs", "I'm a cat person"],
+            return_documents=True,
+        )
+        assert len(result.data) == 3
+        assert result.data[0].index == 1
+        assert result.data[0].document.text == "everyone loves dogs"
+        assert result.model == model
+        assert isinstance(result.usage.rerank_units, int)
+        assert result.usage.rerank_units == 1
+
+    def test_rerank_no_return_documents(self):
+        pc = Pinecone()
+        model = pc.inference.RerankModel.Bge_Reranker_V2_M3
+        result = pc.inference.rerank(
+            model=model,
+            query="i love dogs",
+            documents=["dogs are pretty cool", "everyone loves dogs", "I'm a cat person"],
+            return_documents=False,
+        )
+        assert len(result.data) == 3
+        assert result.data[0].index == 1
+        assert not result.data[0].document
+        assert result.model == model.value
+        assert isinstance(result.usage.rerank_units, int)
+        assert result.usage.rerank_units == 1
+
+    def test_rerank_allows_unknown_models_to_be_passed(self):
+        pc = Pinecone()
+
+        # We don't want to reject these requests client side because we want
+        # to remain forwards compatible with any new models that become available
+        model = "unknown-model"
+        with pytest.raises(PineconeApiException) as excinfo:
+            pc.inference.rerank(
+                model=model,
+                query="i love dogs",
+                documents=["dogs are pretty cool", "everyone loves dogs", "I'm a cat person"],
+                return_documents=False,
+            )
+        assert "Model 'unknown-model' not found" in str(excinfo.value)

--- a/tests/unit/data/test_bulk_import.py
+++ b/tests/unit/data/test_bulk_import.py
@@ -3,13 +3,12 @@ import pytest
 from urllib3 import BaseHTTPResponse
 
 from pinecone.openapi_support import ApiClient, PineconeApiException
-from pinecone.core.openapi.db_data.api.bulk_operations_api import BulkOperationsApi
 from pinecone.core.openapi.db_data.models import StartImportResponse
 
 from pinecone.data.features.bulk_import import ImportFeatureMixin, ImportErrorMode
 
 
-def build_api_w_faked_response(mocker, body: str, status: int = 200) -> BaseHTTPResponse:
+def build_client_w_faked_response(mocker, body: str, status: int = 200) -> BaseHTTPResponse:
     response = mocker.Mock()
     response.headers = {"content-type": "application/json"}
     response.status = status
@@ -19,14 +18,7 @@ def build_api_w_faked_response(mocker, body: str, status: int = 200) -> BaseHTTP
     mock_request = mocker.patch.object(
         api_client.rest_client.pool_manager, "request", return_value=response
     )
-    return BulkOperationsApi(api_client=api_client), mock_request
-
-
-def build_client_w_faked_response(mocker, body: str, status: int = 200):
-    api_client, mock_req = build_api_w_faked_response(mocker, body, status)
-    return ImportFeatureMixin(
-        __import_operations_api=api_client, api_key="asdf", host="asdf"
-    ), mock_req
+    return ImportFeatureMixin(api_client=api_client), mock_request
 
 
 class TestBulkImportStartImport:


### PR DESCRIPTION
## Problem

Previous work implemented asyncio for the db data plane, and now we want to roll out a similar approach for the db control plane and inference as well.

## Solution

- Extract request construction logic out of `Pinecone` and move it to a request factory
- Implement `PineconeAsyncio` using the request factory to keep most of the method-specific logic the same.
- Add new integration tests using the asyncio code path. These are mostly modified from the existing serverless integration tests.
- Update tests for the asyncio index client to reflect new setup steps
- Some refactorings around async context management to address log warnings being shown from aiohttp

## Usage

The async version of the client has some async setup/teardown related to the underlying aiohttp library being used. You can either use the `async with` syntax to have the async context automatically managed for you. Or, if you prefer, you can take the responsibility to close the async context yourself by using `close()`.

#### Context management option 1: Using `async with`

```python
import asyncio
from pinecone import (
    PineconeAsyncio,
    ServerlessSpec,
    CloudProvider,
    AwsRegion,
)

async def main():
    async with PineconeAsyncio(api_key="key") as pc:
        await pc.create_index(
            name="my-index",
            metric="cosine",
            spec=ServerlessSpec(
                cloud=CloudProvider.AWS, 
                region=AwsRegion.US_EAST_1
            ),
        )
        
asyncio.run(main())
```

#### Context management option 2: Manually `close()`

```python
import asyncio
from pinecone import (
    PineconeAsyncio,
    ServerlessSpec,
    CloudProvider,
    AwsRegion,
)

async def main():
    pc = PineconeAsyncio(api_key="key")
    await pc.create_index(
        name="my-index",
        metric="cosine",
        spec=ServerlessSpec(
            cloud=CloudProvider.AWS, 
            region=AwsRegion.US_EAST_1
        ),
    )
    await pc.close() # <-- Don't forget to close the client when you are done mking network calls
        
asyncio.run(main())
```

#### Sparse index example

```python
import asyncio
import random
from pinecone import (
    PineconeAsyncio,
    ServerlessSpec,
    CloudProvider,
    AwsRegion,
    Metric,
    VectorType,
    Vector,
    SparseValues,
)

async def main():
    async with PineconeAsyncio() as pc:
        # Create a sparse index
        index_name = "my-index2"
        
        if not await pc.has_index(index_name):
            await pc.create_index(
                name=index_name,
                metric=Metric.DOTPRODUCT,
                spec=ServerlessSpec(
                    cloud=CloudProvider.AWS, 
                    region=AwsRegion.US_EAST_1
                ),
                vector_type=VectorType.SPARSE,
                tags={
                    "env": "testing",
                }
            )
        
        # Get the index host
        description = await pc.describe_index(name=index_name)
        
        # Make an index client
        async with pc.Index(host=description.host) as idx:

            # Upsert some sparse vectors
            await idx.upsert(
                vectors=[
                    Vector(
                        id=str(i), 
                        sparse_values=SparseValues(
                            indices=[j for j in range(100)], 
                            values=[random.random() for _ in range(100)]
                        )
                    ) for i in range(50)
                ]
            )
            
            # Query the index
            query_results = await idx.query(
                top_k=5,
                sparse_vector=SparseValues(
                    indices=[5, 10, 20], 
                    values=[0.5, 0.5, 0.5]
                ),
            )
            print(query_results)

asyncio.run(main())
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

