### PR TITLE
Expose SSL configurations for PineconeAsyncio

### DIFF
--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -63,14 +63,11 @@ class Pinecone(PineconeDBControlInterface, PluginAware):
         pool_threads: Optional[int] = None,
         **kwargs,
     ):
-        if kwargs.get("config", None):
-            raise Exception(
-                "Passing config is no longer supported. Please pass individual settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at https://github.com/pinecone-io/pinecone-python-client for examples."
-            )
-        if kwargs.get("openapi_config", None):
-            raise Exception(
-                "Passing openapi_config is no longer supported. Please pass individual settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at https://github.com/pinecone-io/pinecone-python-client for examples."
-            )
+        for deprecated_kwarg in {"config", "openapi_config"}:
+            if deprecated_kwarg in kwargs:
+                raise NotImplementedError(
+                    f"Passing {deprecated_kwarg} is no longer supported. Please pass individual settings such as proxy_url, proxy_headers, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at {docslinks['README']} for examples."
+                )
 
         self.config = PineconeConfig.build(
             api_key=api_key,

--- a/pinecone/control/pinecone_asyncio.py
+++ b/pinecone/control/pinecone_asyncio.py
@@ -51,33 +51,33 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
         self,
         api_key: Optional[str] = None,
         host: Optional[str] = None,
-        # proxy_url: Optional[str] = None,
+        proxy_url: Optional[str] = None,
         # proxy_headers: Optional[Dict[str, str]] = None,
-        # ssl_ca_certs: Optional[str] = None,
-        # ssl_verify: Optional[bool] = None,
-        # additional_headers: Optional[Dict[str, str]] = {},
+        ssl_ca_certs: Optional[str] = None,
+        ssl_verify: Optional[bool] = None,
+        additional_headers: Optional[Dict[str, str]] = {},
         **kwargs,
     ):
-        for kwarg in {
-            "additional_headers",
-            "proxy_url",
-            "proxy_headers",
-            "ssl_ca_certs",
-            "ssl_verify",
-        }:
-            if kwarg in kwargs:
+        for deprecated_kwarg in {"config", "openapi_config"}:
+            if deprecated_kwarg in kwargs:
                 raise NotImplementedError(
-                    f"You have passed {kwarg} but this configuration has not been implemented yet for PineconeAsyncio."
+                    f"Passing {deprecated_kwarg} is no longer supported. Please pass individual settings such as proxy_url, ssl_ca_certs, and ssl_verify directly to the Pinecone constructor as keyword arguments. See the README at {docslinks['README']} for examples."
+                )
+
+        for unimplemented_kwarg in {"proxy_headers"}:
+            if unimplemented_kwarg in kwargs:
+                raise NotImplementedError(
+                    f"You have passed {unimplemented_kwarg} but this configuration has not been implemented for PineconeAsyncio."
                 )
 
         self.config = PineconeConfig.build(
             api_key=api_key,
             host=host,
-            additional_headers=None,
-            proxy_url=None,
+            additional_headers=additional_headers,
+            proxy_url=proxy_url,
             proxy_headers=None,
-            ssl_ca_certs=None,
-            ssl_verify=None,
+            ssl_ca_certs=ssl_ca_certs,
+            ssl_verify=ssl_verify,
             **kwargs,
         )
         self.openapi_config = ConfigBuilder.build_openapi_config(self.config, **kwargs)

--- a/pinecone/openapi_support/rest_aiohttp.py
+++ b/pinecone/openapi_support/rest_aiohttp.py
@@ -19,7 +19,7 @@ class AiohttpRestClient(RestClientInterface):
         else:
             ca_certs = certifi.where()
 
-        ssl_context = ssl.create_default_context(cafile=ca_certs, purpose=ssl.Purpose.CLIENT_AUTH)
+        ssl_context = ssl.create_default_context(cafile=ca_certs)
 
         conn = aiohttp.TCPConnector(verify_ssl=configuration.verify_ssl, ssl=ssl_context)
 

--- a/pinecone/openapi_support/rest_aiohttp.py
+++ b/pinecone/openapi_support/rest_aiohttp.py
@@ -1,9 +1,12 @@
+import ssl
+import certifi
 import json
 from .rest_utils import RestClientInterface, RESTResponse, raise_exceptions_or_return
+from .configuration import Configuration
 
 
 class AiohttpRestClient(RestClientInterface):
-    def __init__(self, configuration) -> None:
+    def __init__(self, configuration: Configuration) -> None:
         try:
             import aiohttp
         except ImportError:
@@ -11,8 +14,19 @@ class AiohttpRestClient(RestClientInterface):
                 "Additional dependencies are required to use Pinecone with asyncio. Include these extra dependencies in your project by installing `pinecone[asyncio]`."
             ) from None
 
-        conn = aiohttp.TCPConnector()
-        self._session = aiohttp.ClientSession(connector=conn)
+        if configuration.ssl_ca_cert is not None:
+            ca_certs = configuration.ssl_ca_cert
+        else:
+            ca_certs = certifi.where()
+
+        ssl_context = ssl.create_default_context(cafile=ca_certs, purpose=ssl.Purpose.CLIENT_AUTH)
+
+        conn = aiohttp.TCPConnector(verify_ssl=configuration.verify_ssl, ssl=ssl_context)
+
+        if configuration.proxy:
+            self._session = aiohttp.ClientSession(connector=conn, proxy=configuration.proxy)
+        else:
+            self._session = aiohttp.ClientSession(connector=conn)
 
     async def close(self):
         await self._session.close()

--- a/pinecone/openapi_support/rest_urllib3.py
+++ b/pinecone/openapi_support/rest_urllib3.py
@@ -2,7 +2,9 @@ import json
 import logging
 import ssl
 import os
+from typing import Optional
 from urllib.parse import urlencode, quote
+from .configuration import Configuration
 from .rest_utils import raise_exceptions_or_return, RESTResponse, RestClientInterface
 
 import urllib3
@@ -28,7 +30,9 @@ logger = logging.getLogger(__name__)
 class Urllib3RestClient(RestClientInterface):
     pool_manager: urllib3.PoolManager
 
-    def __init__(self, configuration, pools_size=4, maxsize=None) -> None:
+    def __init__(
+        self, configuration: Configuration, pools_size: int = 4, maxsize: Optional[int] = None
+    ) -> None:
         # urllib3.PoolManager will pass all kw parameters to connectionpool
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/poolmanager.py#L75  # noqa: E501
         # https://github.com/shazow/urllib3/blob/f9409436f83aeb79fbaf090181cd81b784f1b8ce/urllib3/connectionpool.py#L680  # noqa: E501


### PR DESCRIPTION
## Problem

Need to wire up several properties that pass configurations in to the underlying aiohttp library.

## Solution

Wire up several properties for `PineconeAsyncio` that are already supported in `Pinecone`: 
- `additional_headers` to pass extra headers on each request. Useful for internal testing.
- `ssl_verify` to turn off ssl verification. Sometimes useful for testing.
- `proxy_url` to send traffic through a proxy
- `ssl_ca_certs` to specify a custom cert bundle. Expecting a path to a PEM file.

Currently `proxy_headers` is not accepted by `PineconeAsyncio` because I haven't figured out how to use these with aiohttp.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

