### PR TITLE
Expose delete organization function

### DIFF
--- a/pinecone/admin/resources/organization.py
+++ b/pinecone/admin/resources/organization.py
@@ -7,7 +7,7 @@ from pinecone.core.openapi.admin.models import UpdateOrganizationRequest
 
 class OrganizationResource:
     """
-    This class is used to list, fetch, and update organizations.
+    This class is used to list, fetch, update, and delete organizations.
 
     .. note::
         The class should not be instantiated directly. Instead, access this classes
@@ -191,3 +191,40 @@ class OrganizationResource:
         return self._organizations_api.update_organization(
             organization_id=organization_id, update_organization_request=update_request
         )
+
+    @require_kwargs
+    def delete(self, organization_id: str):
+        """
+        Delete an organization by organization_id.
+
+        .. warning::
+            Deleting an organization is a permanent and irreversible operation.
+            Please be very sure you want to delete the organization and everything
+            associated with it before calling this function.
+
+        Before deleting an organization, you must delete all projects (including indexes,
+        assistants, backups, and collections) associated with the organization.
+
+        :param organization_id: The organization_id of the organization to delete.
+        :type organization_id: str
+        :return: ``None``
+
+        Examples
+        --------
+
+        .. code-block:: python
+            :caption: Delete an organization by organization_id
+            :emphasize-lines: 7-9
+
+            from pinecone import Admin
+
+            # Credentials read from PINECONE_CLIENT_ID and
+            # PINECONE_CLIENT_SECRET environment variables
+            admin = Admin()
+
+            admin.organization.delete(
+                organization_id="42ca341d-43bf-47cb-9f27-e645dbfabea6"
+            )
+
+        """
+        return self._organizations_api.delete_organization(organization_id=organization_id)

--- a/tests/unit/admin/__init__.py
+++ b/tests/unit/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for admin resources."""

--- a/tests/unit/admin/test_organization.py
+++ b/tests/unit/admin/test_organization.py
@@ -1,0 +1,52 @@
+"""Unit tests for OrganizationResource delete method.
+
+These tests verify that the delete() method correctly builds and passes requests
+to the underlying API client without making real API calls.
+"""
+
+import pytest
+
+from pinecone.admin.resources.organization import OrganizationResource
+from pinecone.openapi_support import ApiClient
+
+
+class TestOrganizationResourceDelete:
+    """Test parameter translation in OrganizationResource.delete()"""
+
+    def setup_method(self):
+        """Set up test fixtures"""
+        api_client = ApiClient()
+        self.organization_resource = OrganizationResource(api_client=api_client)
+
+    def test_delete_calls_api_with_organization_id(self, mocker):
+        """Test delete() calls the API method with correct organization_id"""
+        mocker.patch.object(
+            self.organization_resource._organizations_api, "delete_organization", autospec=True
+        )
+
+        organization_id = "test-org-id-123"
+        self.organization_resource.delete(organization_id=organization_id)
+
+        # Verify API was called with correct arguments
+        self.organization_resource._organizations_api.delete_organization.assert_called_once_with(
+            organization_id=organization_id
+        )
+
+    def test_delete_requires_organization_id(self):
+        """Test that delete() requires organization_id parameter via @require_kwargs"""
+        with pytest.raises(TypeError):
+            self.organization_resource.delete()
+
+    def test_delete_with_different_organization_id(self, mocker):
+        """Test delete() with a different organization_id value"""
+        mocker.patch.object(
+            self.organization_resource._organizations_api, "delete_organization", autospec=True
+        )
+
+        organization_id = "another-org-id-456"
+        self.organization_resource.delete(organization_id=organization_id)
+
+        # Verify API was called with the specific organization_id
+        self.organization_resource._organizations_api.delete_organization.assert_called_once_with(
+            organization_id=organization_id
+        )


### PR DESCRIPTION
# Expose delete organization function

## Summary
Exposes the `delete_organization` endpoint through the public `OrganizationResource` interface. This endpoint was available in the generated OpenAPI client but was not accessible through the public SDK API.

## Changes

### Implementation
- Added `delete()` method to `OrganizationResource` class in `pinecone/admin/resources/organization.py`
- Method follows the same pattern as `ApiKeyResource.delete()` and `ProjectResource.delete()`
- Includes `@require_kwargs` decorator for parameter validation
- Added RST-formatted docstring with warning about permanent deletion
- Updated class docstring to mention delete functionality

### Testing
Added comprehensive unit tests in `tests/unit/admin/test_organization.py`:
- **Request verification**: Tests verify that `delete()` correctly calls the underlying API method with the correct `organization_id` parameter
- **Parameter validation**: Tests verify that `@require_kwargs` enforces the required `organization_id` parameter
- **Edge cases**: Tests with different `organization_id` values to ensure proper parameter passing

All tests use mocks to verify request building without making real API calls.

## Usage Example

```python
from pinecone import Admin

admin = Admin()

# Delete an organization
admin.organization.delete(
    organization_id="42ca341d-43bf-47cb-9f27-e645dbfabea6"
)
```

## Backward Compatibility
✅ Fully backward compatible. This is a new method addition that does not modify existing functionality.

## Files Changed
- `pinecone/admin/resources/organization.py` - Added `delete()` method
- `tests/unit/admin/test_organization.py` - New file with unit tests
- `tests/unit/admin/__init__.py` - New file for package structure

## Related
This addresses the gap identified in `ENDPOINT_COVERAGE_AUDIT_RESULTS.md` where `delete_organization` was marked as missing from the public interface. The endpoint was available in `pinecone/core/openapi/admin/api/organizations_api.py` but not exposed through `OrganizationResource`.
