### PR TITLE
Remove explicit tqdm dependency

### DIFF
--- a/pinecone/__init__.py
+++ b/pinecone/__init__.py
@@ -2,11 +2,6 @@
 .. include:: ../README.md
 """
 
-import warnings
-from tqdm import TqdmExperimentalWarning
-
-warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)
-
 from .deprecated_plugins import check_for_deprecated_plugins
 from .deprecation_warnings import *
 from .config import *

--- a/pinecone/data/index.py
+++ b/pinecone/data/index.py
@@ -1,4 +1,4 @@
-from tqdm.autonotebook import tqdm
+from pinecone.utils.tqdm import tqdm
 
 import logging
 import json

--- a/pinecone/data/index_asyncio.py
+++ b/pinecone/data/index_asyncio.py
@@ -1,4 +1,5 @@
-from tqdm.autonotebook import tqdm
+from pinecone.utils.tqdm import tqdm
+
 
 import logging
 import asyncio

--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -207,7 +207,9 @@ class GRPCIndex(GRPCIndexBase):
             results = [
                 async_result.result()
                 for async_result in tqdm(
-                    cast_results, disable=not show_progress, desc="collecting async responses"
+                    iterable=cast_results,
+                    disable=not show_progress,
+                    desc="collecting async responses",
                 )
             ]
 

--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict, Union, List, Tuple, Any, Iterable, cast, Lite
 
 from google.protobuf import json_format
 
-from tqdm.autonotebook import tqdm
+from pinecone.utils.tqdm import tqdm
 from concurrent.futures import as_completed, Future
 
 

--- a/pinecone/utils/tqdm.py
+++ b/pinecone/utils/tqdm.py
@@ -4,20 +4,25 @@ try:
 except ImportError:
     # Fallback: define a dummy tqdm that supports the same interface.
     class tqdm:
-        def __init__(self, total=None, desc=None, disable=False, *args, **kwargs):
+        def __init__(self, iterable=None, total=None, desc="", **kwargs):
+            self.iterable = iterable
             self.total = total
             self.desc = desc
-            self.disable = disable
-            self.current = 0  # to keep track of progress
+            # You can store additional kwargs if needed
+
+        def __iter__(self):
+            # Just iterate over the underlying iterable
+            for item in self.iterable:
+                yield item
 
         def update(self, n=1):
-            # Simply increment the internal counter.
-            self.current += n
+            # No-op: This stub doesn't track progress
+            pass
 
         def __enter__(self):
-            # When entering the context, just return self.
+            # Allow use as a context manager
             return self
 
         def __exit__(self, exc_type, exc_value, traceback):
-            # Nothing special to do when exiting the context.
+            # Nothing to cleanup
             pass

--- a/pinecone/utils/tqdm.py
+++ b/pinecone/utils/tqdm.py
@@ -3,7 +3,7 @@ try:
     from tqdm.auto import tqdm
 except ImportError:
     # Fallback: define a dummy tqdm that supports the same interface.
-    class tqdm:
+    class tqdm:  # type: ignore
         def __init__(self, iterable=None, total=None, desc="", **kwargs):
             self.iterable = iterable
             self.total = total

--- a/pinecone/utils/tqdm.py
+++ b/pinecone/utils/tqdm.py
@@ -1,0 +1,23 @@
+try:
+    # Use the notebook-friendly auto selection if tqdm is installed.
+    from tqdm.auto import tqdm
+except ImportError:
+    # Fallback: define a dummy tqdm that supports the same interface.
+    class tqdm:
+        def __init__(self, total=None, desc=None, disable=False, *args, **kwargs):
+            self.total = total
+            self.desc = desc
+            self.disable = disable
+            self.current = 0  # to keep track of progress
+
+        def update(self, n=1):
+            # Simply increment the internal counter.
+            self.current += n
+
+        def __enter__(self):
+            # When entering the context, just return self.
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            # Nothing special to do when exiting the context.
+            pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -1619,26 +1619,6 @@ files = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.66.3"
-description = "Fast, Extensible Progress Meter"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tqdm-4.66.3-py3-none-any.whl", hash = "sha256:4f41d54107ff9a223dca80b53efe4fb654c67efaba7f47bada3ee9d50e05bd53"},
-    {file = "tqdm-4.66.3.tar.gz", hash = "sha256:23097a41eba115ba99ecae40d06444c15d1c0c698d527a01c6c8bd1c5d0647e5"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[package.extras]
-dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
-notebook = ["ipywidgets (>=6)"]
-slack = ["slack-sdk"]
-telegram = ["requests"]
-
-[[package]]
 name = "types-protobuf"
 version = "4.24.0.4"
 description = "Typing stubs for protobuf"
@@ -1869,4 +1849,4 @@ grpc = ["googleapis-common-protos", "grpcio", "grpcio", "grpcio", "lz4", "protob
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a2fbf9fee6a7ff0e7e8065df37e07b4e0cc58818f0d60c58cc074aae2eae9d56"
+content-hash = "77c1844df36ad78e1d4609f1a135804cf35da0ef5a8df8eaf0c7b177c663139a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ urllib3 = [
   { version = ">=1.26.0", python = ">=3.8,<3.12" },
   { version = ">=1.26.5", python = "^3.12" }
 ]
-tqdm = ">=4.64.1"
 # certifi does not follow semver. Should always be
 # on latest but setting a broad range to have maximum
 # compatibility with libraries that may pin version.

--- a/tests/integration/data/test_upsert_from_dataframe.py
+++ b/tests/integration/data/test_upsert_from_dataframe.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from pinecone.data import _Index
+from ..helpers import embedding_values, random_string
+
+
+class TestUpsertFromDataFrame:
+    def test_upsert_from_dataframe(self, idx: _Index):
+        # Create sample data for testing.
+        data = {
+            "id": ["1", "2", "3"],
+            "values": [embedding_values(), embedding_values(), embedding_values()],
+            "sparse_values": [
+                {"indices": [1], "values": [0.234]},
+                {"indices": [2], "values": [0.432]},
+                {"indices": [3], "values": [0.543]},
+            ],
+            "metadata": [
+                {"source": "generated", "quality": "high"},
+                {"source": "generated", "quality": "medium"},
+                {"source": "generated", "quality": "low"},
+            ],
+        }
+
+        # Create the DataFrame
+        df = pd.DataFrame(data)
+
+        ns = random_string(10)
+        idx.upsert_from_dataframe(df=df, namespace=ns)


### PR DESCRIPTION
## Problem

We want to minimize the number of required dependencies we have, and tqdm is non-essential. Moreover, common notebook environments like Google Colab will already have tqdm loaded even if we do not declare this an explicit dependency.

## Solution

Instead of having a specific dependency on tqdm, we want to detect and use it if it is available in the environment. Otherwise just noop with a stub implementation of our own.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
