### PR TITLE
Remove Github username from index_name for integration tests

### DIFF
--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -280,11 +280,7 @@ async def asyncio_wait_until(
 
 
 def default_create_index_params(request, run_id):
-    github_actor = os.getenv("GITHUB_ACTOR", None)
-    user = os.getenv("USER", None)
-    index_owner = github_actor or user or "unknown"
-
-    index_name = f"{index_owner}-{str(uuid.uuid4())}"
+    index_name = f"{str(uuid.uuid4())}"
     tags = index_tags(request, run_id)
     cloud = get_environment_var("SERVERLESS_CLOUD", "aws")
     region = get_environment_var("SERVERLESS_REGION", "us-west-2")


### PR DESCRIPTION
## Problem

A couple of integration tests were failing because the index_name included the GitHub username and a UUID, which caused it to exceed the 45-character limit.

## Solution

Remove Github username from the index_name

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Failing integration tests should run successfully now
