### PR TITLE
Fix types for FilterTypedDict

### DIFF
--- a/pinecone/db_data/types/query_filter.py
+++ b/pinecone/db_data/types/query_filter.py
@@ -32,4 +32,4 @@ SimpleFilter = (
 AndFilter = dict[Literal["$and"], list[SimpleFilter]]
 OrFilter = dict[Literal["$or"], list[SimpleFilter]]
 
-FilterTypedDict = SimpleFilter | AndFilter | OrFilter
+FilterTypedDict = dict[str, SimpleFilter | AndFilter | OrFilter]


### PR DESCRIPTION
## Problem

I believe the currently-set type for FilterTypedDict is incorrect. It suggests that the correct type is, for example:
```
index.query(
    ...,
    filter={"$in": ["red", "blue", "green"]}, # metadata key missing
    namespace=str(company_id),
),
```

when the correct type from [your documentation](https://docs.pinecone.io/guides/search/filter-by-metadata#metadata-filter-expressions) indicates that it should be
```
index.query(
    ...,
    filter={"colors": {"$in": ["red", "blue", "green"]}},
    namespace=str(company_id),
),
```

## Solution

```diff
- FilterTypedDict = SimpleFilter | AndFilter | OrFilter
+ FilterTypedDict = dict[str, SimpleFilter | AndFilter | OrFilter]
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Was running into this when running pyright on my codebase which uses pinecone. 

```
index.query(
    ...,
    filter={"colors": {"$in": ["red", "blue", "green"]}}, # <- error on this line
    namespace=str(company_id),
),
```

```
Argument of type "dict[str, dict[str, list[str]]]" cannot be assigned to parameter "filter" of type "FilterTypedDict | None" in function "query"
  Type "dict[str, dict[str, list[str]]]" is not assignable to type "FilterTypedDict | None"
    "dict[str, dict[str, list[str]]]" is not assignable to "Dict[str, FieldValue]"
```

Modifying the type as shown causes the error to go away.
