### PR TITLE
Update pinecone-plugin-assistant to >=3.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "orjson>=3.0.0",
     "pinecone-plugin-interface>=0.0.7,<0.1.0",
     "python-dateutil>=2.5.3",
-    "pinecone-plugin-assistant==3.0.1",
+    "pinecone-plugin-assistant>=3.0.1,<4.0.0",
     "urllib3>=1.26.0; python_version<'3.12'",
     "urllib3>=1.26.5; python_version>='3.12'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1659,7 +1659,7 @@ requires-dist = [
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'dev'", specifier = ">=2.2.3" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=1.3.5,<2.2.3" },
     { name = "pandas-stubs", marker = "extra == 'types'", specifier = ">=2.1.1.230928,<2.2.0.0" },
-    { name = "pinecone-plugin-assistant", specifier = "==3.0.1" },
+    { name = "pinecone-plugin-assistant", specifier = ">=3.0.1,<4.0.0" },
     { name = "pinecone-plugin-interface", specifier = ">=0.0.7,<0.1.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0,<4.0.0" },
     { name = "protobuf", marker = "extra == 'grpc'", specifier = ">=5.29.5,<6.0.0" },


### PR DESCRIPTION
## Problem

The SDK was pinned to `pinecone-plugin-assistant==3.0.0`, which prevents automatic updates to compatible patch and minor versions (e.g., 3.0.1, 3.0.2, 3.1.0).

## Solution

Updated the dependency specification to use a version range (`>=3.0.1,<4.0.0`) instead of an exact pin. This allows the SDK to automatically pick up compatible future versions while maintaining API compatibility within the 3.x series.

## Changes

- **`pyproject.toml`**: Changed `pinecone-plugin-assistant==3.0.0` to `pinecone-plugin-assistant>=3.0.1,<4.0.0`
- **`uv.lock`**: Regenerated lock file to resolve to version 3.0.1

## Impact

Users will automatically receive compatible updates to the assistant plugin (3.0.1, 3.0.2, 3.1.0, etc.) when installing or updating the SDK, without requiring a new SDK release. The version range ensures compatibility within the 3.x major version while preventing breaking changes from 4.0.0+.

## Breaking Changes

None. This change maintains backward compatibility and only affects how future compatible versions are resolved.