### PR TITLE
Move asyncio deps into extras

### DIFF
--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Install typing dependencies (mypy, type stubs, etc)'
     required: true
     default: 'true'
+  include_asyncio:
+    description: 'Install asyncio dependencies'
+    required: true
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -26,8 +30,10 @@ runs:
         INCLUDE_GRPC: ${{ inputs.include_grpc }}
         INCLUDE_DEV: ${{ inputs.include_dev }}
         INCLUDE_TYPES: ${{ inputs.include_types }}
+        INCLUDE_ASYNCIO: ${{ inputs.include_asyncio }}
       run: |
         GRPC_FLAG=$( [ "$INCLUDE_GRPC" = "true" ] && echo "--extras grpc" || echo "" )
+        ASYNCIO_FLAG=$( [ "$INCLUDE_ASYNCIO" = "true" ] && echo "--extras asyncio" || echo "" )
         DEV_FLAG=$( [ "$INCLUDE_DEV" = "false" ] && echo "--without dev" || echo "" )
         TYPING_FLAG=$( [ "$INCLUDE_TYPES" = "true" ] && echo "--with types" || echo "" )
-        poetry install $DEV_FLAG $TYPING_FLAG $GRPC_FLAG
+        poetry install $DEV_FLAG $TYPING_FLAG $GRPC_FLAG $ASYNCIO_FLAG

--- a/.github/actions/test-data-asyncio/action.yaml
+++ b/.github/actions/test-data-asyncio/action.yaml
@@ -33,6 +33,7 @@ runs:
       with:
         include_grpc: ${{ inputs.use_grpc }}
         include_dev: 'true'
+        include_asyncio: 'true'
 
     - name: Run data plane tests
       id: data-plane-asyncio-tests

--- a/.github/actions/test-dependency-asyncio-rest/action.yaml
+++ b/.github/actions/test-dependency-asyncio-rest/action.yaml
@@ -29,6 +29,7 @@ runs:
       with:
         include_grpc: false
         include_types: false
+        include_asyncio: true
 
     - name: 'Install aiohttp ${{ matrix.aiohttp-version }}'
       run: 'poetry add aiohttp==${{ matrix.aiohttp-version }}'

--- a/.github/workflows/testing-integration-asyncio.yaml
+++ b/.github/workflows/testing-integration-asyncio.yaml
@@ -3,28 +3,6 @@ name: "DB Integration: Asyncio"
   workflow_call: {}
 
 jobs:
-  db-data-serverless:
-    name: db_data rest
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version:
-          - 3.9
-          - 3.13
-        use_grpc: [true, false]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/test-data-plane
-        with:
-          python_version: '${{ matrix.python_version }}'
-          use_grpc: '${{ matrix.use_grpc }}'
-          metric: 'cosine'
-          spec: '{ "serverless": { "region": "us-west-2", "cloud": "aws" }}'
-          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
-          freshness_timeout_seconds: 600
-          skip_weird_id_tests: 'true'
-
   db-data-asyncio:
     name: db_data asyncio
     runs-on: ubuntu-latest

--- a/.github/workflows/testing-integration-asyncio.yaml
+++ b/.github/workflows/testing-integration-asyncio.yaml
@@ -1,0 +1,78 @@
+name: "DB Integration: Asyncio"
+'on':
+  workflow_call: {}
+
+jobs:
+  db-data-serverless:
+    name: db_data rest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - 3.9
+          - 3.13
+        use_grpc: [true, false]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/test-data-plane
+        with:
+          python_version: '${{ matrix.python_version }}'
+          use_grpc: '${{ matrix.use_grpc }}'
+          metric: 'cosine'
+          spec: '{ "serverless": { "region": "us-west-2", "cloud": "aws" }}'
+          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
+          freshness_timeout_seconds: 600
+          skip_weird_id_tests: 'true'
+
+  db-data-asyncio:
+    name: db_data asyncio
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - 3.9
+          - 3.13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+        with:
+          include_dev: true
+          include_asyncio: true
+      - name: Run data plane tests
+        id: data-plane-asyncio-tests
+        shell: bash
+        run: poetry run pytest tests/integration/data_asyncio -s -vv
+        env:
+            PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+
+  db-control-asyncio:
+    name: db_control asyncio
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version:
+          - 3.9
+          - 3.12
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Set up Python ${{ matrix.python_version }}'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python_version }}'
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+        with:
+          include_asyncio: true
+          include_dev: true
+      - name: 'db_control asyncio'
+        run: poetry run pytest tests/integration/control_asyncio -s -vv
+        env:
+          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'

--- a/.github/workflows/testing-integration.yaml
+++ b/.github/workflows/testing-integration.yaml
@@ -159,6 +159,8 @@ jobs:
           python-version: '${{ matrix.python_version }}'
       - name: Setup Poetry
         uses: ./.github/actions/setup-poetry
+        with:
+          include_asyncio: true
       - name: 'Run integration tests'
         run: poetry run pytest tests/integration/inference -s -vv
         env:

--- a/.github/workflows/testing-integration.yaml
+++ b/.github/workflows/testing-integration.yaml
@@ -3,6 +3,11 @@ name: "Integration Tests"
   workflow_call: {}
 
 jobs:
+  dependency-test-asyncio:
+    uses: './.github/workflows/testing-integration-asyncio.yaml'
+    secrets: inherit
+    needs: inference
+
   db-data-serverless:
     name: db_data rest
     runs-on: ubuntu-latest
@@ -49,7 +54,6 @@ jobs:
           PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
           freshness_timeout_seconds: 600
 
-
   db-control-rest-pod:
     name: db_control pod/collection tests
     runs-on: ubuntu-latest
@@ -71,7 +75,9 @@ jobs:
           python-version: '${{ matrix.testConfig.python-version }}'
       - name: Setup Poetry
         uses: ./.github/actions/setup-poetry
-      - name: 'Run integration tests (REST, prod)'
+        with:
+          include_asyncio: true
+      - name: 'Run integration tests (REST)'
         run: poetry run pytest tests/integration/control/pod -s -v
         env:
           PINECONE_DEBUG_CURL: 'true'
@@ -104,7 +110,7 @@ jobs:
           python-version: '${{ matrix.testConfig.python-version }}'
       - name: Setup Poetry
         uses: ./.github/actions/setup-poetry
-      - name: 'Run integration tests (REST, prod)'
+      - name: 'Run integration tests (REST)'
         run: poetry run pytest tests/integration/control/serverless -s -vv
         env:
           PINECONE_DEBUG_CURL: 'true'
@@ -131,7 +137,9 @@ jobs:
           python-version: '${{ matrix.python_version }}'
       - name: Setup Poetry
         uses: ./.github/actions/setup-poetry
-      - name: 'Run integration tests (asyncio, prod)'
+        with:
+          include_asyncio: true
+      - name: 'Run integration tests (asyncio)'
         run: poetry run pytest tests/integration/control_asyncio -s -vv
         env:
           PINECONE_DEBUG_CURL: 'true'

--- a/.github/workflows/testing-integration.yaml
+++ b/.github/workflows/testing-integration.yaml
@@ -3,6 +3,30 @@ name: "Integration Tests"
   workflow_call: {}
 
 jobs:
+
+  inference:
+    name: Inference tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: [3.9, 3.12]
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Set up Python ${{ matrix.python_version }}'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python_version }}'
+      - name: Setup Poetry
+        uses: ./.github/actions/setup-poetry
+        with:
+          include_asyncio: true
+      - name: 'Run integration tests'
+        run: poetry run pytest tests/integration/inference -s -vv
+        env:
+          PINECONE_DEBUG_CURL: 'true'
+          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
+
+
   dependency-test-asyncio:
     uses: './.github/workflows/testing-integration-asyncio.yaml'
     secrets: inherit
@@ -31,28 +55,6 @@ jobs:
           PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
           freshness_timeout_seconds: 600
           skip_weird_id_tests: 'true'
-
-  db-data-asyncio:
-    name: db_data asyncio
-    runs-on: ubuntu-latest
-    needs:
-      - inference
-    strategy:
-      fail-fast: false
-      matrix:
-        python_version:
-          - 3.9
-          - 3.13
-        use_grpc: [false, true]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/test-asyncio
-        with:
-          python_version: '${{ matrix.python_version }}'
-          use_grpc: '${{ matrix.use_grpc }}'
-          spec: '{ "serverless": { "region": "us-west-2", "cloud": "aws" }}'
-          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
-          freshness_timeout_seconds: 600
 
   db-control-rest-pod:
     name: db_control pod/collection tests
@@ -117,52 +119,3 @@ jobs:
           PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
           SERVERLESS_CLOUD: '${{ matrix.testConfig.serverless.cloud }}'
           SERVERLESS_REGION: '${{ matrix.testConfig.serverless.region }}'
-
-  db-control-asyncio:
-    name: db_control asyncio
-    runs-on: ubuntu-latest
-    needs:
-      - inference
-    strategy:
-      matrix:
-        python_version:
-          - 3.9
-          - 3.12
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Set up Python ${{ matrix.python_version }}'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '${{ matrix.python_version }}'
-      - name: Setup Poetry
-        uses: ./.github/actions/setup-poetry
-        with:
-          include_asyncio: true
-      - name: 'Run integration tests (asyncio)'
-        run: poetry run pytest tests/integration/control_asyncio -s -vv
-        env:
-          PINECONE_DEBUG_CURL: 'true'
-          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
-
-  inference:
-    name: Inference tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python_version: [3.9, 3.12]
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Set up Python ${{ matrix.python_version }}'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '${{ matrix.python_version }}'
-      - name: Setup Poetry
-        uses: ./.github/actions/setup-poetry
-        with:
-          include_asyncio: true
-      - name: 'Run integration tests'
-        run: poetry run pytest tests/integration/inference -s -vv
-        env:
-          PINECONE_DEBUG_CURL: 'true'
-          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'

--- a/.github/workflows/testing-integration.yaml
+++ b/.github/workflows/testing-integration.yaml
@@ -56,38 +56,38 @@ jobs:
           freshness_timeout_seconds: 600
           skip_weird_id_tests: 'true'
 
-  db-control-rest-pod:
-    name: db_control pod/collection tests
-    runs-on: ubuntu-latest
-    needs:
-      - inference
-    strategy:
-      matrix:
-        testConfig:
-          - python-version: 3.9
-            pod: { environment: 'us-east1-gcp'}
-          - python-version: 3.13
-            pod: { environment: 'us-east1-gcp'}
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'Set up Python ${{ matrix.testConfig.python-version }}'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '${{ matrix.testConfig.python-version }}'
-      - name: Setup Poetry
-        uses: ./.github/actions/setup-poetry
-        with:
-          include_asyncio: true
-      - name: 'Run integration tests (REST)'
-        run: poetry run pytest tests/integration/control/pod -s -v
-        env:
-          PINECONE_DEBUG_CURL: 'true'
-          PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
-          PINECONE_ENVIRONMENT: '${{ matrix.testConfig.pod.environment }}'
-          GITHUB_BUILD_NUMBER: '${{ github.run_number }}-s-${{ matrix.testConfig.python-version}}'
-          DIMENSION: 10
-          METRIC: 'cosine'
+  # db-control-rest-pod:
+  #   name: db_control pod/collection tests
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - inference
+  #   strategy:
+  #     matrix:
+  #       testConfig:
+  #         - python-version: 3.9
+  #           pod: { environment: 'us-east1-gcp'}
+  #         - python-version: 3.13
+  #           pod: { environment: 'us-east1-gcp'}
+  #     fail-fast: false
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: 'Set up Python ${{ matrix.testConfig.python-version }}'
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: '${{ matrix.testConfig.python-version }}'
+  #     - name: Setup Poetry
+  #       uses: ./.github/actions/setup-poetry
+  #       with:
+  #         include_asyncio: true
+  #     - name: 'Run integration tests (REST)'
+  #       run: poetry run pytest tests/integration/control/pod -s -v
+  #       env:
+  #         PINECONE_DEBUG_CURL: 'true'
+  #         PINECONE_API_KEY: '${{ secrets.PINECONE_API_KEY }}'
+  #         PINECONE_ENVIRONMENT: '${{ matrix.testConfig.pod.environment }}'
+  #         GITHUB_BUILD_NUMBER: '${{ github.run_number }}-s-${{ matrix.testConfig.python-version}}'
+  #         DIMENSION: 10
+  #         METRIC: 'cosine'
 
   db-control-rest-serverless:
     name: db_control serverless

--- a/.github/workflows/testing-unit.yaml
+++ b/.github/workflows/testing-unit.yaml
@@ -54,6 +54,7 @@ jobs:
         with:
           include_grpc: '${{ matrix.use_grpc }}'
           include_types: false
+          include_asyncio: true
 
       - name: Run unit tests (REST)
         run: poetry run pytest --cov=pinecone --timeout=120 tests/unit

--- a/.github/workflows/testing-unit.yaml
+++ b/.github/workflows/testing-unit.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           include_grpc: '${{ matrix.use_grpc }}'
           include_types: true
+          include_asyncio: true
 
       - name: mypy check
         run: poetry run mypy pinecone

--- a/pinecone/openapi_support/rest_aiohttp.py
+++ b/pinecone/openapi_support/rest_aiohttp.py
@@ -3,15 +3,16 @@ from .rest_utils import RestClientInterface, RESTResponse, raise_exceptions_or_r
 
 
 class AiohttpRestClient(RestClientInterface):
-    def __init__(self, configuration, pools_size=4, maxsize=None) -> None:
-        import aiohttp
+    def __init__(self, configuration) -> None:
+        try:
+            import aiohttp
+        except ImportError:
+            raise ImportError(
+                "Additional dependencies are required to use Pinecone with asyncio. Include these extra dependencies in your project by installing `pinecone[asyncio]`."
+            ) from None
 
         conn = aiohttp.TCPConnector()
         self._session = aiohttp.ClientSession(connector=conn)
-
-    # async def _cleanup(self):
-    #     if not self._session.closed:
-    #         await self._session.close()
 
     async def close(self):
         await self._session.close()

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "aiohappyeyeballs"
 version = "2.4.3"
 description = "Happy Eyeballs for asyncio"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "aiohappyeyeballs-2.4.3-py3-none-any.whl", hash = "sha256:8a7a83727b2756f394ab2895ea0765a0a8c475e3c71e98d43d76f22b4b435572"},
@@ -15,7 +15,7 @@ files = [
 name = "aiohttp"
 version = "3.11.5"
 description = "Async http client/server framework (asyncio)"
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "aiohttp-3.11.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6f9afa6500aed9d3ea6d8bdd1dfed19252bb254dfc8503660c50bee908701c2a"},
@@ -113,7 +113,7 @@ speedups = ["Brotli", "aiodns (>=3.2.0)", "brotlicffi"]
 name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
@@ -127,7 +127,7 @@ frozenlist = ">=1.1.0"
 name = "async-timeout"
 version = "5.0.1"
 description = "Timeout context manager for asyncio programs"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c"},
@@ -138,7 +138,7 @@ files = [
 name = "attrs"
 version = "24.2.0"
 description = "Classes Without Boilerplate"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
@@ -394,7 +394,7 @@ typing = ["typing-extensions (>=4.8)"]
 name = "frozenlist"
 version = "1.5.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "frozenlist-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5b6a66c18b5b9dd261ca98dffcb826a525334b2f29e7caa54e182255c5f6a65a"},
@@ -764,7 +764,7 @@ files = [
 name = "multidict"
 version = "6.1.0"
 description = "multidict implementation"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "multidict-6.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3380252550e372e8511d49481bd836264c009adb826b23fefcc5dd3c69692f60"},
@@ -1172,7 +1172,7 @@ virtualenv = ">=20.10.0"
 name = "propcache"
 version = "0.2.0"
 description = "Accelerated property cache"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "propcache-0.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c5869b8fd70b81835a6f187c5fdbe67917a04d7e52b6e7cc4e5fe39d55c39d58"},
@@ -1770,7 +1770,7 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 name = "yarl"
 version = "1.17.2"
 description = "Yet another URL library"
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "yarl-1.17.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93771146ef048b34201bfa382c2bf74c524980870bb278e6df515efaf93699ff"},
@@ -1863,9 +1863,10 @@ multidict = ">=4.0"
 propcache = ">=0.2.0"
 
 [extras]
+asyncio = ["aiohttp"]
 grpc = ["googleapis-common-protos", "grpcio", "grpcio", "grpcio", "lz4", "protobuf", "protoc-gen-openapiv2"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "58073880009c45ea1ab4bf8aa346f390b316faaa122eb59ba75171814e74ba85"
+content-hash = "a2fbf9fee6a7ff0e7e8065df37e07b4e0cc58818f0d60c58cc074aae2eae9d56"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ protobuf = { version = "^5.29", optional = true }
 protoc-gen-openapiv2 = {version = "^0.0.1", optional = true }
 pinecone-plugin-interface = "^0.0.7"
 python-dateutil = ">=2.5.3"
-aiohttp = ">=3.9.0"
+aiohttp = { version = ">=3.9.0", optional = true }
 
 [tool.poetry.group.types]
 optional = true
@@ -97,6 +97,7 @@ ruff = "^0.9.3"
 
 [tool.poetry.extras]
 grpc = ["grpcio", "googleapis-common-protos", "lz4", "protobuf", "protoc-gen-openapiv2"]
+asyncio = ["aiohttp"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Problem

Rather than adding a new dependency for everyone, we want asyncio to be an extras install similar to how grpc is handled.

## Solution

Adjust pyproject.toml to migrate aiohttp into an asyncio extras that will be installed like `pinecone[asyncio]`. Adjust test configuration to install the required dependencies.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

