### PR TITLE
ci: skip integration tests for PRs targeting fts branch

### DIFF
--- a/.github/workflows/on-pr.yaml
+++ b/.github/workflows/on-pr.yaml
@@ -41,11 +41,12 @@ jobs:
       python_versions_json: '["3.10", "3.11", "3.12", "3.13"]'
 
   create-project:
+    if: github.base_ref != 'fts'
     uses: './.github/workflows/project-setup.yaml'
     secrets: inherit
 
   integration-tests:
-    if: always() && (needs.create-project.result == 'success')
+    if: always() && (needs.create-project.result == 'success') && github.base_ref != 'fts'
     uses: './.github/workflows/testing-integration.yaml'
     secrets: inherit
     needs:
@@ -57,7 +58,7 @@ jobs:
       sparse_index_host: ${{ needs.create-project.outputs.index_host_sparse }}
 
   cleanup-project:
-    if: ${{ always() }}
+    if: always() && github.base_ref != 'fts'
     needs:
       - create-project
       - integration-tests


### PR DESCRIPTION
## Problem

The FTS branch will involve a large number of breaking changes. Running the full integration test suite on every PR significantly slows down integration velocity during this development phase.

## Solution

Added branch conditions to skip integration tests when PRs target the `fts` branch:

- `create-project` job - Skipped to avoid unnecessary Pinecone infrastructure setup
- `integration-tests` job - Skipped to avoid running expensive test suites  
- `cleanup-project` job - Skipped since no infrastructure needs cleanup

Linting and unit tests still run on all PRs, providing fast feedback on code style and logic errors.

## Usage

PRs targeting the `fts` branch will only run:
- Linting
- Unit tests (all Python versions)

PRs targeting `main` or other branches continue to run the full test suite.

## Reverting

When the FTS branch is ready to merge to main, remove the `github.base_ref != 'fts'` conditions from `.github/workflows/on-pr.yaml` to restore full testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips costly integration workflow when PR base is `fts`.
> 
> - Adds `github.base_ref != 'fts'` guard to `create-project`, `integration-tests`, and `cleanup-project` jobs in `on-pr.yaml`
> - Linting and unit tests still run unchanged (all specified Python versions)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 716a3607a1ef1f0dc5899168dea943f62487e96e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->