### PR TITLE
Add alternative constructor for AsyncioIndex

### DIFF
--- a/pinecone/control/pinecone.py
+++ b/pinecone/control/pinecone.py
@@ -25,7 +25,7 @@ from pinecone.models import (
 from .langchain_import_warnings import _build_langchain_attribute_error_message
 from pinecone.utils import docslinks
 
-from pinecone.data import _Index, _Inference
+from pinecone.data import _Index, _Inference, _AsyncioIndex
 from pinecone.enums import (
     Metric,
     VectorType,
@@ -309,6 +309,24 @@ class Pinecone(PineconeDBControlInterface, PluginAware):
             host=index_host,
             api_key=api_key,
             pool_threads=pt,
+            openapi_config=openapi_config,
+            source_tag=self.config.source_tag,
+            **kwargs,
+        )
+
+    def IndexAsyncio(self, host: str, **kwargs):
+        api_key = self.config.api_key
+        openapi_config = self.openapi_config
+
+        if host is None or host == "":
+            raise ValueError("A host must be specified")
+
+        check_realistic_host(host)
+        index_host = normalize_host(host)
+
+        return _AsyncioIndex(
+            host=index_host,
+            api_key=api_key,
             openapi_config=openapi_config,
             source_tag=self.config.source_tag,
             **kwargs,

--- a/tests/integration/data_asyncio/test_client_instantiation.py
+++ b/tests/integration/data_asyncio/test_client_instantiation.py
@@ -1,0 +1,18 @@
+import pytest
+from pinecone import Pinecone
+from ..helpers import random_string, embedding_values
+
+
+@pytest.mark.asyncio
+async def test_instantiation_through_non_async_client(index_host, dimension):
+    asyncio_idx = Pinecone().IndexAsyncio(host=index_host)
+
+    def emb():
+        return embedding_values(dimension)
+
+    # Upsert with tuples
+    await asyncio_idx.upsert(
+        vectors=[("1", emb()), ("2", emb()), ("3", emb())], namespace=random_string(10)
+    )
+
+    await asyncio_idx.close()


### PR DESCRIPTION
## Problem

If you only care about doing async index oeprations, it's cumbersome to have to manage nested async contexts by going through the `PineconeAsyncio` class.

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
