### PR TITLE
Fix: GRPCIndex.query future result type

### DIFF
--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -408,7 +408,7 @@ class GRPCIndex(GRPCIndexBase):
 
         if async_req:
             future = self.runner.run(self.stub.Query.future, request, timeout=timeout)
-            return PineconeGrpcFuture(future)
+            return PineconeGrpcFuture(future, result_transformer=lambda x: parse_query_response(json_format.MessageToDict(x)))
         else:
             response = self.runner.run(self.stub.Query, request, timeout=timeout)
             json_response = json_format.MessageToDict(response)


### PR DESCRIPTION
This was missing a parse_query_response call, causing the result to be the raw Message.

## Problem

`GRPCIndex.query` was returning a raw `Message` when using `async_req`. This change fixes that.

## Solution

Set a result_transformer on the future to parse it.

## Type of Change

This is somewhat breaking because anyone affected was likely working around it.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Unclear, the current strategy for testing query doesn't actually generate a response.