### PR TITLE
Disable client-side validation of responses

### DIFF
--- a/pinecone/core/openapi/db_control/model/backup_list.py
+++ b/pinecone/core/openapi/db_control/model/backup_list.py
@@ -152,6 +152,7 @@ class BackupList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -170,6 +171,7 @@ class BackupList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -191,6 +193,7 @@ class BackupList(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -240,6 +243,7 @@ class BackupList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -256,6 +260,7 @@ class BackupList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/backup_model.py
+++ b/pinecone/core/openapi/db_control/model/backup_model.py
@@ -205,6 +205,7 @@ class BackupModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -223,6 +224,7 @@ class BackupModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -250,6 +252,7 @@ class BackupModel(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -316,6 +319,7 @@ class BackupModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -332,6 +336,7 @@ class BackupModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/byoc_spec.py
+++ b/pinecone/core/openapi/db_control/model/byoc_spec.py
@@ -141,6 +141,7 @@ class ByocSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -159,6 +160,7 @@ class ByocSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -181,6 +183,7 @@ class ByocSpec(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -231,6 +234,7 @@ class ByocSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -247,6 +251,7 @@ class ByocSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/collection_list.py
+++ b/pinecone/core/openapi/db_control/model/collection_list.py
@@ -147,6 +147,7 @@ class CollectionList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -165,6 +166,7 @@ class CollectionList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -186,6 +188,7 @@ class CollectionList(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -234,6 +237,7 @@ class CollectionList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -250,6 +254,7 @@ class CollectionList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/collection_model.py
+++ b/pinecone/core/openapi/db_control/model/collection_model.py
@@ -164,6 +164,7 @@ class CollectionModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -182,6 +183,7 @@ class CollectionModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -206,6 +208,7 @@ class CollectionModel(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -261,6 +264,7 @@ class CollectionModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -277,6 +281,7 @@ class CollectionModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/configure_index_request.py
+++ b/pinecone/core/openapi/db_control/model/configure_index_request.py
@@ -166,6 +166,7 @@ class ConfigureIndexRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -184,6 +185,7 @@ class ConfigureIndexRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -205,6 +207,7 @@ class ConfigureIndexRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -256,6 +259,7 @@ class ConfigureIndexRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -272,6 +276,7 @@ class ConfigureIndexRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/configure_index_request_embed.py
+++ b/pinecone/core/openapi/db_control/model/configure_index_request_embed.py
@@ -148,6 +148,7 @@ class ConfigureIndexRequestEmbed(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -166,6 +167,7 @@ class ConfigureIndexRequestEmbed(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -187,6 +189,7 @@ class ConfigureIndexRequestEmbed(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -238,6 +241,7 @@ class ConfigureIndexRequestEmbed(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -254,6 +258,7 @@ class ConfigureIndexRequestEmbed(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/configure_index_request_spec.py
+++ b/pinecone/core/openapi/db_control/model/configure_index_request_spec.py
@@ -151,6 +151,7 @@ class ConfigureIndexRequestSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -169,6 +170,7 @@ class ConfigureIndexRequestSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -191,6 +193,7 @@ class ConfigureIndexRequestSpec(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -241,6 +244,7 @@ class ConfigureIndexRequestSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -257,6 +261,7 @@ class ConfigureIndexRequestSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/configure_index_request_spec_pod.py
+++ b/pinecone/core/openapi/db_control/model/configure_index_request_spec_pod.py
@@ -144,6 +144,7 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -162,6 +163,7 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -183,6 +185,7 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -232,6 +235,7 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -248,6 +252,7 @@ class ConfigureIndexRequestSpecPod(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/create_backup_request.py
+++ b/pinecone/core/openapi/db_control/model/create_backup_request.py
@@ -142,6 +142,7 @@ class CreateBackupRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -160,6 +161,7 @@ class CreateBackupRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -181,6 +183,7 @@ class CreateBackupRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -230,6 +233,7 @@ class CreateBackupRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -246,6 +250,7 @@ class CreateBackupRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/create_collection_request.py
+++ b/pinecone/core/openapi/db_control/model/create_collection_request.py
@@ -146,6 +146,7 @@ class CreateCollectionRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -164,6 +165,7 @@ class CreateCollectionRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -187,6 +189,7 @@ class CreateCollectionRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -238,6 +241,7 @@ class CreateCollectionRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -254,6 +258,7 @@ class CreateCollectionRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/create_index_for_model_request.py
+++ b/pinecone/core/openapi/db_control/model/create_index_for_model_request.py
@@ -174,6 +174,7 @@ class CreateIndexForModelRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -192,6 +193,7 @@ class CreateIndexForModelRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -217,6 +219,7 @@ class CreateIndexForModelRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -272,6 +275,7 @@ class CreateIndexForModelRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -288,6 +292,7 @@ class CreateIndexForModelRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/create_index_for_model_request_embed.py
+++ b/pinecone/core/openapi/db_control/model/create_index_for_model_request_embed.py
@@ -158,6 +158,7 @@ class CreateIndexForModelRequestEmbed(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -176,6 +177,7 @@ class CreateIndexForModelRequestEmbed(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -199,6 +201,7 @@ class CreateIndexForModelRequestEmbed(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -254,6 +257,7 @@ class CreateIndexForModelRequestEmbed(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -270,6 +274,7 @@ class CreateIndexForModelRequestEmbed(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/create_index_from_backup_request.py
+++ b/pinecone/core/openapi/db_control/model/create_index_from_backup_request.py
@@ -159,6 +159,7 @@ class CreateIndexFromBackupRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -177,6 +178,7 @@ class CreateIndexFromBackupRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -199,6 +201,7 @@ class CreateIndexFromBackupRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -251,6 +254,7 @@ class CreateIndexFromBackupRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -267,6 +271,7 @@ class CreateIndexFromBackupRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/create_index_from_backup_response.py
+++ b/pinecone/core/openapi/db_control/model/create_index_from_backup_response.py
@@ -144,6 +144,7 @@ class CreateIndexFromBackupResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -162,6 +163,7 @@ class CreateIndexFromBackupResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -185,6 +187,7 @@ class CreateIndexFromBackupResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -236,6 +239,7 @@ class CreateIndexFromBackupResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -252,6 +256,7 @@ class CreateIndexFromBackupResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/create_index_request.py
+++ b/pinecone/core/openapi/db_control/model/create_index_request.py
@@ -176,6 +176,7 @@ class CreateIndexRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -194,6 +195,7 @@ class CreateIndexRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -217,6 +219,7 @@ class CreateIndexRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -273,6 +276,7 @@ class CreateIndexRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -289,6 +293,7 @@ class CreateIndexRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/deletion_protection.py
+++ b/pinecone/core/openapi/db_control/model/deletion_protection.py
@@ -96,6 +96,7 @@ class DeletionProtection(ModelSimple):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -169,6 +170,7 @@ class DeletionProtection(ModelSimple):
             value = "disabled"
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -176,6 +178,7 @@ class DeletionProtection(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -257,6 +260,7 @@ class DeletionProtection(ModelSimple):
             value = "disabled"
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -264,6 +268,7 @@ class DeletionProtection(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/error_response.py
+++ b/pinecone/core/openapi/db_control/model/error_response.py
@@ -152,6 +152,7 @@ class ErrorResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -170,6 +171,7 @@ class ErrorResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -193,6 +195,7 @@ class ErrorResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -244,6 +247,7 @@ class ErrorResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -260,6 +264,7 @@ class ErrorResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/error_response_error.py
+++ b/pinecone/core/openapi/db_control/model/error_response_error.py
@@ -170,6 +170,7 @@ class ErrorResponseError(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -188,6 +189,7 @@ class ErrorResponseError(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -211,6 +213,7 @@ class ErrorResponseError(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -263,6 +266,7 @@ class ErrorResponseError(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -279,6 +283,7 @@ class ErrorResponseError(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/index_list.py
+++ b/pinecone/core/openapi/db_control/model/index_list.py
@@ -147,6 +147,7 @@ class IndexList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -165,6 +166,7 @@ class IndexList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -186,6 +188,7 @@ class IndexList(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -234,6 +237,7 @@ class IndexList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -250,6 +254,7 @@ class IndexList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/index_model.py
+++ b/pinecone/core/openapi/db_control/model/index_model.py
@@ -190,6 +190,7 @@ class IndexModel(ModelNormal):
 
         vector_type = kwargs.get("vector_type", "dense")
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -208,6 +209,7 @@ class IndexModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -235,6 +237,7 @@ class IndexModel(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -295,6 +298,7 @@ class IndexModel(ModelNormal):
 
         vector_type = kwargs.get("vector_type", "dense")
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -311,6 +315,7 @@ class IndexModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/index_model_spec.py
+++ b/pinecone/core/openapi/db_control/model/index_model_spec.py
@@ -157,6 +157,7 @@ class IndexModelSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -175,6 +176,7 @@ class IndexModelSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -196,6 +198,7 @@ class IndexModelSpec(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -246,6 +249,7 @@ class IndexModelSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -262,6 +266,7 @@ class IndexModelSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/index_model_status.py
+++ b/pinecone/core/openapi/db_control/model/index_model_status.py
@@ -156,6 +156,7 @@ class IndexModelStatus(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -174,6 +175,7 @@ class IndexModelStatus(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -197,6 +199,7 @@ class IndexModelStatus(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -248,6 +251,7 @@ class IndexModelStatus(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -264,6 +268,7 @@ class IndexModelStatus(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/index_spec.py
+++ b/pinecone/core/openapi/db_control/model/index_spec.py
@@ -150,6 +150,7 @@ class IndexSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -168,6 +169,7 @@ class IndexSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -189,6 +191,7 @@ class IndexSpec(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -239,6 +242,7 @@ class IndexSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -255,6 +259,7 @@ class IndexSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/index_tags.py
+++ b/pinecone/core/openapi/db_control/model/index_tags.py
@@ -134,6 +134,7 @@ class IndexTags(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -152,6 +153,7 @@ class IndexTags(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -173,6 +175,7 @@ class IndexTags(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -220,6 +223,7 @@ class IndexTags(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -236,6 +240,7 @@ class IndexTags(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/model_index_embed.py
+++ b/pinecone/core/openapi/db_control/model/model_index_embed.py
@@ -163,6 +163,7 @@ class ModelIndexEmbed(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -181,6 +182,7 @@ class ModelIndexEmbed(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -203,6 +205,7 @@ class ModelIndexEmbed(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -259,6 +262,7 @@ class ModelIndexEmbed(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -275,6 +279,7 @@ class ModelIndexEmbed(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/pagination_response.py
+++ b/pinecone/core/openapi/db_control/model/pagination_response.py
@@ -141,6 +141,7 @@ class PaginationResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -159,6 +160,7 @@ class PaginationResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -181,6 +183,7 @@ class PaginationResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -231,6 +234,7 @@ class PaginationResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -247,6 +251,7 @@ class PaginationResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/pod_spec.py
+++ b/pinecone/core/openapi/db_control/model/pod_spec.py
@@ -174,6 +174,7 @@ class PodSpec(ModelNormal):
 
         pod_type = kwargs.get("pod_type", "p1.x1")
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -192,6 +193,7 @@ class PodSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -215,6 +217,7 @@ class PodSpec(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -272,6 +275,7 @@ class PodSpec(ModelNormal):
 
         pod_type = kwargs.get("pod_type", "p1.x1")
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -288,6 +292,7 @@ class PodSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/pod_spec_metadata_config.py
+++ b/pinecone/core/openapi/db_control/model/pod_spec_metadata_config.py
@@ -139,6 +139,7 @@ class PodSpecMetadataConfig(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class PodSpecMetadataConfig(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class PodSpecMetadataConfig(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class PodSpecMetadataConfig(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class PodSpecMetadataConfig(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/restore_job_list.py
+++ b/pinecone/core/openapi/db_control/model/restore_job_list.py
@@ -154,6 +154,7 @@ class RestoreJobList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -172,6 +173,7 @@ class RestoreJobList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -194,6 +196,7 @@ class RestoreJobList(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -245,6 +248,7 @@ class RestoreJobList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -261,6 +265,7 @@ class RestoreJobList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/restore_job_model.py
+++ b/pinecone/core/openapi/db_control/model/restore_job_model.py
@@ -174,6 +174,7 @@ class RestoreJobModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -192,6 +193,7 @@ class RestoreJobModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -219,6 +221,7 @@ class RestoreJobModel(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -286,6 +289,7 @@ class RestoreJobModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -302,6 +306,7 @@ class RestoreJobModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_control/model/serverless_spec.py
+++ b/pinecone/core/openapi/db_control/model/serverless_spec.py
@@ -146,6 +146,7 @@ class ServerlessSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -164,6 +165,7 @@ class ServerlessSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -187,6 +189,7 @@ class ServerlessSpec(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -238,6 +241,7 @@ class ServerlessSpec(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -254,6 +258,7 @@ class ServerlessSpec(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/delete_request.py
+++ b/pinecone/core/openapi/db_data/model/delete_request.py
@@ -148,6 +148,7 @@ class DeleteRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -166,6 +167,7 @@ class DeleteRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -187,6 +189,7 @@ class DeleteRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -238,6 +241,7 @@ class DeleteRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -254,6 +258,7 @@ class DeleteRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/describe_index_stats_request.py
+++ b/pinecone/core/openapi/db_data/model/describe_index_stats_request.py
@@ -139,6 +139,7 @@ class DescribeIndexStatsRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class DescribeIndexStatsRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class DescribeIndexStatsRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class DescribeIndexStatsRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class DescribeIndexStatsRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/fetch_response.py
+++ b/pinecone/core/openapi/db_data/model/fetch_response.py
@@ -155,6 +155,7 @@ class FetchResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -173,6 +174,7 @@ class FetchResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -194,6 +196,7 @@ class FetchResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -244,6 +247,7 @@ class FetchResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -260,6 +264,7 @@ class FetchResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/hit.py
+++ b/pinecone/core/openapi/db_data/model/hit.py
@@ -147,6 +147,7 @@ class Hit(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -165,6 +166,7 @@ class Hit(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -189,6 +191,7 @@ class Hit(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -241,6 +244,7 @@ class Hit(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -257,6 +261,7 @@ class Hit(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/import_error_mode.py
+++ b/pinecone/core/openapi/db_data/model/import_error_mode.py
@@ -141,6 +141,7 @@ class ImportErrorMode(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -159,6 +160,7 @@ class ImportErrorMode(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -180,6 +182,7 @@ class ImportErrorMode(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -228,6 +231,7 @@ class ImportErrorMode(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -244,6 +248,7 @@ class ImportErrorMode(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/import_model.py
+++ b/pinecone/core/openapi/db_data/model/import_model.py
@@ -171,6 +171,7 @@ class ImportModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -189,6 +190,7 @@ class ImportModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -210,6 +212,7 @@ class ImportModel(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -265,6 +268,7 @@ class ImportModel(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -281,6 +285,7 @@ class ImportModel(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/index_description.py
+++ b/pinecone/core/openapi/db_data/model/index_description.py
@@ -162,6 +162,7 @@ class IndexDescription(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -180,6 +181,7 @@ class IndexDescription(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -201,6 +203,7 @@ class IndexDescription(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -254,6 +257,7 @@ class IndexDescription(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -270,6 +274,7 @@ class IndexDescription(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/list_imports_response.py
+++ b/pinecone/core/openapi/db_data/model/list_imports_response.py
@@ -152,6 +152,7 @@ class ListImportsResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -170,6 +171,7 @@ class ListImportsResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -191,6 +193,7 @@ class ListImportsResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -240,6 +243,7 @@ class ListImportsResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -256,6 +260,7 @@ class ListImportsResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/list_item.py
+++ b/pinecone/core/openapi/db_data/model/list_item.py
@@ -139,6 +139,7 @@ class ListItem(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class ListItem(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class ListItem(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class ListItem(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class ListItem(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/list_namespaces_response.py
+++ b/pinecone/core/openapi/db_data/model/list_namespaces_response.py
@@ -152,6 +152,7 @@ class ListNamespacesResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -170,6 +171,7 @@ class ListNamespacesResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -191,6 +193,7 @@ class ListNamespacesResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -240,6 +243,7 @@ class ListNamespacesResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -256,6 +260,7 @@ class ListNamespacesResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/list_response.py
+++ b/pinecone/core/openapi/db_data/model/list_response.py
@@ -160,6 +160,7 @@ class ListResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -178,6 +179,7 @@ class ListResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -199,6 +201,7 @@ class ListResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -250,6 +253,7 @@ class ListResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -266,6 +270,7 @@ class ListResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/namespace_description.py
+++ b/pinecone/core/openapi/db_data/model/namespace_description.py
@@ -142,6 +142,7 @@ class NamespaceDescription(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -160,6 +161,7 @@ class NamespaceDescription(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -181,6 +183,7 @@ class NamespaceDescription(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -230,6 +233,7 @@ class NamespaceDescription(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -246,6 +250,7 @@ class NamespaceDescription(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/namespace_summary.py
+++ b/pinecone/core/openapi/db_data/model/namespace_summary.py
@@ -139,6 +139,7 @@ class NamespaceSummary(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class NamespaceSummary(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class NamespaceSummary(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class NamespaceSummary(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class NamespaceSummary(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/pagination.py
+++ b/pinecone/core/openapi/db_data/model/pagination.py
@@ -139,6 +139,7 @@ class Pagination(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class Pagination(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class Pagination(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class Pagination(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class Pagination(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/protobuf_any.py
+++ b/pinecone/core/openapi/db_data/model/protobuf_any.py
@@ -142,6 +142,7 @@ class ProtobufAny(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -160,6 +161,7 @@ class ProtobufAny(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -181,6 +183,7 @@ class ProtobufAny(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -230,6 +233,7 @@ class ProtobufAny(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -246,6 +250,7 @@ class ProtobufAny(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/protobuf_null_value.py
+++ b/pinecone/core/openapi/db_data/model/protobuf_null_value.py
@@ -96,6 +96,7 @@ class ProtobufNullValue(ModelSimple):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -169,6 +170,7 @@ class ProtobufNullValue(ModelSimple):
             value = "NULL_VALUE"
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -176,6 +178,7 @@ class ProtobufNullValue(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -257,6 +260,7 @@ class ProtobufNullValue(ModelSimple):
             value = "NULL_VALUE"
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -264,6 +268,7 @@ class ProtobufNullValue(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/query_request.py
+++ b/pinecone/core/openapi/db_data/model/query_request.py
@@ -180,6 +180,7 @@ class QueryRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -198,6 +199,7 @@ class QueryRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -220,6 +222,7 @@ class QueryRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -278,6 +281,7 @@ class QueryRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -294,6 +298,7 @@ class QueryRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/query_response.py
+++ b/pinecone/core/openapi/db_data/model/query_response.py
@@ -160,6 +160,7 @@ class QueryResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -178,6 +179,7 @@ class QueryResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -199,6 +201,7 @@ class QueryResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -250,6 +253,7 @@ class QueryResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -266,6 +270,7 @@ class QueryResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/query_vector.py
+++ b/pinecone/core/openapi/db_data/model/query_vector.py
@@ -164,6 +164,7 @@ class QueryVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -182,6 +183,7 @@ class QueryVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -204,6 +206,7 @@ class QueryVector(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -258,6 +261,7 @@ class QueryVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -274,6 +278,7 @@ class QueryVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/rpc_status.py
+++ b/pinecone/core/openapi/db_data/model/rpc_status.py
@@ -153,6 +153,7 @@ class RpcStatus(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -171,6 +172,7 @@ class RpcStatus(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -192,6 +194,7 @@ class RpcStatus(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -242,6 +245,7 @@ class RpcStatus(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -258,6 +262,7 @@ class RpcStatus(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/scored_vector.py
+++ b/pinecone/core/openapi/db_data/model/scored_vector.py
@@ -163,6 +163,7 @@ class ScoredVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -181,6 +182,7 @@ class ScoredVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -203,6 +205,7 @@ class ScoredVector(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -257,6 +260,7 @@ class ScoredVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -273,6 +277,7 @@ class ScoredVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_records_request.py
+++ b/pinecone/core/openapi/db_data/model/search_records_request.py
@@ -161,6 +161,7 @@ class SearchRecordsRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -179,6 +180,7 @@ class SearchRecordsRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -201,6 +203,7 @@ class SearchRecordsRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -253,6 +256,7 @@ class SearchRecordsRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -269,6 +273,7 @@ class SearchRecordsRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_records_request_query.py
+++ b/pinecone/core/openapi/db_data/model/search_records_request_query.py
@@ -161,6 +161,7 @@ class SearchRecordsRequestQuery(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -179,6 +180,7 @@ class SearchRecordsRequestQuery(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -201,6 +203,7 @@ class SearchRecordsRequestQuery(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -255,6 +258,7 @@ class SearchRecordsRequestQuery(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -271,6 +275,7 @@ class SearchRecordsRequestQuery(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_records_request_rerank.py
+++ b/pinecone/core/openapi/db_data/model/search_records_request_rerank.py
@@ -153,6 +153,7 @@ class SearchRecordsRequestRerank(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -171,6 +172,7 @@ class SearchRecordsRequestRerank(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -194,6 +196,7 @@ class SearchRecordsRequestRerank(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -248,6 +251,7 @@ class SearchRecordsRequestRerank(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -264,6 +268,7 @@ class SearchRecordsRequestRerank(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_records_response.py
+++ b/pinecone/core/openapi/db_data/model/search_records_response.py
@@ -156,6 +156,7 @@ class SearchRecordsResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -174,6 +175,7 @@ class SearchRecordsResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -197,6 +199,7 @@ class SearchRecordsResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -248,6 +251,7 @@ class SearchRecordsResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -264,6 +268,7 @@ class SearchRecordsResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_records_response_result.py
+++ b/pinecone/core/openapi/db_data/model/search_records_response_result.py
@@ -149,6 +149,7 @@ class SearchRecordsResponseResult(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -167,6 +168,7 @@ class SearchRecordsResponseResult(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -189,6 +191,7 @@ class SearchRecordsResponseResult(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -239,6 +242,7 @@ class SearchRecordsResponseResult(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -255,6 +259,7 @@ class SearchRecordsResponseResult(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_records_vector.py
+++ b/pinecone/core/openapi/db_data/model/search_records_vector.py
@@ -153,6 +153,7 @@ class SearchRecordsVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -171,6 +172,7 @@ class SearchRecordsVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -192,6 +194,7 @@ class SearchRecordsVector(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -242,6 +245,7 @@ class SearchRecordsVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -258,6 +262,7 @@ class SearchRecordsVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_usage.py
+++ b/pinecone/core/openapi/db_data/model/search_usage.py
@@ -151,6 +151,7 @@ class SearchUsage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -169,6 +170,7 @@ class SearchUsage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -191,6 +193,7 @@ class SearchUsage(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -243,6 +246,7 @@ class SearchUsage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -259,6 +263,7 @@ class SearchUsage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/search_vector.py
+++ b/pinecone/core/openapi/db_data/model/search_vector.py
@@ -147,6 +147,7 @@ class SearchVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -165,6 +166,7 @@ class SearchVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -186,6 +188,7 @@ class SearchVector(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -234,6 +237,7 @@ class SearchVector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -250,6 +254,7 @@ class SearchVector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/single_query_results.py
+++ b/pinecone/core/openapi/db_data/model/single_query_results.py
@@ -150,6 +150,7 @@ class SingleQueryResults(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -168,6 +169,7 @@ class SingleQueryResults(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -189,6 +191,7 @@ class SingleQueryResults(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -238,6 +241,7 @@ class SingleQueryResults(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -254,6 +258,7 @@ class SingleQueryResults(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/sparse_values.py
+++ b/pinecone/core/openapi/db_data/model/sparse_values.py
@@ -147,6 +147,7 @@ class SparseValues(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -165,6 +166,7 @@ class SparseValues(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -188,6 +190,7 @@ class SparseValues(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -239,6 +242,7 @@ class SparseValues(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -255,6 +259,7 @@ class SparseValues(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/start_import_request.py
+++ b/pinecone/core/openapi/db_data/model/start_import_request.py
@@ -158,6 +158,7 @@ class StartImportRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -176,6 +177,7 @@ class StartImportRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -198,6 +200,7 @@ class StartImportRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -250,6 +253,7 @@ class StartImportRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -266,6 +270,7 @@ class StartImportRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/start_import_response.py
+++ b/pinecone/core/openapi/db_data/model/start_import_response.py
@@ -141,6 +141,7 @@ class StartImportResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -159,6 +160,7 @@ class StartImportResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -180,6 +182,7 @@ class StartImportResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -228,6 +231,7 @@ class StartImportResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -244,6 +248,7 @@ class StartImportResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/update_request.py
+++ b/pinecone/core/openapi/db_data/model/update_request.py
@@ -164,6 +164,7 @@ class UpdateRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -182,6 +183,7 @@ class UpdateRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -204,6 +206,7 @@ class UpdateRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -258,6 +261,7 @@ class UpdateRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -274,6 +278,7 @@ class UpdateRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/upsert_record.py
+++ b/pinecone/core/openapi/db_data/model/upsert_record.py
@@ -141,6 +141,7 @@ class UpsertRecord(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -159,6 +160,7 @@ class UpsertRecord(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -181,6 +183,7 @@ class UpsertRecord(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -231,6 +234,7 @@ class UpsertRecord(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -247,6 +251,7 @@ class UpsertRecord(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/upsert_request.py
+++ b/pinecone/core/openapi/db_data/model/upsert_request.py
@@ -152,6 +152,7 @@ class UpsertRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -170,6 +171,7 @@ class UpsertRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -192,6 +194,7 @@ class UpsertRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -243,6 +246,7 @@ class UpsertRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -259,6 +263,7 @@ class UpsertRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/upsert_response.py
+++ b/pinecone/core/openapi/db_data/model/upsert_response.py
@@ -139,6 +139,7 @@ class UpsertResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class UpsertResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class UpsertResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class UpsertResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class UpsertResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/usage.py
+++ b/pinecone/core/openapi/db_data/model/usage.py
@@ -139,6 +139,7 @@ class Usage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class Usage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class Usage(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class Usage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class Usage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/vector.py
+++ b/pinecone/core/openapi/db_data/model/vector.py
@@ -161,6 +161,7 @@ class Vector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -179,6 +180,7 @@ class Vector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -201,6 +203,7 @@ class Vector(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -254,6 +257,7 @@ class Vector(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -270,6 +274,7 @@ class Vector(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/db_data/model/vector_values.py
+++ b/pinecone/core/openapi/db_data/model/vector_values.py
@@ -94,6 +94,7 @@ class VectorValues(ModelSimple):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -171,6 +172,7 @@ class VectorValues(ModelSimple):
             )
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -178,6 +180,7 @@ class VectorValues(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -263,6 +266,7 @@ class VectorValues(ModelSimple):
             )
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -270,6 +274,7 @@ class VectorValues(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/dense_embedding.py
+++ b/pinecone/core/openapi/inference/model/dense_embedding.py
@@ -144,6 +144,7 @@ class DenseEmbedding(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -162,6 +163,7 @@ class DenseEmbedding(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -185,6 +187,7 @@ class DenseEmbedding(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -236,6 +239,7 @@ class DenseEmbedding(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -252,6 +256,7 @@ class DenseEmbedding(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/document.py
+++ b/pinecone/core/openapi/inference/model/document.py
@@ -134,6 +134,7 @@ class Document(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -152,6 +153,7 @@ class Document(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -173,6 +175,7 @@ class Document(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -220,6 +223,7 @@ class Document(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -236,6 +240,7 @@ class Document(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/embed_request.py
+++ b/pinecone/core/openapi/inference/model/embed_request.py
@@ -155,6 +155,7 @@ class EmbedRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -173,6 +174,7 @@ class EmbedRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -196,6 +198,7 @@ class EmbedRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -248,6 +251,7 @@ class EmbedRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -264,6 +268,7 @@ class EmbedRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/embed_request_inputs.py
+++ b/pinecone/core/openapi/inference/model/embed_request_inputs.py
@@ -139,6 +139,7 @@ class EmbedRequestInputs(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -157,6 +158,7 @@ class EmbedRequestInputs(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -178,6 +180,7 @@ class EmbedRequestInputs(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -226,6 +229,7 @@ class EmbedRequestInputs(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -242,6 +246,7 @@ class EmbedRequestInputs(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/embedding.py
+++ b/pinecone/core/openapi/inference/model/embedding.py
@@ -219,6 +219,7 @@ class Embedding(ModelComposed):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -274,6 +275,7 @@ class Embedding(ModelComposed):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -290,6 +292,7 @@ class Embedding(ModelComposed):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/embeddings_list.py
+++ b/pinecone/core/openapi/inference/model/embeddings_list.py
@@ -160,6 +160,7 @@ class EmbeddingsList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -178,6 +179,7 @@ class EmbeddingsList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -203,6 +205,7 @@ class EmbeddingsList(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -256,6 +259,7 @@ class EmbeddingsList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -272,6 +276,7 @@ class EmbeddingsList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/embeddings_list_usage.py
+++ b/pinecone/core/openapi/inference/model/embeddings_list_usage.py
@@ -141,6 +141,7 @@ class EmbeddingsListUsage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -159,6 +160,7 @@ class EmbeddingsListUsage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -180,6 +182,7 @@ class EmbeddingsListUsage(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -228,6 +231,7 @@ class EmbeddingsListUsage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -244,6 +248,7 @@ class EmbeddingsListUsage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/error_response.py
+++ b/pinecone/core/openapi/inference/model/error_response.py
@@ -152,6 +152,7 @@ class ErrorResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -170,6 +171,7 @@ class ErrorResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -193,6 +195,7 @@ class ErrorResponse(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -244,6 +247,7 @@ class ErrorResponse(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -260,6 +264,7 @@ class ErrorResponse(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/error_response_error.py
+++ b/pinecone/core/openapi/inference/model/error_response_error.py
@@ -168,6 +168,7 @@ class ErrorResponseError(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -186,6 +187,7 @@ class ErrorResponseError(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -209,6 +211,7 @@ class ErrorResponseError(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -261,6 +264,7 @@ class ErrorResponseError(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -277,6 +281,7 @@ class ErrorResponseError(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/model_info.py
+++ b/pinecone/core/openapi/inference/model/model_info.py
@@ -194,6 +194,7 @@ class ModelInfo(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -212,6 +213,7 @@ class ModelInfo(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -237,6 +239,7 @@ class ModelInfo(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -300,6 +303,7 @@ class ModelInfo(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -316,6 +320,7 @@ class ModelInfo(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/model_info_list.py
+++ b/pinecone/core/openapi/inference/model/model_info_list.py
@@ -147,6 +147,7 @@ class ModelInfoList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -165,6 +166,7 @@ class ModelInfoList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -186,6 +188,7 @@ class ModelInfoList(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -234,6 +237,7 @@ class ModelInfoList(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -250,6 +254,7 @@ class ModelInfoList(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/model_info_metric.py
+++ b/pinecone/core/openapi/inference/model/model_info_metric.py
@@ -96,6 +96,7 @@ class ModelInfoMetric(ModelSimple):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -173,6 +174,7 @@ class ModelInfoMetric(ModelSimple):
             )
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -180,6 +182,7 @@ class ModelInfoMetric(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -265,6 +268,7 @@ class ModelInfoMetric(ModelSimple):
             )
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -272,6 +276,7 @@ class ModelInfoMetric(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/model_info_supported_metrics.py
+++ b/pinecone/core/openapi/inference/model/model_info_supported_metrics.py
@@ -102,6 +102,7 @@ class ModelInfoSupportedMetrics(ModelSimple):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -179,6 +180,7 @@ class ModelInfoSupportedMetrics(ModelSimple):
             )
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -186,6 +188,7 @@ class ModelInfoSupportedMetrics(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -271,6 +274,7 @@ class ModelInfoSupportedMetrics(ModelSimple):
             )
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _configuration = kwargs.pop("_configuration", None)
@@ -278,6 +282,7 @@ class ModelInfoSupportedMetrics(ModelSimple):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/model_info_supported_parameter.py
+++ b/pinecone/core/openapi/inference/model/model_info_supported_parameter.py
@@ -164,6 +164,7 @@ class ModelInfoSupportedParameter(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -182,6 +183,7 @@ class ModelInfoSupportedParameter(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -207,6 +209,7 @@ class ModelInfoSupportedParameter(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -264,6 +267,7 @@ class ModelInfoSupportedParameter(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -280,6 +284,7 @@ class ModelInfoSupportedParameter(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/ranked_document.py
+++ b/pinecone/core/openapi/inference/model/ranked_document.py
@@ -155,6 +155,7 @@ class RankedDocument(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -173,6 +174,7 @@ class RankedDocument(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -196,6 +198,7 @@ class RankedDocument(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -248,6 +251,7 @@ class RankedDocument(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -264,6 +268,7 @@ class RankedDocument(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/rerank_request.py
+++ b/pinecone/core/openapi/inference/model/rerank_request.py
@@ -167,6 +167,7 @@ class RerankRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -185,6 +186,7 @@ class RerankRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -209,6 +211,7 @@ class RerankRequest(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -265,6 +268,7 @@ class RerankRequest(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -281,6 +285,7 @@ class RerankRequest(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/rerank_result.py
+++ b/pinecone/core/openapi/inference/model/rerank_result.py
@@ -157,6 +157,7 @@ class RerankResult(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -175,6 +176,7 @@ class RerankResult(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -199,6 +201,7 @@ class RerankResult(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -251,6 +254,7 @@ class RerankResult(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -267,6 +271,7 @@ class RerankResult(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/rerank_result_usage.py
+++ b/pinecone/core/openapi/inference/model/rerank_result_usage.py
@@ -141,6 +141,7 @@ class RerankResultUsage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -159,6 +160,7 @@ class RerankResultUsage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -180,6 +182,7 @@ class RerankResultUsage(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -228,6 +231,7 @@ class RerankResultUsage(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -244,6 +248,7 @@ class RerankResultUsage(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/core/openapi/inference/model/sparse_embedding.py
+++ b/pinecone/core/openapi/inference/model/sparse_embedding.py
@@ -152,6 +152,7 @@ class SparseEmbedding(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", False)
+        _enforce_validations = kwargs.pop("_enforce_validations", False)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -170,6 +171,7 @@ class SparseEmbedding(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item
@@ -194,6 +196,7 @@ class SparseEmbedding(ModelNormal):
     required_properties = set(
         [
             "_enforce_allowed_values",
+            "_enforce_validations",
             "_data_store",
             "_check_type",
             "_spec_property_naming",
@@ -247,6 +250,7 @@ class SparseEmbedding(ModelNormal):
         """
 
         _enforce_allowed_values = kwargs.pop("_enforce_allowed_values", True)
+        _enforce_validations = kwargs.pop("_enforce_validations", True)
         _check_type = kwargs.pop("_check_type", True)
         _spec_property_naming = kwargs.pop("_spec_property_naming", False)
         _path_to_item = kwargs.pop("_path_to_item", ())
@@ -263,6 +267,7 @@ class SparseEmbedding(ModelNormal):
 
         self._data_store = {}
         self._enforce_allowed_values = _enforce_allowed_values
+        self._enforce_validations = _enforce_validations
         self._check_type = _check_type
         self._spec_property_naming = _spec_property_naming
         self._path_to_item = _path_to_item

--- a/pinecone/openapi_support/model_utils.py
+++ b/pinecone/openapi_support/model_utils.py
@@ -151,7 +151,10 @@ class OpenApiModel(object):
             # when listing indexes due to validation on the status field against
             # the allowed values in the enum.
             check_allowed_values(self.allowed_values, (name,), value)
-        if (name,) in self.validations:
+        if (name,) in self.validations and self._enforce_validations:
+            # Disabling validation on response makes the SDK
+            # less fragile if unexpected values are returned. In general,
+            # we want the SDK to display whatever is returned by the API.
             check_validations(self.validations, (name,), value, self._configuration)
         self.__dict__["_data_store"][name] = value
 


### PR DESCRIPTION
## Problem

Sometimes unexpected values in API responses can cause unnecessary errors due to validation logic being applied. Fields labeled in the openapi as `enum` fields will error when unexpected values appear in the response. In general, we want the client to just display what the API returns without applying validation.

## Solution

Adjust the code generation to disable validation logic when instantiating model objects from API response.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

I created a mock server script to do some manual testing of different responses with odd values in them and saw this works without erroring. For example, these responses no longer raise:
- New index status
- Index dimension > 20k
- Index name too long