### PR TITLE
Remove urllib3 info from useragent string

### DIFF
--- a/pinecone/utils/user_agent.py
+++ b/pinecone/utils/user_agent.py
@@ -1,5 +1,3 @@
-import urllib3
-
 from .version import __version__
 from .constants import SOURCE_TAG
 import re
@@ -19,11 +17,11 @@ def _build_source_tag_field(source_tag):
 
 
 def _get_user_agent(client_id, config):
-    user_agent_details = {"urllib3": urllib3.__version__}
-    user_agent = "{} ({})".format(
-        client_id, ", ".join([f"{k}:{v}" for k, v in user_agent_details.items()])
+    user_agent = (
+        f"{client_id}; {_build_source_tag_field(config.source_tag)}"
+        if config.source_tag
+        else client_id
     )
-    user_agent += f"; {_build_source_tag_field(config.source_tag)}" if config.source_tag else ""
     return user_agent
 
 

--- a/tests/unit/utils/test_setup_openapi_client.py
+++ b/tests/unit/utils/test_setup_openapi_client.py
@@ -19,7 +19,7 @@ class TestSetupOpenAPIClient:
             openapi_config=openapi_config,
             pool_threads=2,
         )
-        user_agent_regex = re.compile(r"python-client-\d+\.\d+\.\d+ \(urllib3\:\d+\.\d+\.\d+\)")
+        user_agent_regex = re.compile(r"python-client-\d+\.\d+\.\d+")
         assert re.match(user_agent_regex, control_plane_client.api_client.user_agent)
         assert re.match(
             user_agent_regex, control_plane_client.api_client.default_headers["User-Agent"]
@@ -38,7 +38,7 @@ class TestSetupOpenAPIClient:
             pool_threads=2,
             api_version="2024-04",
         )
-        user_agent_regex = re.compile(r"python-client-\d+\.\d+\.\d+ \(urllib3\:\d+\.\d+\.\d+\)")
+        user_agent_regex = re.compile(r"python-client-\d+\.\d+\.\d+")
         assert re.match(user_agent_regex, control_plane_client.api_client.user_agent)
         assert re.match(
             user_agent_regex, control_plane_client.api_client.default_headers["User-Agent"]
@@ -102,7 +102,7 @@ class TestBuildPluginSetupClient:
         assert isinstance(plugin_client, plugin_api)
 
         # We want requests from plugins to have a user-agent matching the host SDK.
-        user_agent_regex = re.compile(r"python-client-\d+\.\d+\.\d+ \(urllib3\:\d+\.\d+\.\d+\)")
+        user_agent_regex = re.compile(r"python-client-\d+\.\d+\.\d+")
         assert re.match(user_agent_regex, plugin_client.api_client.user_agent)
         assert re.match(user_agent_regex, plugin_client.api_client.default_headers["User-Agent"])
 

--- a/tests/unit/utils/test_user_agent.py
+++ b/tests/unit/utils/test_user_agent.py
@@ -7,30 +7,38 @@ class TestUserAgent:
     def test_user_agent(self):
         config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host")
         useragent = get_user_agent(config)
-        assert re.search(r"python-client-\d+\.\d+\.\d+", useragent) is not None
-        assert re.search(r"urllib3:\d+\.\d+\.\d+", useragent) is not None
+        assert re.search(r"^python-client-\d+\.\d+\.\d+$", useragent) is not None
 
     def test_user_agent_with_source_tag(self):
         config = ConfigBuilder.build(
             api_key="my-api-key", host="https://my-controller-host", source_tag="my_source_tag"
         )
         useragent = get_user_agent(config)
-        assert re.search(r"python-client-\d+\.\d+\.\d+", useragent) is not None
-        assert re.search(r"urllib3:\d+\.\d+\.\d+", useragent) is not None
-        assert re.search(r"source_tag=my_source_tag", useragent) is not None
+        assert (
+            re.search(r"^python-client-\d+\.\d+\.\d+; source_tag=my_source_tag$", useragent)
+            is not None
+        )
 
     def test_source_tag_is_normalized(self):
         config = ConfigBuilder.build(
             api_key="my-api-key", host="https://my-controller-host", source_tag="my source tag!!!!"
         )
         useragent = get_user_agent(config)
-        assert re.search(r"source_tag=my_source_tag", useragent) is not None
+        assert (
+            re.search(r"^python-client-\d+\.\d+\.\d+; source_tag=my_source_tag$", useragent)
+            is not None
+        )
+        assert "!!!!" not in useragent
 
         config = ConfigBuilder.build(
             api_key="my-api-key", host="https://my-controller-host", source_tag="My Source Tag"
         )
         useragent = get_user_agent(config)
-        assert re.search(r"source_tag=my_source_tag", useragent) is not None
+        assert (
+            re.search(r"^python-client-\d+\.\d+\.\d+; source_tag=my_source_tag$", useragent)
+            is not None
+        )
+        assert "My Source Tag" not in useragent
 
         config = ConfigBuilder.build(
             api_key="my-api-key",
@@ -46,25 +54,31 @@ class TestUserAgent:
             source_tag="   My Source Tag  123 #### !! ",
         )
         useragent = get_user_agent(config)
-        assert re.search(r"source_tag=my_source_tag_123", useragent) is not None
+        assert (
+            re.search(r"^python-client-\d+\.\d+\.\d+; source_tag=my_source_tag_123$", useragent)
+            is not None
+        )
 
         config = ConfigBuilder.build(
             api_key="my-api-key", host="https://my-controller-host", source_tag="colon:allowed"
         )
         useragent = get_user_agent(config)
-        assert re.search(r"source_tag=colon:allowed", useragent) is not None
+        assert (
+            re.search(r"^python-client-\d+\.\d+\.\d+; source_tag=colon:allowed$", useragent)
+            is not None
+        )
 
     def test_user_agent_grpc(self):
         config = ConfigBuilder.build(api_key="my-api-key", host="https://my-controller-host")
         useragent = get_user_agent_grpc(config)
         assert re.search(r"python-client\[grpc\]-\d+\.\d+\.\d+", useragent) is not None
-        assert re.search(r"urllib3:\d+\.\d+\.\d+", useragent) is not None
 
     def test_user_agent_grpc_with_source_tag(self):
         config = ConfigBuilder.build(
             api_key="my-api-key", host="https://my-controller-host", source_tag="my_source_tag"
         )
         useragent = get_user_agent_grpc(config)
-        assert re.search(r"python-client\[grpc\]-\d+\.\d+\.\d+", useragent) is not None
-        assert re.search(r"urllib3:\d+\.\d+\.\d+", useragent) is not None
-        assert re.search(r"source_tag=my_source_tag", useragent) is not None
+        assert (
+            re.search(r"^python-client\[grpc\]-\d+\.\d+\.\d+; source_tag=my_source_tag$", useragent)
+            is not None
+        )


### PR DESCRIPTION
## Problem

- Currently we send urllib3 version in the user agent string
- Testing with importtime shows importing urllib3 just to get the version extends the initial load time of the pinecone package by about 35 milliseconds.

## Solution

I confirmed we're not using this information in the header, so we should remove it to improve initialization performance.

## Test Plan

- Analysis with showed Loading this urllib3 to get the version was adding 35 milliseconds to the time needed to "from pinecone import Pinecone"
- Updated unit tests