### PR TITLE
Improve IDE Tab-Completion and Type Hinting Support

### DIFF
--- a/pinecone/__init__.pyi
+++ b/pinecone/__init__.pyi
@@ -79,16 +79,59 @@ from pinecone.db_control.models import (
     ServerlessSpecDefinition,
     PodSpec,
     PodSpecDefinition,
+    ByocSpec,
+    BackupModel,
+    BackupList,
+    RestoreJobModel,
+    RestoreJobList,
 )
+from pinecone.db_control.models.serverless_spec import (
+    ScalingConfigManualDict,
+    ReadCapacityDedicatedConfigDict,
+    ReadCapacityOnDemandDict,
+    ReadCapacityDedicatedDict,
+    ReadCapacityDict,
+    MetadataSchemaFieldConfig,
+)
+from pinecone.db_data.filter_builder import FilterBuilder
 from pinecone.db_control.types import ConfigureIndexEmbed, CreateIndexForModelEmbedTypedDict
 from pinecone.pinecone import Pinecone
 from pinecone.pinecone_asyncio import PineconeAsyncio
+from pinecone.admin import Admin
+from pinecone.utils import __version__
+
+# Deprecated top-level functions
+def init(*args: object, **kwargs: object) -> None: ...
+def create_index(*args: object, **kwargs: object) -> None: ...
+def delete_index(*args: object, **kwargs: object) -> None: ...
+def list_indexes(*args: object, **kwargs: object) -> None: ...
+def describe_index(*args: object, **kwargs: object) -> None: ...
+def configure_index(*args: object, **kwargs: object) -> None: ...
+def scale_index(*args: object, **kwargs: object) -> None: ...
+def create_collection(*args: object, **kwargs: object) -> None: ...
+def delete_collection(*args: object, **kwargs: object) -> None: ...
+def describe_collection(*args: object, **kwargs: object) -> None: ...
+def list_collections(*args: object, **kwargs: object) -> None: ...
 
 # Re-export all the types
 __all__ = [
+    "__version__",
+    # Deprecated top-level functions
+    "init",
+    "create_index",
+    "delete_index",
+    "list_indexes",
+    "describe_index",
+    "configure_index",
+    "scale_index",
+    "create_collection",
+    "delete_collection",
+    "describe_collection",
+    "list_collections",
     # Primary client classes
     "Pinecone",
     "PineconeAsyncio",
+    "Admin",
     # Config classes
     "Config",
     "ConfigBuilder",
@@ -139,6 +182,7 @@ __all__ = [
     "UpdateRequest",
     "NamespaceDescription",
     "ImportErrorMode",
+    "FilterBuilder",
     # Error classes
     "VectorDictionaryMissingKeysError",
     "VectorDictionaryExcessKeysError",
@@ -166,7 +210,18 @@ __all__ = [
     "ServerlessSpecDefinition",
     "PodSpec",
     "PodSpecDefinition",
+    "ByocSpec",
+    "BackupModel",
+    "BackupList",
+    "RestoreJobModel",
+    "RestoreJobList",
     # Control plane types
     "ConfigureIndexEmbed",
     "CreateIndexForModelEmbedTypedDict",
+    "ScalingConfigManualDict",
+    "ReadCapacityDedicatedConfigDict",
+    "ReadCapacityOnDemandDict",
+    "ReadCapacityDedicatedDict",
+    "ReadCapacityDict",
+    "MetadataSchemaFieldConfig",
 ]

--- a/pinecone/db_data/index.py
+++ b/pinecone/db_data/index.py
@@ -107,10 +107,13 @@ class UpsertResponseTransformer:
     while delegating other methods to the underlying ApplyResult.
     """
 
-    def __init__(self, apply_result: ApplyResult):
+    _apply_result: ApplyResult
+    """ :meta private: """
+
+    def __init__(self, apply_result: ApplyResult) -> None:
         self._apply_result = apply_result
 
-    def get(self, timeout=None):
+    def get(self, timeout: float | None = None) -> UpsertResponse:
         openapi_response = self._apply_result.get(timeout)
         from pinecone.utils.response_info import extract_response_info
 
@@ -123,7 +126,7 @@ class UpsertResponseTransformer:
             upserted_count=openapi_response.upserted_count, _response_info=response_info
         )
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         # Delegate other methods to the underlying ApplyResult
         return getattr(self._apply_result, name)
 
@@ -133,6 +136,21 @@ class Index(PluginAware, IndexInterface):
     A client for interacting with a Pinecone index via REST API.
     For improved performance, use the Pinecone GRPC index client.
     """
+
+    _config: "Config"
+    """ :meta private: """
+
+    _openapi_config: "OpenApiConfiguration"
+    """ :meta private: """
+
+    _pool_threads: int
+    """ :meta private: """
+
+    _vector_api: VectorOperationsApi
+    """ :meta private: """
+
+    _api_client: ApiClient
+    """ :meta private: """
 
     _bulk_import_resource: "BulkImportResource" | None
     """ :meta private: """

--- a/pinecone/db_data/index_asyncio.py
+++ b/pinecone/db_data/index_asyncio.py
@@ -65,6 +65,7 @@ from .vector_factory import VectorFactory
 from .query_results_aggregator import QueryNamespacesResults
 
 if TYPE_CHECKING:
+    from pinecone.config import Config, OpenApiConfiguration
     from .resources.asyncio.bulk_import_asyncio import BulkImportResourceAsyncio
     from .resources.asyncio.namespace_asyncio import NamespaceResourceAsyncio
 
@@ -167,6 +168,18 @@ class _IndexAsyncio(IndexAsyncioInterface):
 
     Failing to do this may result in error messages appearing from the underlyling aiohttp library.
     """
+
+    config: "Config"
+    """ :meta private: """
+
+    _openapi_config: "OpenApiConfiguration"
+    """ :meta private: """
+
+    _vector_api: AsyncioVectorOperationsApi
+    """ :meta private: """
+
+    _api_client: AsyncioApiClient
+    """ :meta private: """
 
     _bulk_import_resource: "BulkImportResourceAsyncio" | None
     """ :meta private: """

--- a/pinecone/grpc/resources/vector_grpc.py
+++ b/pinecone/grpc/resources/vector_grpc.py
@@ -176,7 +176,7 @@ class VectorResourceGRPC(PluginAware):
     def upsert_from_dataframe(
         self,
         df,
-        namespace: Optional[str] = None,
+        namespace: str | None = None,
         batch_size: int = 500,
         use_async_requests: bool = True,
         show_progress: bool = True,

--- a/pinecone/inference/inference.py
+++ b/pinecone/inference/inference.py
@@ -172,8 +172,7 @@ class Inference(PluginAware):
           ``n`` embeddings, where ``n`` = len(inputs). Precision of returned embeddings is either
           float16 or float32, with float32 being the default. ``model`` key is the model used to generate the embeddings.
           ``usage`` key contains the total number of tokens used at request-time.
-
-        Example:
+        :rtype: EmbeddingsList
 
         .. code-block:: python
 

--- a/pinecone/utils/plugin_aware.py
+++ b/pinecone/utils/plugin_aware.py
@@ -25,6 +25,9 @@ class PluginAware:
     can't be changed without breaking compatibility with plugins in the wild.
     """
 
+    _plugins_loaded: bool
+    """ :meta private: """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """
         Initialize the PluginAware class.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["pinecone"]
+include = ["pinecone/py.typed"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"


### PR DESCRIPTION
# Improve IDE Tab-Completion and Type Hinting Support

## Summary
This PR enhances IDE tab-completion and type hinting support for the Pinecone Python SDK by ensuring complete type coverage. It adds missing return type annotations, class-level attribute type annotations, completes the type stub file, and ensures the `py.typed` marker file is included in package distribution.

## Problem
Some areas of the codebase lacked complete type annotations, which limited IDE tab-completion and type checking capabilities:
- Some methods were missing return type annotations (e.g., `UpsertResponseTransformer.get()`, `__getattr__()`)
- Instance attributes lacked class-level type annotations, making it difficult for IDEs to infer types
- The `__init__.pyi` stub file was incomplete, missing several exported types including deprecated functions, the `Admin` class, `__version__`, and various lazy-loaded types
- The `py.typed` marker file wasn't explicitly configured in the build system, potentially causing issues with type checker discovery

## Solution
Enhanced IDE support and type checking by:
- **Ensured `py.typed` marker file is included**: Added explicit configuration in `pyproject.toml` to guarantee the PEP 561 marker file is packaged
- **Added missing return type annotations**: Added return types to `UpsertResponseTransformer.get()` (returns `UpsertResponse`) and `__getattr__()` (returns `Any`)
- **Added class-level type annotations**: Added type annotations for instance attributes in:
  - `PluginAware._plugins_loaded`
  - `UpsertResponseTransformer._apply_result`
  - `Index` class attributes (`_config`, `_openapi_config`, `_pool_threads`, `_vector_api`, `_api_client`)
  - `IndexAsyncio` class attributes (`config`, `_openapi_config`, `_vector_api`, `_api_client`)
- **Completed `__init__.pyi` stub file**: Added all missing exported types including:
  - Deprecated top-level functions (init, create_index, delete_index, etc.)
  - `Admin` class
  - `__version__`
  - Missing lazy-loaded types (FilterBuilder, ByocSpec, BackupModel, RestoreJobModel, RestoreJobList, BackupList, and all ReadCapacity and MetadataSchema types)
- **Fixed type annotation**: Replaced `Optional[str]` with `str | None` in `vector_grpc.py` for consistency

## User-Facing Impact

### Benefits
- **Enhanced IDE Support**: Complete type annotations enable better autocomplete, tab-completion, and inline type hints in IDEs like VS Code, PyCharm, and others
- **Better Type Checking**: More complete type coverage improves static type checking with mypy, pyright, and other tools
- **Improved Developer Experience**: Developers get better IntelliSense and can catch type errors earlier in their development workflow
- **No Breaking Changes**: All changes are purely additive - runtime behavior is unchanged

### Breaking Changes
**None** - This is a purely additive change. All existing code continues to work without modification.

### Migration Guide
No migration required for users. The changes are internal to the SDK and transparent to users. Users will automatically benefit from improved IDE support when they update to this version.

## Example Usage

The improvements are transparent to users, but developers will notice better IDE support:

```python
from pinecone import Pinecone

pc = Pinecone(api_key="your-api-key")
index = pc.Index("my-index")

# IDE now provides better autocomplete and type hints for:
# - index.upsert() method parameters and return type
# - index.query() method parameters and return type
# - All exported types from pinecone package
```

## Technical Details

### Type Stub File Completion
The `__init__.pyi` stub file now includes all exports from `__init__.py`, ensuring type checkers and IDEs have complete information about what's available in the package. This includes:
- All lazy-loaded types that are dynamically imported
- Deprecated functions that raise helpful error messages
- All enum types, model classes, and dataclasses

### Class-Level Attribute Annotations
Adding class-level type annotations for instance attributes (PEP 526) allows IDEs to:
- Provide autocomplete for instance attributes
- Show type information in hover tooltips
- Perform type checking on attribute access

### PEP 561 Compliance
Explicitly including `py.typed` in the package distribution ensures type checkers can discover that the package contains type information, following PEP 561 guidelines.

## Testing
- All existing tests pass
- Mypy type checking passes with no errors (192 source files checked, excluding generated code)
- Verified `py.typed` is included in package distribution
- Verified `__init__.pyi` stub file matches all exports from `__init__.py`
- All files compile successfully

## Compatibility
- **Python Version**: Requires Python 3.10+ (already a requirement)
- **Backward Compatibility**: Fully backward compatible - no API changes
- **Type Checkers**: Compatible with mypy, pyright, and other modern type checkers
