### PR TITLE
fix: correct TextQuery and VectorQuery API serialization

### DIFF
--- a/pinecone/db_data/dataclasses/text_query.py
+++ b/pinecone/db_data/dataclasses/text_query.py
@@ -36,12 +36,12 @@ class TextQuery(DictLike):
     boost: float | None = None
     slop: int | None = None
 
-    def to_dict(self) -> dict:
+    def as_dict(self) -> dict:
         """Serialize to API format.
 
         :returns: Dictionary representation for the API.
         """
-        result: dict = {"field": self.field, "query": self.query}
+        result: dict = {"type": "text", "field": self.field, "text_query": self.query}
         if self.boost is not None:
             result["boost"] = self.boost
         if self.slop is not None:

--- a/pinecone/db_data/dataclasses/vector_query.py
+++ b/pinecone/db_data/dataclasses/vector_query.py
@@ -45,12 +45,12 @@ class VectorQuery(DictLike):
     values: list[float] | None = None
     sparse_values: SparseValues | None = None
 
-    def to_dict(self) -> dict:
+    def as_dict(self) -> dict:
         """Serialize to API format.
 
         :returns: Dictionary representation for the API.
         """
-        result: dict = {"field": self.field}
+        result: dict = {"type": "vector", "field": self.field}
         if self.values is not None:
             result["values"] = self.values
         if self.sparse_values is not None:

--- a/tests/unit/data/test_query_classes.py
+++ b/tests/unit/data/test_query_classes.py
@@ -11,25 +11,36 @@ class TestTextQuery:
         assert query.boost is None
         assert query.slop is None
 
-    def test_to_dict_minimal(self):
+    def test_as_dict_minimal(self):
         query = TextQuery(field="title", query="pink panther")
-        result = query.to_dict()
-        assert result == {"field": "title", "query": "pink panther"}
+        result = query.as_dict()
+        assert result == {"type": "text", "field": "title", "text_query": "pink panther"}
 
-    def test_to_dict_with_boost(self):
+    def test_as_dict_with_boost(self):
         query = TextQuery(field="title", query="pink panther", boost=2.0)
-        result = query.to_dict()
-        assert result == {"field": "title", "query": "pink panther", "boost": 2.0}
+        result = query.as_dict()
+        assert result == {
+            "type": "text",
+            "field": "title",
+            "text_query": "pink panther",
+            "boost": 2.0,
+        }
 
-    def test_to_dict_with_slop(self):
+    def test_as_dict_with_slop(self):
         query = TextQuery(field="title", query="pink panther", slop=2)
-        result = query.to_dict()
-        assert result == {"field": "title", "query": "pink panther", "slop": 2}
+        result = query.as_dict()
+        assert result == {"type": "text", "field": "title", "text_query": "pink panther", "slop": 2}
 
-    def test_to_dict_with_all_options(self):
+    def test_as_dict_with_all_options(self):
         query = TextQuery(field="title", query="pink panther", boost=1.5, slop=3)
-        result = query.to_dict()
-        assert result == {"field": "title", "query": "pink panther", "boost": 1.5, "slop": 3}
+        result = query.as_dict()
+        assert result == {
+            "type": "text",
+            "field": "title",
+            "text_query": "pink panther",
+            "boost": 1.5,
+            "slop": 3,
+        }
 
     def test_dict_like_access(self):
         query = TextQuery(field="title", query="pink panther", boost=2.0)
@@ -51,30 +62,32 @@ class TestVectorQuery:
         assert query.values is None
         assert query.sparse_values is None
 
-    def test_to_dict_minimal(self):
+    def test_as_dict_minimal(self):
         query = VectorQuery(field="embedding")
-        result = query.to_dict()
-        assert result == {"field": "embedding"}
+        result = query.as_dict()
+        assert result == {"type": "vector", "field": "embedding"}
 
-    def test_to_dict_with_values(self):
+    def test_as_dict_with_values(self):
         query = VectorQuery(field="embedding", values=[0.1, 0.2, 0.3])
-        result = query.to_dict()
-        assert result == {"field": "embedding", "values": [0.1, 0.2, 0.3]}
+        result = query.as_dict()
+        assert result == {"type": "vector", "field": "embedding", "values": [0.1, 0.2, 0.3]}
 
-    def test_to_dict_with_sparse_values(self):
+    def test_as_dict_with_sparse_values(self):
         sparse = SparseValues(indices=[1, 5, 10], values=[0.5, 0.3, 0.2])
         query = VectorQuery(field="sparse_embedding", sparse_values=sparse)
-        result = query.to_dict()
+        result = query.as_dict()
         assert result == {
+            "type": "vector",
             "field": "sparse_embedding",
             "sparse_values": {"indices": [1, 5, 10], "values": [0.5, 0.3, 0.2]},
         }
 
-    def test_to_dict_with_both_values(self):
+    def test_as_dict_with_both_values(self):
         sparse = SparseValues(indices=[1, 2], values=[0.5, 0.5])
         query = VectorQuery(field="hybrid", values=[0.1, 0.2, 0.3], sparse_values=sparse)
-        result = query.to_dict()
+        result = query.as_dict()
         assert result == {
+            "type": "vector",
             "field": "hybrid",
             "values": [0.1, 0.2, 0.3],
             "sparse_values": {"indices": [1, 2], "values": [0.5, 0.5]},
@@ -97,12 +110,14 @@ class TestQueryUsageExamples:
 
     def test_text_query_example(self):
         query = TextQuery(field="title", query='return "pink panther"')
-        result = query.to_dict()
+        result = query.as_dict()
+        assert result["type"] == "text"
         assert result["field"] == "title"
-        assert result["query"] == 'return "pink panther"'
+        assert result["text_query"] == 'return "pink panther"'
 
     def test_vector_query_example(self):
         query = VectorQuery(field="embedding", values=[0.1, 0.2, 0.3])
-        result = query.to_dict()
+        result = query.as_dict()
+        assert result["type"] == "vector"
         assert result["field"] == "embedding"
         assert result["values"] == [0.1, 0.2, 0.3]


### PR DESCRIPTION
## Summary

Fixes unresolved review comments from PR #586 that were merged without being addressed.

**Related PR:** #586

## Problems Fixed

### 1. Wrong API field name in `TextQuery` (High Severity)
The `as_dict()` method was serializing the query string with key `"query"`, but the Pinecone API expects `"text_query"` as defined in the OpenAPI spec.

### 2. Missing `type` discriminator field (High Severity)
Both `TextQuery` and `VectorQuery` were missing the required `type` discriminator field used by the `ScoreByQuery` oneOf schema:
- `TextQuery` → `"type": "text"`
- `VectorQuery` → `"type": "vector"`

### 3. Inconsistent method naming (Low Severity)
Changed `to_dict()` to `as_dict()` for consistency with similar search-related classes (`SearchQuery`, `SearchQueryVector`, `SearchRerank`).

## Breaking Changes

Since these classes were just added in PR #586 and haven't been released yet, these changes should not affect any users:
- `TextQuery.to_dict()` → `TextQuery.as_dict()`
- `VectorQuery.to_dict()` → `VectorQuery.as_dict()`

## Usage Example

```python
from pinecone import TextQuery, VectorQuery

# TextQuery for full-text search
text_query = TextQuery(field="title", query="pink panther")
text_query.as_dict()
# Returns: {"type": "text", "field": "title", "text_query": "pink panther"}

# With optional parameters
text_query = TextQuery(field="title", query="pink panther", boost=2.0, slop=1)
text_query.as_dict()
# Returns: {"type": "text", "field": "title", "text_query": "pink panther", "boost": 2.0, "slop": 1}

# VectorQuery for similarity search
vector_query = VectorQuery(field="embedding", values=[0.1, 0.2, 0.3])
vector_query.as_dict()
# Returns: {"type": "vector", "field": "embedding", "values": [0.1, 0.2, 0.3]}

# Use with search_documents()
results = index.search_documents(
    namespace="movies",
    score_by=TextQuery(field="title", query="pink panther"),
    top_k=10,
)
```

## Test Plan

- [x] Updated unit tests to verify correct API format with `type` discriminator
- [x] Updated tests to use `as_dict()` method name
- [x] All 16 query class tests pass
- [x] mypy type checking passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the serialized request shape and renames a public method (`to_dict()` → `as_dict()`), which can break any existing callers even though the change is localized.
> 
> **Overview**
> Fixes `TextQuery` and `VectorQuery` API serialization used by `score_by` by adding the required `type` discriminator (`"text"`/`"vector"`) and aligning field names (notably `query` → `text_query` for text scoring).
> 
> Renames the serialization helper from `to_dict()` to `as_dict()` on both classes and updates unit tests to assert the new payload format and method name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50ee95335932e3d9906c9d737a85b2bc7e960fbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->