### PR TITLE
Fix inference autocomplete

### DIFF
--- a/pinecone/__init__.py
+++ b/pinecone/__init__.py
@@ -6,7 +6,21 @@ from .deprecated_plugins import check_for_deprecated_plugins as _check_for_depre
 from .deprecation_warnings import *
 from .pinecone import Pinecone
 from .pinecone_asyncio import PineconeAsyncio
-from .exceptions import *
+from .exceptions import (
+    PineconeException,
+    PineconeApiTypeError,
+    PineconeApiValueError,
+    PineconeApiAttributeError,
+    PineconeApiKeyError,
+    PineconeApiException,
+    NotFoundException,
+    UnauthorizedException,
+    ForbiddenException,
+    ServiceException,
+    PineconeProtocolError,
+    PineconeConfigurationError,
+    ListConversionException,
+)
 
 from .utils import __version__
 

--- a/pinecone/__init__.pyi
+++ b/pinecone/__init__.pyi
@@ -1,7 +1,24 @@
 from pinecone.config import Config
 from pinecone.config import ConfigBuilder
 from pinecone.config import PineconeConfig
+from .exceptions import (
+    PineconeException,
+    PineconeApiTypeError,
+    PineconeApiValueError,
+    PineconeApiAttributeError,
+    PineconeApiKeyError,
+    PineconeApiException,
+    NotFoundException,
+    UnauthorizedException,
+    ForbiddenException,
+    ServiceException,
+    PineconeProtocolError,
+    PineconeConfigurationError,
+    ListConversionException,
+)
 from pinecone.inference import (
+    Inference,
+    AsyncioInference,
     RerankModel,
     EmbedModel,
     ModelInfo,
@@ -72,7 +89,23 @@ __all__ = [
     "Config",
     "ConfigBuilder",
     "PineconeConfig",
+    # Exceptions
+    "PineconeException",
+    "PineconeApiTypeError",
+    "PineconeApiValueError",
+    "PineconeApiAttributeError",
+    "PineconeApiKeyError",
+    "PineconeApiException",
+    "NotFoundException",
+    "UnauthorizedException",
+    "ForbiddenException",
+    "ServiceException",
+    "PineconeProtocolError",
+    "PineconeConfigurationError",
+    "ListConversionException",
     # Inference classes
+    "Inference",
+    "AsyncioInference",
     "RerankModel",
     "EmbedModel",
     "ModelInfo",

--- a/pinecone/exceptions/__init__.py
+++ b/pinecone/exceptions/__init__.py
@@ -15,17 +15,17 @@ from .exceptions import (
 )
 
 __all__ = [
-    "PineconeConfigurationError",
-    "PineconeProtocolError",
     "PineconeException",
-    "PineconeApiAttributeError",
     "PineconeApiTypeError",
     "PineconeApiValueError",
+    "PineconeApiAttributeError",
     "PineconeApiKeyError",
     "PineconeApiException",
     "NotFoundException",
     "UnauthorizedException",
     "ForbiddenException",
     "ServiceException",
+    "PineconeProtocolError",
+    "PineconeConfigurationError",
     "ListConversionException",
 ]

--- a/pinecone/exceptions/exceptions.py
+++ b/pinecone/exceptions/exceptions.py
@@ -49,10 +49,10 @@ class PineconeApiValueError(PineconeException, ValueError):
 
 
 class PineconeApiAttributeError(PineconeException, AttributeError):
+    """Raised when an attribute reference or assignment fails."""
+
     def __init__(self, msg, path_to_item=None) -> None:
         """
-        Raised when an attribute reference or assignment fails.
-
         Args:
             msg (str): the exception message
 
@@ -85,6 +85,8 @@ class PineconeApiKeyError(PineconeException, KeyError):
 
 
 class PineconeApiException(PineconeException):
+    """Raised when an API exception occurs."""
+
     def __init__(self, status=None, reason=None, http_resp=None) -> None:
         if http_resp:
             self.status = http_resp.status
@@ -110,21 +112,29 @@ class PineconeApiException(PineconeException):
 
 
 class NotFoundException(PineconeApiException):
+    """Raised when a resource is not found."""
+
     def __init__(self, status=None, reason=None, http_resp=None) -> None:
         super(NotFoundException, self).__init__(status, reason, http_resp)
 
 
 class UnauthorizedException(PineconeApiException):
+    """Raised when access to a resource is not authorized."""
+
     def __init__(self, status=None, reason=None, http_resp=None) -> None:
         super(UnauthorizedException, self).__init__(status, reason, http_resp)
 
 
 class ForbiddenException(PineconeApiException):
+    """Raised when access to a resource is forbidden."""
+
     def __init__(self, status=None, reason=None, http_resp=None) -> None:
         super(ForbiddenException, self).__init__(status, reason, http_resp)
 
 
 class ServiceException(PineconeApiException):
+    """Raised when a service error occurs."""
+
     def __init__(self, status=None, reason=None, http_resp=None) -> None:
         super(ServiceException, self).__init__(status, reason, http_resp)
 
@@ -151,3 +161,20 @@ class PineconeConfigurationError(PineconeException):
 class ListConversionException(PineconeException, TypeError):
     def __init__(self, message):
         super().__init__(message)
+
+
+__all__ = [
+    "PineconeException",
+    "PineconeApiTypeError",
+    "PineconeApiValueError",
+    "PineconeApiAttributeError",
+    "PineconeApiKeyError",
+    "PineconeApiException",
+    "NotFoundException",
+    "UnauthorizedException",
+    "ForbiddenException",
+    "ServiceException",
+    "PineconeProtocolError",
+    "PineconeConfigurationError",
+    "ListConversionException",
+]

--- a/pinecone/pinecone.py
+++ b/pinecone/pinecone.py
@@ -15,12 +15,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from pinecone.config import Config, OpenApiConfiguration
-    from pinecone.db_data import (
-        _Index as Index,
-        _Inference as Inference,
-        _IndexAsyncio as IndexAsyncio,
-    )
-    from pinecone.db_control import DBControl
+    from pinecone.db_data import _Index as Index, _IndexAsyncio as IndexAsyncio
     from pinecone.db_control.index_host_store import IndexHostStore
     from pinecone.core.openapi.db_control.api.manage_indexes_api import ManageIndexesApi
     from pinecone.db_control.types import CreateIndexForModelEmbedTypedDict
@@ -94,18 +89,18 @@ class Pinecone(PluginAware, LegacyPineconeDBControlInterface):
             self._pool_threads = pool_threads
             """ @private """
 
-        self._inference: Optional["Inference"] = None  # Lazy initialization
+        self._inference = None  # Lazy initialization
         """ @private """
 
-        self._db_control: Optional["DBControl"] = None  # Lazy initialization
+        self._db_control = None  # Lazy initialization
         """ @private """
 
         super().__init__()  # Initialize PluginAware
 
     @property
-    def inference(self) -> "Inference":
+    def inference(self):
         """
-        Inference is a namespace where an instance of the `pinecone.data.features.inference.inference.Inference` class is lazily created and cached.
+        Inference is a namespace where an instance of the `pinecone.inference.Inference` class is lazily created and cached.
         """
         if self._inference is None:
             from pinecone.inference import Inference
@@ -118,7 +113,7 @@ class Pinecone(PluginAware, LegacyPineconeDBControlInterface):
         return self._inference
 
     @property
-    def db(self) -> "DBControl":
+    def db(self):
         """
         DBControl is a namespace where an instance of the `pinecone.control.db_control.DBControl` class is lazily created and cached.
         """

--- a/pinecone/pinecone.py
+++ b/pinecone/pinecone.py
@@ -115,7 +115,7 @@ class Pinecone(PluginAware, LegacyPineconeDBControlInterface):
     @property
     def db(self):
         """
-        DBControl is a namespace where an instance of the `pinecone.control.db_control.DBControl` class is lazily created and cached.
+        DBControl is a namespace where an instance of the `pinecone.db_control.DBControl` class is lazily created and cached.
         """
         if self._db_control is None:
             from pinecone.db_control import DBControl


### PR DESCRIPTION
## Problem

While implementing lazy loading and a package level .pyi file, we accidentally broke intellisense for some classes.

## Solution

- Add missing exceptions to pyi
- Remove type annotations on `pc.inference` that rely on values imported during `TYPE_CHECKING`. It seems like mypy and intellisense/autocomplete are able to infer these types without them being labeled explicitly. I think there is some sort of bug in the way autocomplete works because these type hints used with [TYPE_CHECKING](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) are valid and seem to work for typechecking purposes. 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Made a `7.0.1.dev1` dev build to confirm autocomplete behavior in different environments