### PR TITLE
feat: add schema/deployment params to create_index()

### DIFF
--- a/pinecone/db_control/resources/sync/index.py
+++ b/pinecone/db_control/resources/sync/index.py
@@ -6,7 +6,14 @@ from typing import Dict, TYPE_CHECKING, Any
 
 from pinecone.db_control.index_host_store import IndexHostStore
 
-from pinecone.db_control.models import IndexModel, IndexList, IndexEmbed
+from pinecone.db_control.models import (
+    IndexModel,
+    IndexList,
+    IndexEmbed,
+    ServerlessDeployment,
+    PodDeployment,
+    ByocDeployment,
+)
 from pinecone.utils import docslinks, require_kwargs, PluginAware
 
 from pinecone.db_control.types import CreateIndexForModelEmbedTypedDict
@@ -75,23 +82,91 @@ class IndexResource(PluginAware):
         self,
         *,
         name: str,
-        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec",
+        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec" | None = None,
         dimension: int | None = None,
         metric: ("Metric" | str) | None = "cosine",
         timeout: int | None = None,
         deletion_protection: ("DeletionProtection" | str) | None = "disabled",
         vector_type: ("VectorType" | str) | None = "dense",
         tags: dict[str, str] | None = None,
+        schema: dict[str, Any] | None = None,
+        deployment: ServerlessDeployment | PodDeployment | ByocDeployment | None = None,
     ) -> IndexModel:
-        req = PineconeDBControlRequestFactory.create_index_request(
-            name=name,
-            spec=spec,
-            dimension=dimension,
-            metric=metric,
-            deletion_protection=deletion_protection,
-            vector_type=vector_type,
-            tags=tags,
-        )
+        """Create an index.
+
+        :param name: The name of the index.
+        :param spec: The spec for the index (legacy format). Mutually exclusive with ``schema``.
+        :param dimension: The dimension of vectors for the index (legacy format).
+        :param metric: The distance metric for similarity search (legacy format).
+        :param timeout: Timeout in seconds for waiting for the index to be ready.
+            If -1, returns immediately without waiting. If None, waits indefinitely.
+        :param deletion_protection: Whether to enable deletion protection.
+        :param vector_type: The vector type (dense or sparse) (legacy format).
+        :param tags: Optional tags for the index.
+        :param schema: A dict mapping field names to field configurations. Mutually exclusive with ``spec``.
+        :param deployment: The deployment configuration. Defaults to serverless aws/us-east-1.
+            Only used when ``schema`` is provided.
+        :returns: The created index model.
+        :raises ValueError: If both ``spec`` and ``schema`` are provided or neither is provided.
+
+        **Legacy Usage (spec-based):**
+
+        .. code-block:: python
+
+            from pinecone import ServerlessSpec
+
+            pc.db.index.create(
+                name="my-index",
+                dimension=1536,
+                metric="cosine",
+                spec=ServerlessSpec(cloud="aws", region="us-east-1")
+            )
+
+        **New Usage (schema-based):**
+
+        .. code-block:: python
+
+            from pinecone import TextField, DenseVectorField
+
+            pc.db.index.create(
+                name="my-index",
+                schema={
+                    "title": TextField(full_text_searchable=True),
+                    "embedding": DenseVectorField(dimension=1536, metric="cosine"),
+                }
+                # deployment defaults to aws/us-east-1 if omitted
+            )
+        """
+        # Validate mutual exclusion of spec and schema
+        if spec is not None and schema is not None:
+            raise ValueError(
+                "Cannot specify both 'spec' and 'schema'. Use 'spec' for legacy index "
+                "creation or 'schema' for the new schema-based format."
+            )
+        if spec is None and schema is None:
+            raise ValueError("Either 'spec' or 'schema' must be provided.")
+
+        if schema is not None:
+            # New schema-based creation
+            req = PineconeDBControlRequestFactory.create_index_with_schema_request(
+                name=name,
+                schema=schema,
+                deployment=deployment,
+                deletion_protection=deletion_protection,
+                tags=tags,
+            )
+        else:
+            # Legacy spec-based creation
+            req = PineconeDBControlRequestFactory.create_index_request(
+                name=name,
+                spec=spec,
+                dimension=dimension,
+                metric=metric,
+                deletion_protection=deletion_protection,
+                vector_type=vector_type,
+                tags=tags,
+            )
+
         resp = self._index_api.create_index(create_index_request=req)
 
         if timeout == -1:

--- a/pinecone/pinecone.py
+++ b/pinecone/pinecone.py
@@ -55,6 +55,9 @@ if TYPE_CHECKING:
         BackupList,
         RestoreJobModel,
         RestoreJobList,
+        ServerlessDeployment,
+        PodDeployment,
+        ByocDeployment,
     )
 
 
@@ -378,13 +381,15 @@ class Pinecone(PluginAware):
     def create_index(
         self,
         name: str,
-        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec",
+        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec" | None = None,
         dimension: int | None = None,
         metric: ("Metric" | str) | None = "cosine",
         timeout: int | None = None,
         deletion_protection: ("DeletionProtection" | str) | None = "disabled",
         vector_type: ("VectorType" | str) | None = "dense",
         tags: dict[str, str] | None = None,
+        schema: dict[str, Any] | None = None,
+        deployment: ("ServerlessDeployment" | "PodDeployment" | "ByocDeployment" | None) = None,
     ) -> "IndexModel":
         """Creates a Pinecone index.
 
@@ -505,6 +510,8 @@ class Pinecone(PluginAware):
             deletion_protection=deletion_protection,
             vector_type=vector_type,
             tags=tags,
+            schema=schema,
+            deployment=deployment,
         )
 
     def create_index_for_model(

--- a/pinecone/pinecone_asyncio.py
+++ b/pinecone/pinecone_asyncio.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
         BackupList,
         RestoreJobModel,
         RestoreJobList,
+        ServerlessDeployment,
+        PodDeployment,
+        ByocDeployment,
     )
     from pinecone.db_control.models.serverless_spec import (
         ReadCapacityDict,
@@ -244,13 +247,15 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
     async def create_index(
         self,
         name: str,
-        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec",
+        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec" | None = None,
         dimension: int | None = None,
         metric: ("Metric" | str) | None = "cosine",
         timeout: int | None = None,
         deletion_protection: ("DeletionProtection" | str) | None = "disabled",
         vector_type: ("VectorType" | str) | None = "dense",
         tags: dict[str, str] | None = None,
+        schema: dict[str, Any] | None = None,
+        deployment: ("ServerlessDeployment" | "PodDeployment" | "ByocDeployment" | None) = None,
     ) -> "IndexModel":
         resp = await self.db.index.create(
             name=name,
@@ -261,6 +266,8 @@ class PineconeAsyncio(PineconeAsyncioDBControlInterface):
             vector_type=vector_type,
             tags=tags,
             timeout=timeout,
+            schema=schema,
+            deployment=deployment,
         )
         return resp
 

--- a/pinecone/pinecone_interface_asyncio.py
+++ b/pinecone/pinecone_interface_asyncio.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
         BackupList,
         RestoreJobModel,
         RestoreJobList,
+        ServerlessDeployment,
+        PodDeployment,
+        ByocDeployment,
     )
     from pinecone.db_control.enums import (
         Metric,
@@ -271,13 +274,15 @@ class PineconeAsyncioDBControlInterface(ABC):
     async def create_index(
         self,
         name: str,
-        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec",
-        dimension: int | None,
+        spec: Dict | "ServerlessSpec" | "PodSpec" | "ByocSpec" | None = None,
+        dimension: int | None = None,
         metric: ("Metric" | str) | None = "cosine",
         timeout: int | None = None,
         deletion_protection: ("DeletionProtection" | str) | None = "disabled",
         vector_type: ("VectorType" | str) | None = "dense",
         tags: dict[str, str] | None = None,
+        schema: dict[str, Any] | None = None,
+        deployment: ("ServerlessDeployment" | "PodDeployment" | "ByocDeployment" | None) = None,
     ):
         """Creates a Pinecone index.
 

--- a/tests/unit/db_control/test_index.py
+++ b/tests/unit/db_control/test_index.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 
 from pinecone.config import Config, OpenApiConfiguration
 
@@ -66,3 +67,106 @@ class TestIndexResource:
         assert desc.status.ready == True
         assert desc.deletion_protection == "disabled"
         assert desc.tags["test-tag"] == "test-value"
+
+
+class TestIndexResourceCreateValidation:
+    """Tests for create() method parameter validation."""
+
+    def test_create_requires_spec_or_schema(self, mocker):
+        """Test that create() raises error when neither spec nor schema is provided."""
+        body = (
+            """{"name": "test", "status": {"ready": true, "state": "Ready"}, "host": "test.io"}"""
+        )
+        index_resource, _ = build_client_w_faked_response(mocker, body)
+
+        with pytest.raises(ValueError, match="Either 'spec' or 'schema' must be provided"):
+            index_resource.create(name="test-index", timeout=-1)
+
+    def test_create_rejects_spec_and_schema_together(self, mocker):
+        """Test that create() raises error when both spec and schema are provided."""
+        from pinecone.db_control.models import ServerlessSpec, DenseVectorField
+
+        body = (
+            """{"name": "test", "status": {"ready": true, "state": "Ready"}, "host": "test.io"}"""
+        )
+        index_resource, _ = build_client_w_faked_response(mocker, body)
+
+        with pytest.raises(ValueError, match="Cannot specify both 'spec' and 'schema'"):
+            index_resource.create(
+                name="test-index",
+                spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+                dimension=1536,
+                schema={"embedding": DenseVectorField(dimension=1536, metric="cosine")},
+                timeout=-1,
+            )
+
+    def test_create_with_spec_uses_legacy_path(self, mocker):
+        """Test that create() with spec uses the legacy request factory method."""
+        body = """{
+            "name": "test-index",
+            "dimension": 1536,
+            "metric": "cosine",
+            "spec": {"serverless": {"cloud": "aws", "region": "us-east-1"}},
+            "status": {"ready": true, "state": "Ready"},
+            "host": "test.pinecone.io"
+        }"""
+        index_resource, mock_request = build_client_w_faked_response(mocker, body)
+
+        from pinecone.db_control.models import ServerlessSpec
+
+        result = index_resource.create(
+            name="test-index",
+            spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+            dimension=1536,
+            timeout=-1,
+        )
+
+        assert result.name == "test-index"
+        # Verify the request was made
+        assert mock_request.call_count == 1
+
+    def test_create_with_schema_uses_new_path(self, mocker):
+        """Test that create() with schema uses the new request factory method."""
+        body = """{
+            "name": "test-index",
+            "deployment": {"deployment_type": "serverless", "cloud": "aws", "region": "us-east-1"},
+            "schema": {"fields": {"embedding": {"type": "dense_vector", "dimension": 1536}}},
+            "status": {"ready": true, "state": "Ready"},
+            "host": "test.pinecone.io"
+        }"""
+        index_resource, mock_request = build_client_w_faked_response(mocker, body)
+
+        from pinecone.db_control.models import DenseVectorField
+
+        result = index_resource.create(
+            name="test-index",
+            schema={"embedding": DenseVectorField(dimension=1536, metric="cosine")},
+            timeout=-1,
+        )
+
+        assert result.name == "test-index"
+        # Verify the request was made
+        assert mock_request.call_count == 1
+
+    def test_create_with_schema_and_custom_deployment(self, mocker):
+        """Test create() with schema and custom deployment."""
+        body = """{
+            "name": "test-index",
+            "deployment": {"deployment_type": "serverless", "cloud": "gcp", "region": "us-central1"},
+            "schema": {"fields": {"embedding": {"type": "dense_vector", "dimension": 1536}}},
+            "status": {"ready": true, "state": "Ready"},
+            "host": "test.pinecone.io"
+        }"""
+        index_resource, mock_request = build_client_w_faked_response(mocker, body)
+
+        from pinecone.db_control.models import DenseVectorField, ServerlessDeployment
+
+        result = index_resource.create(
+            name="test-index",
+            schema={"embedding": DenseVectorField(dimension=1536, metric="cosine")},
+            deployment=ServerlessDeployment(cloud="gcp", region="us-central1"),
+            timeout=-1,
+        )
+
+        assert result.name == "test-index"
+        assert mock_request.call_count == 1


### PR DESCRIPTION
## Summary

This PR updates the `create_index()` method signature to accept new `schema` and `deployment` parameters for the new Full-Text Search API, while maintaining backwards compatibility with the existing `spec` parameter.

## Key Changes

- **New Parameters:**
  - `schema`: A dict mapping field names to field configurations (using field type classes like `TextField`, `DenseVectorField`)
  - `deployment`: A deployment configuration object (`ServerlessDeployment`, `PodDeployment`, or `ByocDeployment`). Defaults to `aws/us-east-1`

- **Validation:** `spec` and `schema` are mutually exclusive - using both raises an error

- **New Request Factory Methods:**
  - `create_index_with_schema_request()` - creates index requests in the new schema-based format
  - `_serialize_schema()` - helper to serialize field type objects to dicts

## Usage Examples

**Legacy Usage (spec-based):**

```python
from pinecone import ServerlessSpec

pc.create_index(
    name="my-index",
    dimension=1536,
    metric="cosine",
    spec=ServerlessSpec(cloud="aws", region="us-east-1")
)
```

**New Usage (schema-based):**

```python
from pinecone import TextField, DenseVectorField, ServerlessDeployment

pc.create_index(
    name="my-index",
    schema={
        "title": TextField(full_text_searchable=True),
        "embedding": DenseVectorField(dimension=1536, metric="cosine"),
    }
    # deployment defaults to aws/us-east-1 if omitted
)

# Or with custom deployment:
pc.create_index(
    name="my-index",
    schema={
        "content": TextField(full_text_searchable=True),
        "embedding": DenseVectorField(dimension=1536, metric="cosine"),
    },
    deployment=ServerlessDeployment(cloud="gcp", region="us-central1"),
)
```

## Files Modified

- `pinecone/db_control/request_factory.py` - Added new factory methods
- `pinecone/db_control/resources/sync/index.py` - Updated sync create() method
- `pinecone/db_control/resources/asyncio/index.py` - Updated async create() method
- `pinecone/pinecone.py` - Updated wrapper method
- `pinecone/pinecone_asyncio.py` - Updated async wrapper method
- `pinecone/pinecone_interface_asyncio.py` - Updated interface definition

## Testing

Added unit tests for:
- Parameter validation (mutual exclusion of spec/schema)
- Request routing to correct factory method
- Schema serialization with field type objects
- Schema serialization with dict format
- Custom deployment configurations

## Related

- Linear: SDK-106
- Depends on: SDK-104, SDK-105 (both merged)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new index-creation request shape and changes `create_index`/`index.create` argument validation and routing, which can affect backward compatibility and request payloads. Risk is mitigated by keeping the legacy `spec` path and adding targeted unit tests.
> 
> **Overview**
> Adds support for the new schema-based index creation API by extending `create_index`/`index.create` (sync + asyncio) to accept `schema` and optional `deployment`, while making `spec` optional and enforcing *exactly one of* `spec` or `schema`.
> 
> Introduces `PineconeDBControlRequestFactory.create_index_with_schema_request()` plus `_serialize_schema()` to build the new `CreateIndexRequest` payload (defaulting deployment to serverless `aws/us-east-1` and serializing field objects via `to_dict`). Updates the top-level `Pinecone`/`PineconeAsyncio` wrappers and asyncio interface signatures accordingly, and adds unit tests covering validation, routing, deployment defaults/customization, and schema serialization error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e11730004e7ff15bdaaf739c8e7d9b66ed6f6ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->