### PR TITLE
feat: Add query factory functions (text_query, vector_query)

### DIFF
--- a/pinecone/__init__.py
+++ b/pinecone/__init__.py
@@ -47,6 +47,9 @@ _db_data_lazy_imports = {
     "SearchRerank": ("pinecone.db_data.dataclasses", "SearchRerank"),
     "TextQuery": ("pinecone.db_data.dataclasses", "TextQuery"),
     "VectorQuery": ("pinecone.db_data.dataclasses", "VectorQuery"),
+    # Factory functions for query objects
+    "text_query": ("pinecone.db_data.query_helpers", "text_query"),
+    "vector_query": ("pinecone.db_data.query_helpers", "vector_query"),
     "FetchResponse": ("pinecone.db_data.dataclasses", "FetchResponse"),
     "FetchByMetadataResponse": ("pinecone.db_data.dataclasses", "FetchByMetadataResponse"),
     "DeleteRequest": ("pinecone.db_data.models", "DeleteRequest"),

--- a/pinecone/db_data/query_helpers.py
+++ b/pinecone/db_data/query_helpers.py
@@ -1,0 +1,94 @@
+"""Factory functions for creating query objects.
+
+These functions provide a simpler API for constructing query objects
+to use with ``search_documents()``.
+"""
+
+from __future__ import annotations
+
+from .dataclasses import TextQuery, VectorQuery, SparseValues
+
+
+def text_query(
+    field: str, query: str, boost: float | None = None, slop: int | None = None
+) -> TextQuery:
+    """Create a text query for full-text search.
+
+    Factory function that creates a :class:`~pinecone.TextQuery` object
+    for use with ``search_documents()``.
+
+    :param field: The name of the field to search.
+    :param query: The search query string. Supports:
+
+        - Simple terms: ``"pink panther"``
+        - Phrase matching: ``'"pink panther"'`` (quotes in string)
+        - Required terms: ``"+return +panther"``
+
+    :param boost: Optional boost factor for this query's score contribution.
+    :param slop: Optional slop parameter for phrase queries, controlling
+        how many positions apart terms can be.
+    :returns: A TextQuery object.
+
+    Example usage::
+
+        from pinecone import text_query
+
+        # Simple text search
+        results = index.search_documents(
+            namespace="movies",
+            score_by=text_query("title", "pink panther"),
+            top_k=10,
+        )
+
+        # Phrase match with quotes
+        results = index.search_documents(
+            namespace="movies",
+            score_by=text_query("title", '"pink panther"'),
+            top_k=10,
+        )
+
+        # With boost and slop
+        results = index.search_documents(
+            namespace="movies",
+            score_by=text_query("title", '"pink panther"', boost=3.0, slop=2),
+            top_k=10,
+        )
+    """
+    return TextQuery(field=field, query=query, boost=boost, slop=slop)
+
+
+def vector_query(
+    field: str, values: list[float] | None = None, sparse_values: SparseValues | None = None
+) -> VectorQuery:
+    """Create a vector query for similarity search.
+
+    Factory function that creates a :class:`~pinecone.VectorQuery` object
+    for use with ``search_documents()``.
+
+    :param field: The name of the vector field to search.
+    :param values: Dense vector values for similarity search.
+    :param sparse_values: Sparse vector values for hybrid search.
+    :returns: A VectorQuery object.
+
+    Example usage::
+
+        from pinecone import vector_query, SparseValues
+
+        # Dense vector search
+        results = index.search_documents(
+            namespace="movies",
+            score_by=vector_query("embedding", values=[0.1, 0.2, 0.3]),
+            top_k=10,
+        )
+
+        # Sparse vector search
+        results = index.search_documents(
+            namespace="movies",
+            score_by=vector_query(
+                "sparse_embedding",
+                sparse_values=SparseValues(indices=[1, 5, 10], values=[0.5, 0.3, 0.2]),
+            ),
+            top_k=10,
+        )
+    """
+    return VectorQuery(field=field, values=values, sparse_values=sparse_values)

--- a/tests/unit/data/test_query_helpers.py
+++ b/tests/unit/data/test_query_helpers.py
@@ -1,0 +1,139 @@
+"""Tests for query factory functions."""
+
+from pinecone.db_data.query_helpers import text_query, vector_query
+from pinecone.db_data.dataclasses import TextQuery, VectorQuery, SparseValues
+
+
+class TestTextQueryFactory:
+    """Tests for the text_query factory function."""
+
+    def test_required_params(self):
+        """Factory creates TextQuery with required parameters."""
+        result = text_query(field="title", query="pink panther")
+        assert isinstance(result, TextQuery)
+        assert result.field == "title"
+        assert result.query == "pink panther"
+        assert result.boost is None
+        assert result.slop is None
+
+    def test_with_boost(self):
+        """Factory creates TextQuery with boost parameter."""
+        result = text_query(field="title", query="pink panther", boost=2.5)
+        assert isinstance(result, TextQuery)
+        assert result.field == "title"
+        assert result.query == "pink panther"
+        assert result.boost == 2.5
+        assert result.slop is None
+
+    def test_with_slop(self):
+        """Factory creates TextQuery with slop parameter."""
+        result = text_query(field="title", query="pink panther", slop=3)
+        assert isinstance(result, TextQuery)
+        assert result.field == "title"
+        assert result.query == "pink panther"
+        assert result.boost is None
+        assert result.slop == 3
+
+    def test_with_all_options(self):
+        """Factory creates TextQuery with all optional parameters."""
+        result = text_query(field="title", query="pink panther", boost=1.5, slop=2)
+        assert isinstance(result, TextQuery)
+        assert result.field == "title"
+        assert result.query == "pink panther"
+        assert result.boost == 1.5
+        assert result.slop == 2
+
+    def test_phrase_query(self):
+        """Factory handles phrase queries with quotes."""
+        result = text_query(field="title", query='"pink panther"')
+        assert result.query == '"pink panther"'
+
+    def test_required_terms_query(self):
+        """Factory handles required term syntax."""
+        result = text_query(field="title", query="+return +panther")
+        assert result.query == "+return +panther"
+
+    def test_as_dict_output(self):
+        """Factory result produces correct as_dict output."""
+        result = text_query(field="title", query="test", boost=2.0, slop=1)
+        as_dict = result.as_dict()
+        assert as_dict == {
+            "type": "text",
+            "field": "title",
+            "text_query": "test",
+            "boost": 2.0,
+            "slop": 1,
+        }
+
+
+class TestVectorQueryFactory:
+    """Tests for the vector_query factory function."""
+
+    def test_required_params(self):
+        """Factory creates VectorQuery with required parameters only."""
+        result = vector_query(field="embedding")
+        assert isinstance(result, VectorQuery)
+        assert result.field == "embedding"
+        assert result.values is None
+        assert result.sparse_values is None
+
+    def test_with_dense_values(self):
+        """Factory creates VectorQuery with dense values."""
+        result = vector_query(field="embedding", values=[0.1, 0.2, 0.3])
+        assert isinstance(result, VectorQuery)
+        assert result.field == "embedding"
+        assert result.values == [0.1, 0.2, 0.3]
+        assert result.sparse_values is None
+
+    def test_with_sparse_values(self):
+        """Factory creates VectorQuery with sparse values."""
+        sparse = SparseValues(indices=[1, 5, 10], values=[0.5, 0.3, 0.2])
+        result = vector_query(field="sparse_embedding", sparse_values=sparse)
+        assert isinstance(result, VectorQuery)
+        assert result.field == "sparse_embedding"
+        assert result.values is None
+        assert result.sparse_values is sparse
+
+    def test_with_both_values(self):
+        """Factory creates VectorQuery with both dense and sparse values."""
+        sparse = SparseValues(indices=[1, 2], values=[0.5, 0.5])
+        result = vector_query(field="hybrid", values=[0.1, 0.2, 0.3], sparse_values=sparse)
+        assert isinstance(result, VectorQuery)
+        assert result.field == "hybrid"
+        assert result.values == [0.1, 0.2, 0.3]
+        assert result.sparse_values is sparse
+
+    def test_as_dict_output_dense(self):
+        """Factory result produces correct as_dict output for dense vectors."""
+        result = vector_query(field="embedding", values=[0.1, 0.2, 0.3])
+        as_dict = result.as_dict()
+        assert as_dict == {"type": "vector", "field": "embedding", "values": [0.1, 0.2, 0.3]}
+
+    def test_as_dict_output_sparse(self):
+        """Factory result produces correct as_dict output for sparse vectors."""
+        sparse = SparseValues(indices=[1, 5, 10], values=[0.5, 0.3, 0.2])
+        result = vector_query(field="sparse", sparse_values=sparse)
+        as_dict = result.as_dict()
+        assert as_dict == {
+            "type": "vector",
+            "field": "sparse",
+            "sparse_values": {"indices": [1, 5, 10], "values": [0.5, 0.3, 0.2]},
+        }
+
+
+class TestFactoryTopLevelExports:
+    """Tests that factory functions are exported from pinecone package."""
+
+    def test_text_query_importable(self):
+        """text_query is importable from pinecone package."""
+        from pinecone import text_query as imported_text_query
+
+        result = imported_text_query(field="test", query="query")
+        assert isinstance(result, TextQuery)
+
+    def test_vector_query_importable(self):
+        """vector_query is importable from pinecone package."""
+        from pinecone import vector_query as imported_vector_query
+
+        result = imported_vector_query(field="test")
+        assert isinstance(result, VectorQuery)


### PR DESCRIPTION
## Summary

Adds `text_query()` and `vector_query()` factory functions that provide a simpler, more ergonomic API for constructing query objects to use with `search_documents()`.

## Problem

Users need to import and instantiate `TextQuery` and `VectorQuery` classes directly, which is verbose for simple use cases.

## Solution

Added two factory functions that wrap the dataclass constructors:

- `text_query(field, query, boost=None, slop=None)` - Creates a `TextQuery` for full-text search
- `vector_query(field, values=None, sparse_values=None)` - Creates a `VectorQuery` for similarity search

Both functions are exported from the `pinecone` package for convenient imports.

## Usage Examples

```python
from pinecone import text_query, vector_query, SparseValues

# Simple text search
results = index.search_documents(
    namespace="movies",
    score_by=text_query("title", "pink panther"),
    top_k=10,
)

# Phrase match with quotes
results = index.search_documents(
    namespace="movies",
    score_by=text_query("title", '"pink panther"'),
    top_k=10,
)

# With boost and slop
results = index.search_documents(
    namespace="movies",
    score_by=text_query("title", '"pink panther"', boost=3.0, slop=2),
    top_k=10,
)

# Dense vector search
results = index.search_documents(
    namespace="movies",
    score_by=vector_query("embedding", values=[0.1, 0.2, 0.3]),
    top_k=10,
)

# Sparse vector search
results = index.search_documents(
    namespace="movies",
    score_by=vector_query(
        "sparse_embedding",
        sparse_values=SparseValues(indices=[1, 5, 10], values=[0.5, 0.3, 0.2]),
    ),
    top_k=10,
)
```

## Related Issues

- Linear: [SDK-109](https://linear.app/pinecone-io/issue/SDK-109/query-factory-functions-text-query-vector-query)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds thin wrapper factory functions and exposes them via top-level lazy imports, with unit coverage; main impact is expanded public API surface and import/export behavior.
> 
> **Overview**
> Adds new factory helpers `text_query()` and `vector_query()` (in `pinecone/db_data/query_helpers.py`) to simplify constructing `TextQuery`/`VectorQuery` objects for `search_documents()`.
> 
> Exports these helpers from the top-level `pinecone` package via the existing lazy-import mechanism, and adds unit tests validating parameter handling and `.as_dict()` serialization plus top-level importability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dd026150949965eea89546a3d475f9d2da27c19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->