### PR TITLE
Speed up grpc fetch and query response parsing

### DIFF
--- a/pinecone/grpc/index_grpc.py
+++ b/pinecone/grpc/index_grpc.py
@@ -446,8 +446,7 @@ class GRPCIndex(GRPCIndexBase):
             )
         else:
             response = self.runner.run(self.stub.Query, request, timeout=timeout)
-            json_response = json_format.MessageToDict(response)
-            return parse_query_response(json_response, _check_type=False)
+            return parse_query_response(response, _check_type=False)
 
     def query_namespaces(
         self,


### PR DESCRIPTION


## Problem

Running a profiler on my pinecone-using application. it was CPU-bottlenecked on `json_format.MessageToDict` (being able to do about 100 vectors per second in query and fetch responses).
It turns out converting the embeddings to a dict this way is very slow. It's much faster to convert them to a list without going through `MessageToDict`.

## Solution

Changed `parse_fetch_response` and `parse_query_response` to directly read the protobuf structure instead of going through `MessageToDict`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.

- [x] Ran `make test-grpc-unit`.
