### PR TITLE
Remove deprecated rerank models

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -305,9 +305,9 @@ models = pc.inference.list_models(type="rerank", vector_type="dense")
 Or, if you know the name of a model, you can get just those details
 
 ```
-pc.inference.get_model(model_name='pinecone-rerank-v0')
+pc.inference.get_model(model_name='bge-reranker-v2-m3')
 # {
-#     "model": "pinecone-rerank-v0",
+#     "model": "bge-reranker-v2-m3",
 #     "short_description": "A state of the art reranking model that out-performs competitors on widely accepted benchmarks. It can handle chunks up to 512 tokens (1-2 paragraphs)",
 #     "type": "rerank",
 #     "supported_parameters": [

--- a/pinecone/inference/inference.py
+++ b/pinecone/inference/inference.py
@@ -307,7 +307,7 @@ class Inference(PluginAware):
 
             pc = Pinecone()
             result = pc.inference.rerank(
-                model="pinecone-rerank-v0",
+                model="bge-reranker-v2-m3",
                 query="What is machine learning?",
                 documents=[
                     {"text": "Machine learning is a subset of AI.", "category": "tech"},
@@ -326,7 +326,7 @@ class Inference(PluginAware):
 
             pc = Pinecone()
             result = pc.inference.rerank(
-                model=RerankModel.PINECONE_RERANK_V0,
+                model=RerankModel.Bge_Reranker_V2_M3,
                 query="Your query here",
                 documents=["doc1", "doc2", "doc3"]
             )
@@ -399,10 +399,10 @@ class Inference(PluginAware):
             from pinecone import Pinecone
 
             pc = Pinecone()
-            model_info = pc.inference.get_model(model_name="pinecone-rerank-v0")
+            model_info = pc.inference.get_model(model_name="bge-reranker-v2-m3")
             print(model_info)
             # {
-            #     "model": "pinecone-rerank-v0",
+            #     "model": "bge-reranker-v2-m3",
             #     "short_description": "A state of the art reranking model that out-performs competitors on widely accepted benchmarks. It can handle chunks up to 512 tokens (1-2 paragraphs)",
             #     "type": "rerank",
             #     "supported_parameters": [

--- a/pinecone/inference/inference_asyncio.py
+++ b/pinecone/inference/inference_asyncio.py
@@ -265,7 +265,7 @@ class AsyncioInference:
             async def main():
                 async with PineconeAsyncio() as pc:
                     result = await pc.inference.rerank(
-                        model="pinecone-rerank-v0",
+                        model="bge-reranker-v2-m3",
                         query="What is machine learning?",
                         documents=[
                             {"text": "Machine learning is a subset of AI.", "category": "tech"},
@@ -288,7 +288,7 @@ class AsyncioInference:
             async def main():
                 async with PineconeAsyncio() as pc:
                     result = await pc.inference.rerank(
-                        model=RerankModel.PINECONE_RERANK_V0,
+                        model=RerankModel.Bge_Reranker_V2_M3,
                         query="Your query here",
                         documents=["doc1", "doc2", "doc3"]
                     )

--- a/pinecone/inference/inference_request_builder.py
+++ b/pinecone/inference/inference_request_builder.py
@@ -17,8 +17,6 @@ class EmbedModel(Enum):
 
 class RerankModel(Enum):
     Bge_Reranker_V2_M3 = "bge-reranker-v2-m3"
-    Cohere_Rerank_3_5 = "cohere-rerank-3.5"
-    Pinecone_Rerank_V0 = "pinecone-rerank-v0"
 
 
 class InferenceRequestBuilder:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ exclude = [
 
 line-length = 100
 indent-width = 4
-target-version = "8.0.0"
+target-version = "py310"
 
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
@@ -156,7 +156,3 @@ docstring-code-line-length = "dynamic"
 
 # E712 Allow == comparison to True/False
 "tests/**" = ["E712"]
-
-[tool.black]
-line-length = 100
-target-version = ["py310"]


### PR DESCRIPTION
# Remove Deprecated Rerank Models

## Problem

Support for two rerank models (`cohere-rerank-3.5` and `pinecone-rerank-v0`) is being removed from the Pinecone Inference API. These models are no longer available and should be removed from the SDK to prevent confusion and ensure users only see supported models.

## Solution

Removed the deprecated rerank models from the SDK by:
1. Removing `Cohere_Rerank_3_5` and `Pinecone_Rerank_V0` enum values from the `RerankModel` enum
2. Updating all code examples in docstrings to use the remaining supported model (`bge-reranker-v2-m3`)
3. Updating documentation examples to reflect the change

## Changes

### `pinecone/inference/inference_request_builder.py`
- Removed `Cohere_Rerank_3_5 = "cohere-rerank-3.5"` from `RerankModel` enum
- Removed `Pinecone_Rerank_V0 = "pinecone-rerank-v0"` from `RerankModel` enum

### `pinecone/inference/inference.py`
- Updated `rerank()` docstring example to use `"bge-reranker-v2-m3"` instead of `"pinecone-rerank-v0"`
- Updated `rerank()` enum example to use `RerankModel.Bge_Reranker_V2_M3` instead of `RerankModel.PINECONE_RERANK_V0`
- Updated `get_model()` docstring example to use `"bge-reranker-v2-m3"` instead of `"pinecone-rerank-v0"`

### `pinecone/inference/inference_asyncio.py`
- Updated `rerank()` docstring example to use `"bge-reranker-v2-m3"` instead of `"pinecone-rerank-v0"`
- Updated `rerank()` enum example to use `RerankModel.Bge_Reranker_V2_M3` instead of `RerankModel.PINECONE_RERANK_V0`

### `docs/upgrading.md`
- Updated example to use `"bge-reranker-v2-m3"` instead of `"pinecone-rerank-v0"`

### `pyproject.toml`
- Fixed ruff configuration: changed `target-version = "8.0.0"` to `target-version = "py310"`
- Removed duplicate `[tool.black]` section (ruff handles formatting)

## Impact

### User-Facing Impact

**BREAKING CHANGE**: Code that uses `RerankModel.Cohere_Rerank_3_5` or `RerankModel.PINECONE_RERANK_V0` will fail with an `AttributeError`. Users must migrate to `RerankModel.Bge_Reranker_V2_M3` or pass the model name as a string.

**Migration Path**:
- Replace `RerankModel.Cohere_Rerank_3_5` with `RerankModel.Bge_Reranker_V2_M3` or `"bge-reranker-v2-m3"`
- Replace `RerankModel.PINECONE_RERANK_V0` with `RerankModel.Bge_Reranker_V2_M3` or `"bge-reranker-v2-m3"`
- String-based model names (`"cohere-rerank-3.5"` and `"pinecone-rerank-v0"`) will still work if passed directly, but these models are deprecated and may not be available on the API

### Example Usage

**Before (will break)**:
```python
from pinecone import Pinecone, RerankModel

pc = Pinecone()
result = pc.inference.rerank(
    model=RerankModel.PINECONE_RERANK_V0,  # AttributeError: no such attribute
    query="Your query",
    documents=["doc1", "doc2"]
)
```

**After (correct)**:
```python
from pinecone import Pinecone, RerankModel

pc = Pinecone()
result = pc.inference.rerank(
    model=RerankModel.Bge_Reranker_V2_M3,  # ✅ Works
    query="Your query",
    documents=["doc1", "doc2"]
)
```

## Breaking Changes

**YES** - This is a breaking change. The following enum values have been removed:
- `RerankModel.Cohere_Rerank_3_5`
- `RerankModel.PINECONE_RERANK_V0`

Code using these enum values will raise `AttributeError` at runtime. Users must update their code to use `RerankModel.Bge_Reranker_V2_M3` or pass model names as strings.
