### PR TITLE
Fix: PineconeGrpcFuture blocks during construction

### DIFF
--- a/pinecone/grpc/future.py
+++ b/pinecone/grpc/future.py
@@ -30,8 +30,9 @@ class PineconeGrpcFuture(ConcurrentFuture):
         if self.done():
             return
 
-        if grpc_future.running():
-            self.set_running_or_notify_cancel()
+        if grpc_future.running() and not self.running():
+            if not self.set_running_or_notify_cancel():
+                grpc_future.cancel()
         elif grpc_future.cancelled():
             self.cancel()
         elif grpc_future.done():

--- a/pinecone/grpc/future.py
+++ b/pinecone/grpc/future.py
@@ -30,18 +30,16 @@ class PineconeGrpcFuture(ConcurrentFuture):
         if self.done():
             return
 
-        if grpc_future.cancelled():
+        if grpc_future.running():
+            self.set_running_or_notify_cancel()
+        elif grpc_future.cancelled():
             self.cancel()
-        elif grpc_future.exception(timeout=self._default_timeout):
-            self.set_exception(grpc_future.exception())
         elif grpc_future.done():
             try:
                 result = grpc_future.result(timeout=self._default_timeout)
                 self.set_result(result)
             except Exception as e:
                 self.set_exception(e)
-        elif grpc_future.running():
-            self.set_running_or_notify_cancel()
 
     def set_result(self, result):
         if self._result_transformer:

--- a/tests/unit_grpc/test_futures.py
+++ b/tests/unit_grpc/test_futures.py
@@ -15,6 +15,8 @@ def mock_grpc_future(
     grpc_future.exception.return_value = exception
     grpc_future.running.return_value = running
     grpc_future.result.return_value = result
+    if exception:
+        grpc_future.result.side_effect = exception
     return grpc_future
 
 
@@ -309,6 +311,7 @@ class TestPineconeGrpcFuture:
     def test_exception_when_done_maps_grpc_exception(self, mocker):
         grpc_future = mock_grpc_future(mocker, done=True)
         grpc_future.exception.return_value = FakeGrpcError(mocker)
+        grpc_future.result.side_effect = grpc_future.exception.return_value
 
         future = PineconeGrpcFuture(grpc_future)
 
@@ -467,6 +470,7 @@ class TestPineconeGrpcFuture:
 
         grpc_future2 = mock_grpc_future(mocker, done=True)
         grpc_future2.exception.return_value = Exception("Simulated gRPC error")
+        grpc_future2.result.side_effect = grpc_future2.exception.return_value
         future2 = PineconeGrpcFuture(grpc_future2)
 
         from concurrent.futures import wait, FIRST_EXCEPTION


### PR DESCRIPTION
## Problem

When using grpc with `async_req=True`, the construction of a `PineconeGrpcFuture` would call `_sync_state`, which would do a blocking call to `grpc_future.exception(...)`. This means that the async reqs were all blocking in practice.

Describe the purpose of this change. What problem is being solved and why?

## Solution

We can fix it by checking if the future is still running and not doing any blocking calls when it is.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

How I tested it:

- Before: Run a long query in a loop and hit ctrl-c. Observe the traceback containing `PineconeGrpcFuture()`
- After: Run a long query in a loop and hit ctrl-c. Observe the traceback containing your `.result()` call instead.

