### PR TITLE
Add information to README about package rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ For more information, see the docs at https://docs.pinecone.io
 
 ### Upgrading the SDK
 
+> [!NOTE]
+> The official SDK package was renamed from `pinecone-client` to `pinecone` beginning in version 5.1.0.
+> Please remove `pinecone-client` from your project dependencies and add `pinecone` instead to get
+> the latest updates.
+
 For notes on changes between major versions, see [Upgrading](./docs/upgrading.md)
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The official Pinecone Python SDK.
 ### Upgrading the SDK
 
 > [!NOTE]
-> The official SDK package was renamed from `pinecone-client` to `pinecone` beginning in version 5.1.0.
+> The official SDK package was renamed from `pinecone-client` to `pinecone` beginning in version `5.1.0`.
 > Please remove `pinecone-client` from your project dependencies and add `pinecone` instead to get
 > the latest updates.
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,10 @@
 
 The official Pinecone Python SDK.
 
-For more information, see the docs at https://docs.pinecone.io
-
-
 ## Documentation
 
-- [**Reference Documentation**](https://sdk.pinecone.io/python/index.html)
+- [**Conceptual docs and guides**](https://docs.pinecone.io)
+- [**Python Reference Documentation**](https://sdk.pinecone.io/python/index.html)
 
 ### Upgrading the SDK
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,3 +1,8 @@
+> [!NOTE]
+> The official SDK package was renamed from `pinecone-client` to `pinecone` beginning in version 5.1.0.
+> Please remove `pinecone-client` from your project dependencies and add `pinecone` instead to get
+> the latest updates.
+
 # Upgrading from `5.x` to `6.x`
 
 ## Breaking changes in 6.x


### PR DESCRIPTION
## Problem

The rename of the package from `pinecone-client` to `pinecone` is confusing.

## Solution

Add information to the README that should hopefully help steer people in the right direction.

