### PR TITLE
Make resource classes extend `PluginAware` so they can be extended in the future

### DIFF
--- a/pinecone/db_control/resources/sync/backup.py
+++ b/pinecone/db_control/resources/sync/backup.py
@@ -1,15 +1,35 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
 from pinecone.core.openapi.db_control.model.create_backup_request import CreateBackupRequest
 from pinecone.db_control.models import BackupModel, BackupList
-from pinecone.utils import parse_non_empty_args, require_kwargs
+from pinecone.utils import parse_non_empty_args, require_kwargs, PluginAware
+
+if TYPE_CHECKING:
+    from pinecone.config import Config, OpenApiConfiguration
 
 
-class BackupResource:
-    def __init__(self, index_api: ManageIndexesApi):
+class BackupResource(PluginAware):
+    def __init__(
+        self,
+        index_api: ManageIndexesApi,
+        config: "Config",
+        openapi_config: "OpenApiConfiguration",
+        pool_threads: int,
+    ):
         self._index_api = index_api
         """ @private """
+
+        self.config = config
+        """ @private """
+
+        self._openapi_config = openapi_config
+        """ @private """
+
+        self._pool_threads = pool_threads
+        """ @private """
+
+        super().__init__()  # Initialize PluginAware
 
     @require_kwargs
     def list(

--- a/pinecone/db_control/resources/sync/collection.py
+++ b/pinecone/db_control/resources/sync/collection.py
@@ -1,17 +1,40 @@
+from typing import TYPE_CHECKING
 import logging
 
 from pinecone.db_control.models import CollectionList
 from pinecone.db_control.request_factory import PineconeDBControlRequestFactory
-from pinecone.utils import require_kwargs
+from pinecone.utils import PluginAware, require_kwargs
 
 logger = logging.getLogger(__name__)
 """ @private """
 
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
+    from pinecone.config import Config, OpenApiConfiguration
 
-class CollectionResource:
-    def __init__(self, index_api):
+
+class CollectionResource(PluginAware):
+    def __init__(
+        self,
+        index_api: "ManageIndexesApi",
+        config: "Config",
+        openapi_config: "OpenApiConfiguration",
+        pool_threads: int,
+    ):
         self.index_api = index_api
         """ @private """
+
+
+        self.config = config
+        """ @private """
+
+        self._openapi_config = openapi_config
+        """ @private """
+
+        self._pool_threads = pool_threads
+        """ @private """
+
+        super().__init__()  # Initialize PluginAware
 
     @require_kwargs
     def create(self, *, name: str, source: str) -> None:

--- a/pinecone/db_control/resources/sync/index.py
+++ b/pinecone/db_control/resources/sync/index.py
@@ -93,9 +93,9 @@ class IndexResource(PluginAware):
         self,
         *,
         name: str,
-        cloud: Union[CloudProvider, str],
-        region: Union[AwsRegion, GcpRegion, AzureRegion, str],
-        embed: Union["IndexEmbed", CreateIndexForModelEmbedTypedDict],
+        cloud: Union["CloudProvider", str],
+        region: Union["AwsRegion", "GcpRegion", "AzureRegion", str],
+        embed: Union["IndexEmbed", "CreateIndexForModelEmbedTypedDict"],
         tags: Optional[Dict[str, str]] = None,
         deletion_protection: Optional[Union["DeletionProtection", str]] = "disabled",
         timeout: Optional[int] = None,
@@ -238,8 +238,8 @@ class IndexResource(PluginAware):
         *,
         name: str,
         replicas: Optional[int] = None,
-        pod_type: Optional[Union[PodType, str]] = None,
-        deletion_protection: Optional[Union[DeletionProtection, str]] = None,
+        pod_type: Optional[Union["PodType", str]] = None,
+        deletion_protection: Optional[Union["DeletionProtection", str]] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> None:
         api_instance = self._index_api

--- a/pinecone/db_control/resources/sync/index.py
+++ b/pinecone/db_control/resources/sync/index.py
@@ -1,59 +1,76 @@
 import time
 import logging
-from typing import Optional, Dict, Union
+from typing import Optional, Dict, Union, TYPE_CHECKING
 
 from pinecone.db_control.index_host_store import IndexHostStore
 
 from pinecone.db_control.models import (
-    ServerlessSpec,
-    PodSpec,
-    ByocSpec,
     IndexModel,
     IndexList,
     IndexEmbed,
 )
-from pinecone.utils import docslinks, require_kwargs
+from pinecone.utils import docslinks, require_kwargs, PluginAware
 
-from pinecone.db_control.enums import (
-    Metric,
-    VectorType,
-    DeletionProtection,
-    PodType,
-    CloudProvider,
-    AwsRegion,
-    GcpRegion,
-    AzureRegion,
-)
 from pinecone.db_control.types import CreateIndexForModelEmbedTypedDict
 from pinecone.db_control.request_factory import PineconeDBControlRequestFactory
 from pinecone.core.openapi.db_control import API_VERSION
+from pinecone.db_control.models import IndexModel, IndexList
 
 logger = logging.getLogger(__name__)
 """ @private """
 
+if TYPE_CHECKING:
+    from pinecone.config import Config, OpenApiConfiguration
+    from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
+    from pinecone.db_control.enums import (
+        Metric,
+        VectorType,
+        DeletionProtection,
+        PodType,
+        CloudProvider,
+        AwsRegion,
+        GcpRegion,
+        AzureRegion,
+    )
+    from pinecone.db_control.models import ServerlessSpec, PodSpec, ByocSpec, IndexEmbed
 
-class IndexResource:
-    def __init__(self, index_api, config):
+
+class IndexResource(PluginAware):
+    def __init__(
+        self,
+        index_api: "ManageIndexesApi",
+        config: "Config",
+        openapi_config: "OpenApiConfiguration",
+        pool_threads: int,
+    ):
         self._index_api = index_api
         """ @private """
 
-        self._config = config
+        self.config = config
+        """ @private """
+
+        self._openapi_config = openapi_config
+        """ @private """
+
+        self._pool_threads = pool_threads
         """ @private """
 
         self._index_host_store = IndexHostStore()
         """ @private """
+    
+        super().__init__()  # Initialize PluginAware
 
     @require_kwargs
     def create(
         self,
         *,
         name: str,
-        spec: Union[Dict, ServerlessSpec, PodSpec, ByocSpec],
+        spec: Union[Dict, "ServerlessSpec", "PodSpec", "ByocSpec"],
         dimension: Optional[int] = None,
-        metric: Optional[Union[Metric, str]] = Metric.COSINE,
+        metric: Optional[Union["Metric", str]] = "cosine",
         timeout: Optional[int] = None,
-        deletion_protection: Optional[Union[DeletionProtection, str]] = DeletionProtection.DISABLED,
-        vector_type: Optional[Union[VectorType, str]] = VectorType.DENSE,
+        deletion_protection: Optional[Union["DeletionProtection", str]] = "disabled",
+        vector_type: Optional[Union["VectorType", str]] = "dense",
         tags: Optional[Dict[str, str]] = None,
     ) -> IndexModel:
         req = PineconeDBControlRequestFactory.create_index_request(
@@ -78,9 +95,9 @@ class IndexResource:
         name: str,
         cloud: Union[CloudProvider, str],
         region: Union[AwsRegion, GcpRegion, AzureRegion, str],
-        embed: Union[IndexEmbed, CreateIndexForModelEmbedTypedDict],
+        embed: Union["IndexEmbed", CreateIndexForModelEmbedTypedDict],
         tags: Optional[Dict[str, str]] = None,
-        deletion_protection: Optional[Union[DeletionProtection, str]] = DeletionProtection.DISABLED,
+        deletion_protection: Optional[Union["DeletionProtection", str]] = "disabled",
         timeout: Optional[int] = None,
     ) -> IndexModel:
         req = PineconeDBControlRequestFactory.create_index_for_model_request(
@@ -103,7 +120,7 @@ class IndexResource:
         *,
         name: str,
         backup_id: str,
-        deletion_protection: Optional[Union[DeletionProtection, str]] = DeletionProtection.DISABLED,
+        deletion_protection: Optional[Union["DeletionProtection", str]] = "disabled",
         tags: Optional[Dict[str, str]] = None,
         timeout: Optional[int] = None,
     ) -> IndexModel:
@@ -171,9 +188,9 @@ class IndexResource:
         return description
 
     @require_kwargs
-    def delete(self, *, name: str, timeout: Optional[int] = None):
+    def delete(self, *, name: str, timeout: Optional[int] = None) -> None:
         self._index_api.delete_index(name)
-        self._index_host_store.delete_host(self._config, name)
+        self._index_host_store.delete_host(self.config, name)
 
         if timeout == -1:
             return
@@ -204,7 +221,7 @@ class IndexResource:
         api_instance = self._index_api
         description = api_instance.describe_index(name)
         host = description.host
-        self._index_host_store.set_host(self._config, name, host)
+        self._index_host_store.set_host(self.config, name, host)
 
         return IndexModel(description)
 
@@ -224,7 +241,7 @@ class IndexResource:
         pod_type: Optional[Union[PodType, str]] = None,
         deletion_protection: Optional[Union[DeletionProtection, str]] = None,
         tags: Optional[Dict[str, str]] = None,
-    ):
+    ) -> None:
         api_instance = self._index_api
         description = self.describe(name=name)
 
@@ -240,5 +257,5 @@ class IndexResource:
     def _get_host(self, name: str) -> str:
         """@private"""
         return self._index_host_store.get_host(
-            api=self._index_api, config=self._config, index_name=name
+            api=self._index_api, config=self.config, index_name=name
         )

--- a/pinecone/db_control/resources/sync/index.py
+++ b/pinecone/db_control/resources/sync/index.py
@@ -4,17 +4,12 @@ from typing import Optional, Dict, Union, TYPE_CHECKING
 
 from pinecone.db_control.index_host_store import IndexHostStore
 
-from pinecone.db_control.models import (
-    IndexModel,
-    IndexList,
-    IndexEmbed,
-)
+from pinecone.db_control.models import IndexModel, IndexList, IndexEmbed
 from pinecone.utils import docslinks, require_kwargs, PluginAware
 
 from pinecone.db_control.types import CreateIndexForModelEmbedTypedDict
 from pinecone.db_control.request_factory import PineconeDBControlRequestFactory
 from pinecone.core.openapi.db_control import API_VERSION
-from pinecone.db_control.models import IndexModel, IndexList
 
 logger = logging.getLogger(__name__)
 """ @private """
@@ -57,7 +52,7 @@ class IndexResource(PluginAware):
 
         self._index_host_store = IndexHostStore()
         """ @private """
-    
+
         super().__init__()  # Initialize PluginAware
 
     @require_kwargs

--- a/pinecone/db_control/resources/sync/restore_job.py
+++ b/pinecone/db_control/resources/sync/restore_job.py
@@ -1,14 +1,34 @@
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
-from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
 from pinecone.db_control.models import RestoreJobModel, RestoreJobList
-from pinecone.utils import parse_non_empty_args, require_kwargs
+from pinecone.utils import parse_non_empty_args, require_kwargs, PluginAware
+
+if TYPE_CHECKING:
+    from pinecone.config import Config, OpenApiConfiguration
+    from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
 
 
-class RestoreJobResource:
-    def __init__(self, index_api: ManageIndexesApi):
+class RestoreJobResource(PluginAware):
+    def __init__(
+        self,
+        index_api: "ManageIndexesApi",
+        config: "Config",
+        openapi_config: "OpenApiConfiguration",
+        pool_threads: int,
+    ):
         self._index_api = index_api
         """ @private """
+
+        self.config = config
+        """ @private """
+
+        self._openapi_config = openapi_config
+        """ @private """
+
+        self._pool_threads = pool_threads
+        """ @private """
+
+        super().__init__()  # Initialize PluginAware
 
     @require_kwargs
     def get(self, *, job_id: str) -> RestoreJobModel:

--- a/pinecone/utils/plugin_aware.py
+++ b/pinecone/utils/plugin_aware.py
@@ -36,8 +36,6 @@ class PluginAware:
         Raises:
             AttributeError: If required attributes are not set in the subclass.
         """
-        logger.debug("PluginAware __init__ called for %s", self.__class__.__name__)
-
         self._plugins_loaded = False
         """ @private """
 

--- a/tests/unit/db_control/test_index.py
+++ b/tests/unit/db_control/test_index.py
@@ -1,6 +1,6 @@
 import json
 
-from pinecone import Config
+from pinecone.config import Config, OpenApiConfiguration
 
 from pinecone.db_control.resources.sync.index import IndexResource
 from pinecone.openapi_support.api_client import ApiClient
@@ -20,7 +20,13 @@ def build_client_w_faked_response(mocker, body: str, status: int = 200):
         api_client.rest_client.pool_manager, "request", return_value=response
     )
     index_api = ManageIndexesApi(api_client=api_client)
-    return IndexResource(index_api=index_api, config=Config(api_key="test-api-key")), mock_request
+    resource = IndexResource(
+        index_api=index_api,
+        config=Config(api_key="test-api-key"),
+        openapi_config=OpenApiConfiguration(),
+        pool_threads=1,
+    )
+    return resource, mock_request
 
 
 class TestIndexResource:


### PR DESCRIPTION
## Problem

We need these classes to extend `PluginAware` in case we ever want to add functions via plugin in the future.

## Solution

Adjust the constructor functions for each of these resource classes to set the properties needed by `PluginAware`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
