### PR TITLE
Expand protobuf version constraint to include v6.x

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Bump pyproject.toml version
         run: |
-          python -c "import re; content = open('pyproject.toml').read(); content = re.sub(r'version = \"[^\"]+\"', 'version = \"${{ steps.bump.outputs.version }}\"', content); open('pyproject.toml', 'w').write(content)"
+          python -c "import re; content = open('pyproject.toml').read(); content = re.sub(r'^version = \"[^\"]+\"', 'version = \"${{ steps.bump.outputs.version }}\"', content, flags=re.MULTILINE); open('pyproject.toml', 'w').write(content)"
 
       - name: Build Python client
         run: make package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ grpc = [
     "grpcio>=1.68.0; python_version>='3.13'",
     "googleapis-common-protos>=1.66.0",
     "lz4>=3.1.3",
-    "protobuf>=5.29.5,<6.0.0",
+    "protobuf>=5.29.5,<7.0.0",
     "protoc-gen-openapiv2>=0.0.1,<0.1.0",
 ]
 asyncio = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ exclude = [
 
 line-length = 100
 indent-width = 4
-target-version = "8.0.0"
+target-version = "py310"
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/uv.lock
+++ b/uv.lock
@@ -1580,7 +1580,7 @@ wheels = [
 
 [[package]]
 name = "pinecone"
-version = "7.3.0"
+version = "8.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
@@ -1662,7 +1662,7 @@ requires-dist = [
     { name = "pinecone-plugin-assistant", specifier = ">=3.0.1,<4.0.0" },
     { name = "pinecone-plugin-interface", specifier = ">=0.0.7,<0.1.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0,<4.0.0" },
-    { name = "protobuf", marker = "extra == 'grpc'", specifier = ">=5.29.5,<6.0.0" },
+    { name = "protobuf", marker = "extra == 'grpc'", specifier = ">=5.29.5,<7.0.0" },
     { name = "protoc-gen-openapiv2", marker = "extra == 'grpc'", specifier = ">=0.0.1,<0.1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.2.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.2,<0.26.0" },


### PR DESCRIPTION
## Problem

The current protobuf dependency constraint (`>=5.29.5,<6.0.0`) blocks users from using protobuf 6.x. Some users may want or need to use protobuf 6.x in their environments, and the current upper bound prevents this.

## Solution

Updated the protobuf version constraint from `<6.0.0` to `<7.0.0` in `pyproject.toml`, allowing both protobuf 5.x and 6.x.

According to the [Protocol Buffers Cross-Version Runtime Guarantee](https://protobuf.dev/support/cross-version-runtime-guarantee/), code generated for major version V is supported by runtimes of versions V and V+1. Our proto files were generated with protobuf 5.x, so they should be compatible with 6.x runtimes.

**Verified locally:** Successfully imported proto modules and ran all gRPC unit tests with protobuf 6.33.2 installed.

**Security note:** CVE-2025-4565 is fixed in protobuf 5.29.5 and 6.31.1. The existing `>=5.29.5` lower bound ensures 5.x users get patched versions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

1. Ran all gRPC unit tests with protobuf 6.33.2 installed
2. CI will run the full test suite