### PR TITLE
Fix race condition in integration test cleanup

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -48,7 +48,7 @@ jobs:
       - create-project
     with:
       encrypted_project_api_key: ${{ needs.create-project.outputs.encrypted_project_api_key }}
-      python_versions_json: '["3.9"]'
+      python_versions_json: '["3.13", "3.9"]'
 
   cleanup-project:
     if: ${{ always() }}

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -75,7 +75,7 @@ def poll_stats_for_namespace(
     idx: _Index,
     namespace: str,
     expected_count: int,
-    max_sleep: int = int(os.environ.get("FRESHNESS_TIMEOUT_SECONDS", 60)),
+    max_sleep: int = int(os.environ.get("FRESHNESS_TIMEOUT_SECONDS", 180)),
 ) -> None:
     delta_t = 5
     total_time = 0

--- a/tests/integration/helpers/names.py
+++ b/tests/integration/helpers/names.py
@@ -1,4 +1,5 @@
-import hashlib
+import uuid
+# import hashlib
 
 
 def generate_name(test_name: str, label: str, max_length: int = 20) -> str:
@@ -11,4 +12,11 @@ def generate_name(test_name: str, label: str, max_length: int = 20) -> str:
     since the full length of 64 characters exceeds the allowed length of some fields
     in the API. For example, index names must be 45 characters or less.
     """
-    return hashlib.sha256(f"{test_name}-{label}".encode()).hexdigest()[:max_length]
+    # return hashlib.sha256(f"{test_name}-{label}".encode()).hexdigest()[:max_length]
+
+    # Having names be fully deterministic led to problems when multiple test builds
+    # are running in parallel, for example running the same tests in parallel for
+    # different python versions. We can solve this by incorporating more information
+    # into the name generation, but for now as a quick fix to unblock a release we
+    # will just fall back to using a random uuid.
+    return str(uuid.uuid4())


### PR DESCRIPTION
## Problem

I noticed that tests were failing for the python 3.13 build of `tests/integration/data_grpc_futures` tests after merging PR #510 to main.

## Solution

Context:
- When tests are run on a PR branch, they only execute on python 3.9. 
- When tests they run on main, tests run for both python 3.9 and 3.13. 

What I observed:
- In this case, the python 3.13 build of newly added tests `tests/integration/data_grpc_futures` was consistently failing with "Unauthorized" errors
- Despite the confusing error message from the API, this "Unauthorized" response was being returned when making calls for an index that no longer exists.
- Why did the index no longer exist? Because the python 3.9 build of the same tests was completing first and nuking the index before the 3.13 python build completes.
- Why would the 3.9 tests delete an index being used by the 3.13 tests?
- A test helper was assigning a deterministic name for the index that was the same for both builds.

Solution:
- Revert back to a randomized name strategy for indexes.  Need to rethink deterministic names later before we can use something like VCR to playback recorded API calls in testing.
- Reenable 3.13 tests on PR branches for now so we can see that this change takes care of the problem observed on merge 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure change (CI configs, etc)

## Test Plan

Should see all tests passing even when 3.9 and 3.13 tests are run together on PR push.
