### PR TITLE
[docs] Remove extra async call in PineconeAsyncio example

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -42,8 +42,6 @@ async def main():
                 )
             )
 
-    async with PineconeAsyncio().Index(host="")
-
 asyncio.run(main())
 ```
 


### PR DESCRIPTION
## Problem

The `PineconeAsyncio` example in the upgrading doc includes an extra `async` call. 

## Solution

Remove the extra call.
