### PR TITLE
Add BYOC support to `create_index`, `describe_index`, `list_indexes`

### DIFF
--- a/pinecone/__init__.py
+++ b/pinecone/__init__.py
@@ -71,6 +71,7 @@ _db_control_lazy_imports = {
     "IndexList": ("pinecone.db_control.models", "IndexList"),
     "IndexModel": ("pinecone.db_control.models", "IndexModel"),
     "IndexEmbed": ("pinecone.db_control.models", "IndexEmbed"),
+    "ByocSpec": ("pinecone.db_control.models", "ByocSpec"),
     "ServerlessSpec": ("pinecone.db_control.models", "ServerlessSpec"),
     "ServerlessSpecDefinition": ("pinecone.db_control.models", "ServerlessSpecDefinition"),
     "PodSpec": ("pinecone.db_control.models", "PodSpec"),

--- a/pinecone/db_control/models/__init__.py
+++ b/pinecone/db_control/models/__init__.py
@@ -2,6 +2,7 @@ from .index_description import ServerlessSpecDefinition, PodSpecDefinition
 from .collection_description import CollectionDescription
 from .serverless_spec import ServerlessSpec
 from .pod_spec import PodSpec
+from .byoc_spec import ByocSpec
 from .index_list import IndexList
 from .collection_list import CollectionList
 from .index_model import IndexModel
@@ -18,6 +19,7 @@ __all__ = [
     "PodSpecDefinition",
     "ServerlessSpec",
     "ServerlessSpecDefinition",
+    "ByocSpec",
     "IndexList",
     "CollectionList",
     "IndexModel",

--- a/pinecone/db_control/models/byoc_spec.py
+++ b/pinecone/db_control/models/byoc_spec.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ByocSpec:
+    """
+    ByocSpec represents the configuration used to deploy a BYOC (Bring Your Own Cloud) index.
+
+    To learn more about the options for each configuration, please see [Understanding Indexes](https://docs.pinecone.io/docs/indexes)
+    """
+
+    environment: str

--- a/pinecone/db_control/resources/asyncio/index.py
+++ b/pinecone/db_control/resources/asyncio/index.py
@@ -3,7 +3,14 @@ import asyncio
 from typing import Optional, Dict, Union
 
 
-from pinecone.db_control.models import ServerlessSpec, PodSpec, IndexModel, IndexList, IndexEmbed
+from pinecone.db_control.models import (
+    ServerlessSpec,
+    PodSpec,
+    ByocSpec,
+    IndexModel,
+    IndexList,
+    IndexEmbed,
+)
 from pinecone.utils import docslinks
 
 from pinecone.db_control.enums import (
@@ -33,7 +40,7 @@ class IndexResourceAsyncio:
     async def create(
         self,
         name: str,
-        spec: Union[Dict, ServerlessSpec, PodSpec],
+        spec: Union[Dict, ServerlessSpec, PodSpec, ByocSpec],
         dimension: Optional[int] = None,
         metric: Optional[Union[Metric, str]] = Metric.COSINE,
         timeout: Optional[int] = None,

--- a/pinecone/db_control/resources/sync/index.py
+++ b/pinecone/db_control/resources/sync/index.py
@@ -4,7 +4,14 @@ from typing import Optional, Dict, Union
 
 from pinecone.db_control.index_host_store import IndexHostStore
 
-from pinecone.db_control.models import ServerlessSpec, PodSpec, IndexModel, IndexList, IndexEmbed
+from pinecone.db_control.models import (
+    ServerlessSpec,
+    PodSpec,
+    ByocSpec,
+    IndexModel,
+    IndexList,
+    IndexEmbed,
+)
 from pinecone.utils import docslinks, require_kwargs
 
 from pinecone.db_control.enums import (
@@ -39,7 +46,7 @@ class IndexResource:
     def create(
         self,
         name: str,
-        spec: Union[Dict, ServerlessSpec, PodSpec],
+        spec: Union[Dict, ServerlessSpec, PodSpec, ByocSpec],
         dimension: Optional[int] = None,
         metric: Optional[Union[Metric, str]] = Metric.COSINE,
         timeout: Optional[int] = None,

--- a/pinecone/legacy_pinecone_interface.py
+++ b/pinecone/legacy_pinecone_interface.py
@@ -6,6 +6,7 @@ if TYPE_CHECKING:
     from pinecone.db_control.models import (
         ServerlessSpec,
         PodSpec,
+        ByocSpec,
         IndexList,
         CollectionList,
         IndexModel,
@@ -194,7 +195,7 @@ class LegacyPineconeDBControlInterface(ABC):
     def create_index(
         self,
         name: str,
-        spec: Union[Dict, "ServerlessSpec", "PodSpec"],
+        spec: Union[Dict, "ServerlessSpec", "PodSpec", "ByocSpec"],
         dimension: Optional[int],
         metric: Optional[Union["Metric", str]] = "Metric.COSINE",
         timeout: Optional[int] = None,
@@ -214,7 +215,7 @@ class LegacyPineconeDBControlInterface(ABC):
         :type metric: str, optional
         :param spec: A dictionary containing configurations describing how the index should be deployed. For serverless indexes,
             specify region and cloud. For pod indexes, specify replicas, shards, pods, pod_type, metadata_config, and source_collection.
-            Alternatively, use the `ServerlessSpec` or `PodSpec` objects to specify these configurations.
+            Alternatively, use the `ServerlessSpec`, `PodSpec`, or `ByocSpec` objects to specify these configurations.
         :type spec: Dict
         :param dimension: If you are creating an index with `vector_type="dense"` (which is the default), you need to specify `dimension` to indicate the size of your vectors.
             This should match the dimension of the embeddings you will be inserting. For example, if you are using

--- a/pinecone/pinecone.py
+++ b/pinecone/pinecone.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from pinecone.db_control.models import (
         ServerlessSpec,
         PodSpec,
+        ByocSpec,
         IndexModel,
         IndexList,
         CollectionList,
@@ -177,7 +178,7 @@ class Pinecone(PluginAware, LegacyPineconeDBControlInterface):
     def create_index(
         self,
         name: str,
-        spec: Union[Dict, "ServerlessSpec", "PodSpec"],
+        spec: Union[Dict, "ServerlessSpec", "PodSpec", "ByocSpec"],
         dimension: Optional[int] = None,
         metric: Optional[Union["Metric", str]] = "cosine",
         timeout: Optional[int] = None,

--- a/pinecone/pinecone_asyncio.py
+++ b/pinecone/pinecone_asyncio.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from pinecone.db_control.models import (
         ServerlessSpec,
         PodSpec,
+        ByocSpec,
         IndexModel,
         IndexList,
         CollectionList,
@@ -195,7 +196,7 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
     async def create_index(
         self,
         name: str,
-        spec: Union[Dict, "ServerlessSpec", "PodSpec"],
+        spec: Union[Dict, "ServerlessSpec", "PodSpec", "ByocSpec"],
         dimension: Optional[int] = None,
         metric: Optional[Union["Metric", str]] = "cosine",
         timeout: Optional[int] = None,

--- a/pinecone/pinecone_interface_asyncio.py
+++ b/pinecone/pinecone_interface_asyncio.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from pinecone.db_control.models import (
         ServerlessSpec,
         PodSpec,
+        ByocSpec,
         IndexList,
         CollectionList,
         IndexModel,
@@ -294,14 +295,12 @@ class PineconeAsyncioDBControlInterface(ABC):
     async def create_index(
         self,
         name: str,
-        spec: Union[Dict, "ServerlessSpec", "PodSpec"],
+        spec: Union[Dict, "ServerlessSpec", "PodSpec", "ByocSpec"],
         dimension: Optional[int],
-        metric: Optional[Union["Metric", str]] = "Metric.COSINE",
+        metric: Optional[Union["Metric", str]] = "cosine",
         timeout: Optional[int] = None,
-        deletion_protection: Optional[
-            Union["DeletionProtection", str]
-        ] = "DeletionProtection.DISABLED",
-        vector_type: Optional[Union["VectorType", str]] = "VectorType.DENSE",
+        deletion_protection: Optional[Union["DeletionProtection", str]] = "disabled",
+        vector_type: Optional[Union["VectorType", str]] = "dense",
         tags: Optional[Dict[str, str]] = None,
     ):
         """Creates a Pinecone index.
@@ -417,9 +416,7 @@ class PineconeAsyncioDBControlInterface(ABC):
         region: Union["AwsRegion", "GcpRegion", "AzureRegion", str],
         embed: Union["IndexEmbed", "CreateIndexForModelEmbedTypedDict"],
         tags: Optional[Dict[str, str]] = None,
-        deletion_protection: Optional[
-            Union["DeletionProtection", str]
-        ] = "DeletionProtection.DISABLED",
+        deletion_protection: Optional[Union["DeletionProtection", str]] = "disabled",
         timeout: Optional[int] = None,
     ) -> "IndexModel":
         """

--- a/tests/unit/db_control/test_index.py
+++ b/tests/unit/db_control/test_index.py
@@ -1,0 +1,62 @@
+import json
+
+from pinecone import Config
+
+from pinecone.db_control.resources.sync.index import IndexResource
+from pinecone.openapi_support.api_client import ApiClient
+from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
+
+
+def build_client_w_faked_response(mocker, body: str, status: int = 200):
+    response = mocker.Mock()
+    response.headers = {"content-type": "application/json"}
+    response.status = status
+    # Parse the JSON string into a dict
+    response_data = json.loads(body)
+    response.data = json.dumps(response_data).encode("utf-8")
+
+    api_client = ApiClient()
+    mock_request = mocker.patch.object(
+        api_client.rest_client.pool_manager, "request", return_value=response
+    )
+    index_api = ManageIndexesApi(api_client=api_client)
+    return IndexResource(index_api=index_api, config=Config(api_key="test-api-key")), mock_request
+
+
+class TestIndexResource:
+    def test_describe_index(self, mocker):
+        body = """
+        {
+            "name": "test-index",
+            "description": "test-description",
+            "dimension": 1024,
+            "metric": "cosine",
+            "spec": {
+                "byoc": {
+                    "environment": "test-environment"
+                }
+            },
+            "vector_type": "dense",
+            "status": {
+                "ready": true,
+                "state": "Ready"
+            },
+            "host": "test-host.pinecone.io",
+            "deletion_protection": "disabled",
+            "tags": {
+                "test-tag": "test-value"
+            }
+        }
+        """
+        index_resource, mock_request = build_client_w_faked_response(mocker, body)
+
+        desc = index_resource.describe(name="test-index")
+        assert desc.name == "test-index"
+        assert desc.description == "test-description"
+        assert desc.dimension == 1024
+        assert desc.metric == "cosine"
+        assert desc.spec.byoc.environment == "test-environment"
+        assert desc.vector_type == "dense"
+        assert desc.status.ready == True
+        assert desc.deletion_protection == "disabled"
+        assert desc.tags["test-tag"] == "test-value"

--- a/tests/unit/db_control/test_index_request_factory.py
+++ b/tests/unit/db_control/test_index_request_factory.py
@@ -1,0 +1,62 @@
+from pinecone import ByocSpec, ServerlessSpec
+from pinecone.db_control.request_factory import PineconeDBControlRequestFactory
+
+
+class TestIndexRequestFactory:
+    def test_create_index_request_with_spec_byoc(self):
+        req = PineconeDBControlRequestFactory.create_index_request(
+            name="test-index",
+            metric="cosine",
+            dimension=1024,
+            spec=ByocSpec(environment="test-byoc-spec-id"),
+        )
+        assert req.name == "test-index"
+        assert req.metric == "cosine"
+        assert req.dimension == 1024
+        assert req.spec.byoc.environment == "test-byoc-spec-id"
+        assert req.vector_type == "dense"
+        assert req.deletion_protection.value == "disabled"
+
+    def test_create_index_request_with_spec_serverless(self):
+        req = PineconeDBControlRequestFactory.create_index_request(
+            name="test-index",
+            metric="cosine",
+            dimension=1024,
+            spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+        )
+        assert req.name == "test-index"
+        assert req.metric == "cosine"
+        assert req.dimension == 1024
+        assert req.spec.serverless.cloud == "aws"
+        assert req.spec.serverless.region == "us-east-1"
+        assert req.vector_type == "dense"
+        assert req.deletion_protection.value == "disabled"
+
+    def test_create_index_request_with_spec_serverless_dict(self):
+        req = PineconeDBControlRequestFactory.create_index_request(
+            name="test-index",
+            metric="cosine",
+            dimension=1024,
+            spec={"serverless": {"cloud": "aws", "region": "us-east-1"}},
+        )
+        assert req.name == "test-index"
+        assert req.metric == "cosine"
+        assert req.dimension == 1024
+        assert req.spec.serverless.cloud == "aws"
+        assert req.spec.serverless.region == "us-east-1"
+        assert req.vector_type == "dense"
+        assert req.deletion_protection.value == "disabled"
+
+    def test_create_index_request_with_spec_byoc_dict(self):
+        req = PineconeDBControlRequestFactory.create_index_request(
+            name="test-index",
+            metric="cosine",
+            dimension=1024,
+            spec={"byoc": {"environment": "test-byoc-spec-id"}},
+        )
+        assert req.name == "test-index"
+        assert req.metric == "cosine"
+        assert req.dimension == 1024
+        assert req.spec.byoc.environment == "test-byoc-spec-id"
+        assert req.vector_type == "dense"
+        assert req.deletion_protection.value == "disabled"


### PR DESCRIPTION
## Problem

BYOC requires a new type of spec object, `ByocSpec`.

## Solution

- Update legacy-style methods to accept new `ByocSpec` type:
    - `Pinecone#create_index`
    - `PineconeAsyncio#create_index`
- Update resource classes (accessed from `pc.db.index.create`)
    - `IndexResource#create`
    - `AsyncioIndexResource#create`
- Update interfaces used for docgen

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

- Added a new unit test to ensure the client can properly deserialize API responses (e.g. from describe, list) that include the new byoc spec type into the `IndexModel` object. This is important since I'm currently not set up to do a full integration test of the feature.   