### PR TITLE
Add host validation and normalization to PineconeGRPC.Index()

### DIFF
--- a/pinecone/grpc/pinecone.py
+++ b/pinecone/grpc/pinecone.py
@@ -1,5 +1,7 @@
 from pinecone import Pinecone
 from pinecone.config import ConfigBuilder
+from pinecone.utils import normalize_host
+from pinecone.pinecone import check_realistic_host
 from .index_grpc import GRPCIndex
 
 
@@ -122,8 +124,13 @@ class PineconeGRPC(Pinecone):
         if name == "" and host == "":
             raise ValueError("Either name or host must be specified")
 
-        # Use host if it is provided, otherwise get host from describe_index
-        index_host = host or self.db.index._get_host(name)
+        if host != "":
+            check_realistic_host(host)
+            # Use host url if it is provided
+            index_host = normalize_host(host)
+        else:
+            # Otherwise, get host url from describe_index using the index name
+            index_host = self.db.index._get_host(name)
 
         pt = kwargs.pop("pool_threads", None) or self._pool_threads
 

--- a/tests/unit_grpc/test_grpc_index_initialization.py
+++ b/tests/unit_grpc/test_grpc_index_initialization.py
@@ -74,7 +74,7 @@ class TestGRPCIndexInitialization:
     def test_config_passed_when_target_by_host_and_port(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY")
         config = GRPCClientConfig(timeout=5, secure=False)
-        index = pc.Index(host="myhost:4343", grpc_config=config)
+        index = pc.Index(host="myhost.example.com:4343", grpc_config=config)
 
         assert index.grpc_client_config.timeout == 5
         assert index.grpc_client_config.secure == False
@@ -84,7 +84,7 @@ class TestGRPCIndexInitialization:
         assert index.grpc_client_config.conn_timeout == 1
 
         # Endpoint calculation does not override port
-        assert index._endpoint() == "myhost:4343"
+        assert index._endpoint() == "myhost.example.com:4343"
 
     def test_config_passes_source_tag_when_set(self):
         pc = PineconeGRPC(api_key="YOUR_API_KEY", source_tag="my_source_tag")

--- a/tests/unit_grpc/test_grpc_index_initialization.py
+++ b/tests/unit_grpc/test_grpc_index_initialization.py
@@ -1,3 +1,4 @@
+import pytest
 import re
 from pinecone.grpc import PineconeGRPC, GRPCClientConfig
 
@@ -91,3 +92,24 @@ class TestGRPCIndexInitialization:
             re.search(r"source_tag=my_source_tag", pc.db._index_api.api_client.user_agent)
             is not None
         )
+
+    def test_invalid_host(self):
+        pc = PineconeGRPC(api_key="key")
+
+        with pytest.raises(ValueError) as e:
+            pc.Index(host="invalid")
+        assert "You passed 'invalid' as the host but this does not appear to be valid" in str(
+            e.value
+        )
+
+        with pytest.raises(ValueError) as e:
+            pc.Index(host="my-index")
+        assert "You passed 'my-index' as the host but this does not appear to be valid" in str(
+            e.value
+        )
+
+        # Can instantiate with realistic host
+        pc.Index(host="test-bt8x3su.svc.apw5-4e34-81fa.pinecone.io")
+
+        # Can instantiate with localhost address
+        pc.Index(host="localhost:8080")


### PR DESCRIPTION
## Summary

This PR resolves a discrepancy in host handling between the REST (`Pinecone`) and gRPC (`PineconeGRPC`) clients. Previously, `Pinecone.Index()` validated and normalized host URLs, while `PineconeGRPC.Index()` did not, leading to inconsistent behavior and potential user errors.

## Changes Made

### Core Implementation
- **Added host validation** to `PineconeGRPC.Index()` using `check_realistic_host()` to ensure provided hosts are valid URLs (not index names)
- **Added host normalization** to `PineconeGRPC.Index()` using `normalize_host()` to automatically add the `https://` protocol prefix when missing
- Both validation and normalization now occur when a host is explicitly provided, matching the behavior of `Pinecone.Index()`

### Implementation Details

The changes ensure that when a host is provided to `PineconeGRPC.Index()`:

1. **Validation**: The host is checked to ensure it contains a `.` (dot) or is `localhost`, preventing common mistakes where users accidentally pass an index name as the host parameter
2. **Normalization**: The host is normalized to include a protocol prefix (`https://` or `http://`), ensuring consistent URL formatting

The implementation reuses existing utility functions:
- `check_realistic_host()` - Validates that the host string appears to be a valid hostname
- `normalize_host()` - Ensures the host has a protocol prefix

### Test Coverage

- Added `test_invalid_host()` to verify that invalid hosts (like `"invalid"` or `"my-index"`) raise appropriate `ValueError` exceptions
- Updated existing test `test_config_passed_when_target_by_host_and_port` to use a valid hostname (`myhost.example.com:4343` instead of `myhost:4343`) to comply with validation requirements

## Why This Change Was Made

This change ensures consistency between both client implementations. Without host validation, users could accidentally pass index names as hosts, leading to cryptic DNS resolution errors later. The normalization ensures that hosts are properly formatted regardless of whether users include the protocol prefix, making the API more user-friendly and consistent.

## Result

Both `Pinecone.Index()` and `PineconeGRPC.Index()` now:
- Validate that provided hosts are valid (contain a `.` or are `localhost`)
- Normalize hosts by adding `https://` prefix if no protocol is present
- Handle hosts consistently whether provided directly or fetched by index name

---

*This PR was generated with Vibe Kanban and Cursor.*