### PR TITLE
Adjust config kwargs to Pinecone and PineconeAsyncio

### DIFF
--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -297,6 +297,8 @@ class Pinecone(PineconeDBControlInterface, PluginAware):
         openapi_config = self.openapi_config
 
         if host != "":
+            check_realistic_host(host)
+
             # Use host url if it is provided
             index_host = normalize_host(host)
         else:
@@ -310,4 +312,20 @@ class Pinecone(PineconeDBControlInterface, PluginAware):
             openapi_config=openapi_config,
             source_tag=self.config.source_tag,
             **kwargs,
+        )
+
+
+def check_realistic_host(host: str) -> None:
+    """@private
+
+    Checks whether a user-provided host string seems plausible.
+    Someone could erroneously pass an index name as the host by
+    mistake, and if they have done that we'd like to give them a
+    simple error message as feedback rather than attempting to
+    call the url and getting a more cryptic DNS resolution error.
+    """
+
+    if "." not in host and "localhost" not in host:
+        raise ValueError(
+            f"You passed '{host}' as the host but this does not appear to be valid. Call describe_index() to confirm the host of the index."
         )

--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -6,7 +6,7 @@ from multiprocessing import cpu_count
 from .index_host_store import IndexHostStore
 from .pinecone_interface import PineconeDBControlInterface
 
-from pinecone.config import PineconeConfig, Config, ConfigBuilder
+from pinecone.config import PineconeConfig, ConfigBuilder
 
 from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
 from pinecone.openapi_support.api_client import ApiClient
@@ -59,32 +59,29 @@ class Pinecone(PineconeDBControlInterface, PluginAware):
         proxy_headers: Optional[Dict[str, str]] = None,
         ssl_ca_certs: Optional[str] = None,
         ssl_verify: Optional[bool] = None,
-        config: Optional[Config] = None,
         additional_headers: Optional[Dict[str, str]] = {},
         pool_threads: Optional[int] = None,
         **kwargs,
     ):
-        if config:
-            if not isinstance(config, Config):
-                raise TypeError("config must be of type pinecone.config.Config")
-            else:
-                self.config = config
-        else:
-            self.config = PineconeConfig.build(
-                api_key=api_key,
-                host=host,
-                additional_headers=additional_headers,
-                proxy_url=proxy_url,
-                proxy_headers=proxy_headers,
-                ssl_ca_certs=ssl_ca_certs,
-                ssl_verify=ssl_verify,
-                **kwargs,
+        if kwargs.get("config", None):
+            raise Exception(
+                "Passing config is no longer supported. Please pass individual settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at https://github.com/pinecone-io/pinecone-python-client for examples."
             )
-
         if kwargs.get("openapi_config", None):
             raise Exception(
-                "Passing openapi_config is no longer supported. Please pass settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at https://github.com/pinecone-io/pinecone-python-client for examples."
+                "Passing openapi_config is no longer supported. Please pass individual settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at https://github.com/pinecone-io/pinecone-python-client for examples."
             )
+
+        self.config = PineconeConfig.build(
+            api_key=api_key,
+            host=host,
+            additional_headers=additional_headers,
+            proxy_url=proxy_url,
+            proxy_headers=proxy_headers,
+            ssl_ca_certs=ssl_ca_certs,
+            ssl_verify=ssl_verify,
+            **kwargs,
+        )
 
         self.openapi_config = ConfigBuilder.build_openapi_config(self.config, **kwargs)
 

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -269,19 +269,20 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
         api_key = self.config.api_key
         openapi_config = self.openapi_config
 
-        index_host = normalize_host(host)
-        if index_host == "":
+        if host is None or host == "":
             raise ValueError("A host must be specified")
 
-        if "." not in index_host or "localhost" in index_host:
+        if "." not in host or "localhost" not in host:
             # If someone accidentally passes an index name instead of a host,
             # they will see this error. Index names do not contain periods.
             # If we don't trap this case, they will get an error about failed
             # DNS resolution when attempting to connect to some address that
             # does not exist.
             raise ValueError(
-                f"You passed {index_host} as the host but this does not appear to be valid. Call describe_index() to confirm the host of the index."
+                f"You passed '{host}' as the host but this does not appear to be valid. Call describe_index() to confirm the host of the index."
             )
+
+        index_host = normalize_host(host)
 
         return _AsyncioIndex(
             host=index_host,

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -33,6 +33,7 @@ from pinecone.enums import (
 from .types import CreateIndexForModelEmbedTypedDict
 from .request_factory import PineconeDBControlRequestFactory
 from .pinecone_interface_asyncio import PineconeAsyncioDBControlInterface
+from .pinecone import check_realistic_host
 
 logger = logging.getLogger(__name__)
 """ @private """
@@ -272,16 +273,7 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
         if host is None or host == "":
             raise ValueError("A host must be specified")
 
-        if "." not in host or "localhost" not in host:
-            # If someone accidentally passes an index name instead of a host,
-            # they will see this error. Index names do not contain periods.
-            # If we don't trap this case, they will get an error about failed
-            # DNS resolution when attempting to connect to some address that
-            # does not exist.
-            raise ValueError(
-                f"You passed '{host}' as the host but this does not appear to be valid. Call describe_index() to confirm the host of the index."
-            )
-
+        check_realistic_host(host)
         index_host = normalize_host(host)
 
         return _AsyncioIndex(

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -54,19 +54,25 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
         # proxy_headers: Optional[Dict[str, str]] = None,
         # ssl_ca_certs: Optional[str] = None,
         # ssl_verify: Optional[bool] = None,
-        additional_headers: Optional[Dict[str, str]] = {},
+        # additional_headers: Optional[Dict[str, str]] = {},
         **kwargs,
     ):
-        for kwarg in {"proxy_url", "proxy_headers", "ssl_ca_certs", "ssl_verify"}:
+        for kwarg in {
+            "additional_headers",
+            "proxy_url",
+            "proxy_headers",
+            "ssl_ca_certs",
+            "ssl_verify",
+        }:
             if kwarg in kwargs:
                 raise NotImplementedError(
-                    f"You have passed {kwarg} but support for proxies is not yet implemented in PineconeAsyncio."
+                    f"You have passed {kwarg} but this configuration has not been implemented yet for PineconeAsyncio."
                 )
 
         self.config = PineconeConfig.build(
             api_key=api_key,
             host=host,
-            additional_headers=additional_headers,
+            additional_headers=None,
             proxy_url=None,
             proxy_headers=None,
             ssl_ca_certs=None,

--- a/pinecone/control/pinecone_interface_asyncio.py
+++ b/pinecone/control/pinecone_interface_asyncio.py
@@ -529,7 +529,7 @@ class PineconeAsyncioDBControlInterface(ABC):
         pass
 
     @abstractmethod
-    async def Index(self, host: str, **kwargs):
+    def Index(self, host: str, **kwargs):
         """
         Target an index for data operations.
 

--- a/tests/integration/control/serverless/test_index_instantiation_ux.py
+++ b/tests/integration/control/serverless/test_index_instantiation_ux.py
@@ -5,7 +5,7 @@ import pytest
 class TestIndexInstantiationUX:
     def test_index_instantiation_ux(self):
         with pytest.raises(Exception) as e:
-            pinecone.Index(name="my-index", host="host")
+            pinecone.Index(name="my-index", host="test-bt8x3su.svc.apw5-4e34-81fa.pinecone.io")
 
         assert (
             "You are attempting to access the Index client directly from the pinecone module."

--- a/tests/unit/data/test_instantiation.py
+++ b/tests/unit/data/test_instantiation.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+class TestIndexInstantiation:
+    def test_invalid_host(self):
+        from pinecone import Pinecone
+
+        pc = Pinecone(api_key="key")
+
+        with pytest.raises(ValueError) as e:
+            pc.Index(host="invalid")
+        assert "You passed 'invalid' as the host but this does not appear to be valid" in str(
+            e.value
+        )
+
+        with pytest.raises(ValueError) as e:
+            pc.Index(host="my-index")
+        assert "You passed 'my-index' as the host but this does not appear to be valid" in str(
+            e.value
+        )
+
+        # Can instantiate with realistic host
+        pc.Index(host="test-bt8x3su.svc.apw5-4e34-81fa.pinecone.io")
+
+        # Can instantiate with localhost address
+        pc.Index(host="localhost:8080")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -100,9 +100,11 @@ class TestConfig:
             PineconeConfig.build()
 
     def test_config_pool_threads(self):
-        pc = Pinecone(api_key="test-api-key", host="test-controller-host", pool_threads=10)
+        pc = Pinecone(
+            api_key="test-api-key", host="test-controller-host.pinecone.io", pool_threads=10
+        )
         assert pc.index_api.api_client.pool_threads == 10
-        idx = pc.Index(host="my-index-host", name="my-index-name")
+        idx = pc.Index(host="my-index-host.pinecone.io", name="my-index-name")
         assert idx._vector_api.api_client.pool_threads == 10
 
     def test_ssl_config_passed_to_index_client(self):
@@ -112,7 +114,7 @@ class TestConfig:
         assert pc.openapi_config.ssl_ca_cert == "path/to/cert"
         assert pc.openapi_config.proxy_headers == proxy_headers
 
-        idx = pc.Index(host="host")
+        idx = pc.Index(host="host.pinecone.io")
         assert idx._vector_api.api_client.configuration.ssl_ca_cert == "path/to/cert"
         assert idx._vector_api.api_client.configuration.proxy_headers == proxy_headers
 
@@ -124,10 +126,10 @@ class TestConfig:
         assert pc.openapi_config.proxy_headers == proxy_headers
         assert pc.openapi_config.host == "https://api.pinecone.io"
 
-        idx = pc.Index(host="host")
+        idx = pc.Index(host="host.pinecone.io")
         assert idx._vector_api.api_client.configuration.ssl_ca_cert == "path/to/cert"
         assert idx._vector_api.api_client.configuration.proxy_headers == proxy_headers
-        assert idx._vector_api.api_client.configuration.host == "https://host"
+        assert idx._vector_api.api_client.configuration.host == "https://host.pinecone.io"
 
         assert pc.openapi_config.host == "https://api.pinecone.io"
 

--- a/tests/unit/test_config_builder.py
+++ b/tests/unit/test_config_builder.py
@@ -7,27 +7,27 @@ from pinecone import PineconeConfigurationError
 
 class TestConfigBuilder:
     def test_build_simple(self):
-        config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host")
+        config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host.com")
         assert config.api_key == "my-api-key"
-        assert config.host == "https://my-controller-host"
+        assert config.host == "https://my-controller-host.com"
         assert config.additional_headers == {}
 
     def test_build_merges_key_and_host_when_openapi_config_provided(self):
         config = ConfigBuilder.build(
             api_key="my-api-key",
-            host="https://my-controller-host",
+            host="https://my-controller-host.com",
             openapi_config=OpenApiConfiguration(),
         )
         assert config.api_key == "my-api-key"
-        assert config.host == "https://my-controller-host"
+        assert config.host == "https://my-controller-host.com"
         assert config.additional_headers == {}
 
     def test_build_with_source_tag(self):
         config = ConfigBuilder.build(
-            api_key="my-api-key", host="https://my-controller-host", source_tag="my-source-tag"
+            api_key="my-api-key", host="https://my-controller-host.com", source_tag="my-source-tag"
         )
         assert config.api_key == "my-api-key"
-        assert config.host == "https://my-controller-host"
+        assert config.host == "https://my-controller-host.com"
         assert config.additional_headers == {}
         assert config.source_tag == "my-source-tag"
 
@@ -42,13 +42,13 @@ class TestConfigBuilder:
         assert str(e.value) == "You haven't specified a host."
 
     def test_build_openapi_config(self):
-        config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host")
+        config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host.com")
         openapi_config = ConfigBuilder.build_openapi_config(config)
-        assert openapi_config.host == "https://my-controller-host"
+        assert openapi_config.host == "https://my-controller-host.com"
         assert openapi_config.api_key == {"ApiKeyAuth": "my-api-key"}
 
     def test_build_openapi_config_merges_with_existing_config(self):
-        config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host")
+        config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host.com")
         openapi_config = OpenApiConfiguration()
         openapi_config.ssl_ca_cert = "path/to/bundle"
         openapi_config.proxy = "http://my-proxy:8080"
@@ -56,13 +56,13 @@ class TestConfigBuilder:
         openapi_config = ConfigBuilder.build_openapi_config(config, openapi_config)
 
         assert openapi_config.api_key == {"ApiKeyAuth": "my-api-key"}
-        assert openapi_config.host == "https://my-controller-host"
+        assert openapi_config.host == "https://my-controller-host.com"
         assert openapi_config.ssl_ca_cert == "path/to/bundle"
         assert openapi_config.proxy == "http://my-proxy:8080"
 
     def test_build_openapi_config_does_not_mutate_input(self):
         config = ConfigBuilder.build(
-            api_key="my-api-key", host="foo", ssl_ca_certs="path/to/bundle.foo"
+            api_key="my-api-key", host="foo.pinecone.io", ssl_ca_certs="path/to/bundle.foo"
         )
 
         input_openapi_config = OpenApiConfiguration()
@@ -70,7 +70,7 @@ class TestConfigBuilder:
         input_openapi_config.ssl_ca_cert = "asdfasdf"
 
         openapi_config = ConfigBuilder.build_openapi_config(config, input_openapi_config)
-        assert openapi_config.host == "https://foo"
+        assert openapi_config.host == "https://foo.pinecone.io"
         assert openapi_config.ssl_ca_cert == "path/to/bundle.foo"
 
         assert input_openapi_config.host == "bar"

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -2,7 +2,6 @@ import pytest
 import re
 from unittest.mock import patch, MagicMock
 from pinecone import (
-    ConfigBuilder,
     Pinecone,
     PodSpec,
     ServerlessSpec,
@@ -118,13 +117,6 @@ class TestControl:
         assert (
             re.search(r"source_tag=test_source_tag", p.index_api.api_client.user_agent) is not None
         )
-
-    def test_set_source_tag_in_useragent_via_config(self):
-        config = ConfigBuilder.build(
-            api_key="YOUR_API_KEY", host="https://my-host", source_tag="my_source_tag"
-        )
-        p = Pinecone(config=config)
-        assert re.search(r"source_tag=my_source_tag", p.index_api.api_client.user_agent) is not None
 
     @pytest.mark.parametrize(
         "timeout_value, describe_index_responses, expected_describe_index_calls, expected_sleep_calls",

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -33,7 +33,7 @@ def description_with_status(status: bool):
         status=IndexModelStatus(ready=status, state=state),
         dimension=10,
         deletion_protection=DeletionProtection(value="enabled"),
-        host="https://foo",
+        host="https://foo.pinecone.io",
         metric="euclidean",
         spec=IndexModelSpec(serverless=ServerlessSpecOpenApi(cloud="aws", region="us-west1")),
     )
@@ -47,7 +47,7 @@ def index_list_response():
                 name="index1",
                 dimension=10,
                 metric="euclidean",
-                host="asdf",
+                host="asdf.pinecone.io",
                 status={"ready": True},
                 spec={},
                 deletion_protection=DeletionProtection("enabled"),
@@ -57,7 +57,7 @@ def index_list_response():
                 name="index2",
                 dimension=10,
                 metric="euclidean",
-                host="asdf",
+                host="asdf.pinecone.io",
                 status={"ready": True},
                 spec={},
                 deletion_protection=DeletionProtection("enabled"),
@@ -67,7 +67,7 @@ def index_list_response():
                 name="index3",
                 dimension=10,
                 metric="euclidean",
-                host="asdf",
+                host="asdf.pinecone.io",
                 status={"ready": True},
                 spec={},
                 deletion_protection=DeletionProtection("disabled"),
@@ -88,8 +88,8 @@ class TestControl:
         assert p.index_api.api_client.configuration.host == "https://api.pinecone.io"
 
     def test_passing_host(self):
-        p = Pinecone(api_key="123-456-789", host="my-host")
-        assert p.index_api.api_client.configuration.host == "https://my-host"
+        p = Pinecone(api_key="123-456-789", host="my-host.pinecone.io")
+        assert p.index_api.api_client.configuration.host == "https://my-host.pinecone.io"
 
     def test_passing_additional_headers(self):
         extras = {"header1": "my-value", "header2": "my-value2"}

--- a/tests/unit/test_index_initialization.py
+++ b/tests/unit/test_index_initialization.py
@@ -7,7 +7,7 @@ class TestIndexClientInitialization:
     @pytest.mark.parametrize("additional_headers", [None, {}])
     def test_no_additional_headers_leaves_useragent_and_version_only(self, additional_headers):
         pc = Pinecone(api_key="YOUR_API_KEY")
-        index = pc.Index(host="myhost", additional_headers=additional_headers)
+        index = pc.Index(host="myhost.pinecone.io", additional_headers=additional_headers)
         assert len(index._vector_api.api_client.default_headers) == 2
         assert "User-Agent" in index._vector_api.api_client.default_headers
         assert "python-client-" in index._vector_api.api_client.default_headers["User-Agent"]
@@ -15,7 +15,9 @@ class TestIndexClientInitialization:
 
     def test_additional_headers_one_additional(self):
         pc = Pinecone(api_key="YOUR_API_KEY")
-        index = pc.Index(host="myhost", additional_headers={"test-header": "test-header-value"})
+        index = pc.Index(
+            host="myhost.pinecone.io", additional_headers={"test-header": "test-header-value"}
+        )
         assert "test-header" in index._vector_api.api_client.default_headers
         assert "User-Agent" in index._vector_api.api_client.default_headers
         assert "X-Pinecone-API-Version" in index._vector_api.api_client.default_headers
@@ -24,7 +26,7 @@ class TestIndexClientInitialization:
     def test_multiple_additional_headers(self):
         pc = Pinecone(api_key="YOUR_API_KEY")
         index = pc.Index(
-            host="myhost",
+            host="myhost.pinecone.io",
             additional_headers={
                 "test-header": "test-header-value",
                 "test-header2": "test-header-value2",
@@ -38,7 +40,9 @@ class TestIndexClientInitialization:
         # This doesn't seem like a common use case, but we may want to allow this
         # when embedding the client in other pinecone tools such as canopy.
         pc = Pinecone(api_key="YOUR_API_KEY")
-        index = pc.Index(host="myhost", additional_headers={"User-Agent": "test-user-agent"})
+        index = pc.Index(
+            host="myhost.pinecone.io", additional_headers={"User-Agent": "test-user-agent"}
+        )
         assert len(index._vector_api.api_client.default_headers) == 2
         assert "User-Agent" in index._vector_api.api_client.default_headers
         assert index._vector_api.api_client.default_headers["User-Agent"] == "test-user-agent"

--- a/tests/unit/test_index_initialization.py
+++ b/tests/unit/test_index_initialization.py
@@ -1,6 +1,6 @@
 import pytest
 import re
-from pinecone import ConfigBuilder, Pinecone
+from pinecone import Pinecone
 
 
 class TestIndexClientInitialization:
@@ -48,13 +48,4 @@ class TestIndexClientInitialization:
         pc = Pinecone(api_key="123-456-789", source_tag="test_source_tag")
         assert (
             re.search(r"source_tag=test_source_tag", pc.index_api.api_client.user_agent) is not None
-        )
-
-    def test_set_source_tag_via_config(self):
-        config = ConfigBuilder.build(
-            api_key="YOUR_API_KEY", host="https://my-host", source_tag="my_source_tag"
-        )
-        pc = Pinecone(config=config)
-        assert (
-            re.search(r"source_tag=my_source_tag", pc.index_api.api_client.user_agent) is not None
         )

--- a/tests/unit_grpc/test_grpc_index_describe_index_stats.py
+++ b/tests/unit_grpc/test_grpc_index_describe_index_stats.py
@@ -6,7 +6,7 @@ from pinecone.grpc.utils import dict_to_proto_struct
 
 class TestGrpcIndexDescribeIndexStats:
     def setup_method(self):
-        self.config = Config(api_key="test-api-key", host="foo")
+        self.config = Config(api_key="test-api-key", host="foo.pinecone.io")
         self.index = GRPCIndex(
             config=self.config, index_name="example-name", _endpoint_override="test-endpoint"
         )

--- a/tests/unit_grpc/test_grpc_index_fetch.py
+++ b/tests/unit_grpc/test_grpc_index_fetch.py
@@ -5,7 +5,7 @@ from pinecone.core.grpc.protos.db_data_2025_01_pb2 import FetchRequest
 
 class TestGrpcIndexFetch:
     def setup_method(self):
-        self.config = Config(api_key="test-api-key", host="foo")
+        self.config = Config(api_key="test-api-key", host="foo.pinecone.io")
         self.index = GRPCIndex(
             config=self.config, index_name="example-name", _endpoint_override="test-endpoint"
         )

--- a/tests/unit_grpc/test_grpc_index_initialization.py
+++ b/tests/unit_grpc/test_grpc_index_initialization.py
@@ -5,7 +5,7 @@ from pinecone.grpc import PineconeGRPC, GRPCClientConfig
 class TestGRPCIndexInitialization:
     def test_init_with_default_config(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY")
-        index = pc.Index(name="my-index", host="host")
+        index = pc.Index(name="my-index", host="host.pinecone.io")
 
         assert index.grpc_client_config.secure == True
         assert index.grpc_client_config.timeout == 20
@@ -18,7 +18,7 @@ class TestGRPCIndexInitialization:
     def test_init_with_grpc_config_from_dict(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY")
         config = GRPCClientConfig._from_dict({"timeout": 10})
-        index = pc.Index(name="my-index", host="host", grpc_config=config)
+        index = pc.Index(name="my-index", host="host.pinecone.io", grpc_config=config)
 
         assert index.grpc_client_config.timeout == 10
 
@@ -29,7 +29,7 @@ class TestGRPCIndexInitialization:
     def test_init_with_grpc_config_non_dict(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY")
         config = GRPCClientConfig(timeout=10, secure=False)
-        index = pc.Index(name="my-index", host="host", grpc_config=config)
+        index = pc.Index(name="my-index", host="host.pinecone.io", grpc_config=config)
 
         assert index.grpc_client_config.timeout == 10
         assert index.grpc_client_config.secure == False
@@ -58,7 +58,7 @@ class TestGRPCIndexInitialization:
     def test_config_passed_when_target_by_host(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY")
         config = GRPCClientConfig(timeout=5, secure=True)
-        index = pc.Index(host="myhost", grpc_config=config)
+        index = pc.Index(host="myhost.pinecone.io", grpc_config=config)
 
         assert index.grpc_client_config.timeout == 5
         assert index.grpc_client_config.secure == True

--- a/tests/unit_grpc/test_grpc_index_initialization.py
+++ b/tests/unit_grpc/test_grpc_index_initialization.py
@@ -58,7 +58,7 @@ class TestGRPCIndexInitialization:
     def test_config_passed_when_target_by_host(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY")
         config = GRPCClientConfig(timeout=5, secure=True)
-        index = pc.Index(host="myhost.pinecone.io", grpc_config=config)
+        index = pc.Index(host="localhost", grpc_config=config)
 
         assert index.grpc_client_config.timeout == 5
         assert index.grpc_client_config.secure == True
@@ -68,7 +68,7 @@ class TestGRPCIndexInitialization:
         assert index.grpc_client_config.conn_timeout == 1
 
         # Endpoint port defaults to 443
-        assert index._endpoint() == "myhost:443"
+        assert index._endpoint() == "localhost:443"
 
     def test_config_passed_when_target_by_host_and_port(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY")

--- a/tests/unit_grpc/test_grpc_index_query.py
+++ b/tests/unit_grpc/test_grpc_index_query.py
@@ -8,7 +8,7 @@ from pinecone.grpc.utils import dict_to_proto_struct
 
 class TestGrpcIndexQuery:
     def setup_method(self):
-        self.config = Config(api_key="test-api-key", host="foo")
+        self.config = Config(api_key="test-api-key", host="foo.pinecone.io")
         self.index = GRPCIndex(
             config=self.config, index_name="example-name", _endpoint_override="test-endpoint"
         )

--- a/tests/unit_grpc/test_grpc_index_update.py
+++ b/tests/unit_grpc/test_grpc_index_update.py
@@ -6,7 +6,7 @@ from pinecone.grpc.utils import dict_to_proto_struct
 
 class TestGrpcIndexUpdate:
     def setup_method(self):
-        self.config = Config(api_key="test-api-key", host="foo")
+        self.config = Config(api_key="test-api-key", host="foo.pinecone.io")
         self.index = GRPCIndex(
             config=self.config, index_name="example-name", _endpoint_override="test-endpoint"
         )

--- a/tests/unit_grpc/test_grpc_index_upsert.py
+++ b/tests/unit_grpc/test_grpc_index_upsert.py
@@ -87,7 +87,7 @@ def expected_vec_md_sparse2(vals2, md2, sparse_indices_2, sparse_values_2):
 
 class TestGrpcIndexUpsert:
     def setup_method(self):
-        self.config = Config(api_key="test-api-key", host="foo")
+        self.config = Config(api_key="test-api-key", host="foo.pinecone.io")
         self.index = GRPCIndex(
             config=self.config, index_name="example-name", _endpoint_override="test-endpoint"
         )


### PR DESCRIPTION
## Problem

We want to deprecate a few kwargs and give more helpful error messages.

## Solution

- Deprecate `config` and `openapi_config` kwargs; as far as I know these were only used for tests. They have not appeared in documentation. It adds quite a bit of complexity trying to merge configuration from all these sources so going forward we would prefer to just expect configuration from a single source, which are named kwargs.
- Add `NotImplementedError` messages that clearly explain some features that are not implemented yet for PineconeAsyncio. This is preferrable to allowing users to pass kwargs that have no effect, then getting frustrated when they seem not to work.
- Give more informative error when it looks like the user has passed an invalid value as the host

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
