### PR TITLE
fix: regenerate OpenAPI clients with TYPE_CHECKING imports for mypy

### DIFF
--- a/pinecone/core/openapi/admin/api/api_keys_api.py
+++ b/pinecone/core/openapi/admin/api/api_keys_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -95,7 +95,9 @@ class APIKeysApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
             kwargs["create_api_key_request"] = create_api_key_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                APIKeyWithSecret | ApplyResult[APIKeyWithSecret], self.call_with_http_info(**kwargs)
+            )
 
         self.create_api_key = _Endpoint(
             settings={
@@ -182,7 +184,7 @@ class APIKeysApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["api_key_id"] = api_key_id
-            return self.call_with_http_info(**kwargs)
+            return cast(None, self.call_with_http_info(**kwargs))
 
         self.delete_api_key = _Endpoint(
             settings={
@@ -261,7 +263,7 @@ class APIKeysApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["api_key_id"] = api_key_id
-            return self.call_with_http_info(**kwargs)
+            return cast(APIKey | ApplyResult[APIKey], self.call_with_http_info(**kwargs))
 
         self.fetch_api_key = _Endpoint(
             settings={
@@ -340,7 +342,10 @@ class APIKeysApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                ListApiKeysResponse | ApplyResult[ListApiKeysResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.list_project_api_keys = _Endpoint(
             settings={
@@ -422,7 +427,7 @@ class APIKeysApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["api_key_id"] = api_key_id
             kwargs["update_api_key_request"] = update_api_key_request
-            return self.call_with_http_info(**kwargs)
+            return cast(APIKey | ApplyResult[APIKey], self.call_with_http_info(**kwargs))
 
         self.update_api_key = _Endpoint(
             settings={
@@ -513,7 +518,7 @@ class AsyncioAPIKeysApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
             kwargs["create_api_key_request"] = create_api_key_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(APIKeyWithSecret, await self.call_with_http_info(**kwargs))
 
         self.create_api_key = _AsyncioEndpoint(
             settings={
@@ -590,7 +595,7 @@ class AsyncioAPIKeysApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["api_key_id"] = api_key_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(None, await self.call_with_http_info(**kwargs))
 
         self.delete_api_key = _AsyncioEndpoint(
             settings={
@@ -659,7 +664,7 @@ class AsyncioAPIKeysApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["api_key_id"] = api_key_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(APIKey, await self.call_with_http_info(**kwargs))
 
         self.fetch_api_key = _AsyncioEndpoint(
             settings={
@@ -728,7 +733,7 @@ class AsyncioAPIKeysApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(ListApiKeysResponse, await self.call_with_http_info(**kwargs))
 
         self.list_project_api_keys = _AsyncioEndpoint(
             settings={
@@ -799,7 +804,7 @@ class AsyncioAPIKeysApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["api_key_id"] = api_key_id
             kwargs["update_api_key_request"] = update_api_key_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(APIKey, await self.call_with_http_info(**kwargs))
 
         self.update_api_key = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/admin/api/organizations_api.py
+++ b/pinecone/core/openapi/admin/api/organizations_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -90,7 +90,7 @@ class OrganizationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["organization_id"] = organization_id
-            return self.call_with_http_info(**kwargs)
+            return cast(None, self.call_with_http_info(**kwargs))
 
         self.delete_organization = _Endpoint(
             settings={
@@ -169,7 +169,9 @@ class OrganizationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["organization_id"] = organization_id
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                Organization | ApplyResult[Organization], self.call_with_http_info(**kwargs)
+            )
 
         self.fetch_organization = _Endpoint(
             settings={
@@ -243,7 +245,9 @@ class OrganizationsApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                OrganizationList | ApplyResult[OrganizationList], self.call_with_http_info(**kwargs)
+            )
 
         self.list_organizations = _Endpoint(
             settings={
@@ -322,7 +326,9 @@ class OrganizationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["organization_id"] = organization_id
             kwargs["update_organization_request"] = update_organization_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                Organization | ApplyResult[Organization], self.call_with_http_info(**kwargs)
+            )
 
         self.update_organization = _Endpoint(
             settings={
@@ -415,7 +421,7 @@ class AsyncioOrganizationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["organization_id"] = organization_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(None, await self.call_with_http_info(**kwargs))
 
         self.delete_organization = _AsyncioEndpoint(
             settings={
@@ -484,7 +490,7 @@ class AsyncioOrganizationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["organization_id"] = organization_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(Organization, await self.call_with_http_info(**kwargs))
 
         self.fetch_organization = _AsyncioEndpoint(
             settings={
@@ -551,7 +557,7 @@ class AsyncioOrganizationsApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(OrganizationList, await self.call_with_http_info(**kwargs))
 
         self.list_organizations = _AsyncioEndpoint(
             settings={
@@ -623,7 +629,7 @@ class AsyncioOrganizationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["organization_id"] = organization_id
             kwargs["update_organization_request"] = update_organization_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(Organization, await self.call_with_http_info(**kwargs))
 
         self.update_organization = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/admin/api/projects_api.py
+++ b/pinecone/core/openapi/admin/api/projects_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -91,7 +91,7 @@ class ProjectsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_project_request"] = create_project_request
-            return self.call_with_http_info(**kwargs)
+            return cast(Project | ApplyResult[Project], self.call_with_http_info(**kwargs))
 
         self.create_project = _Endpoint(
             settings={
@@ -173,7 +173,7 @@ class ProjectsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
-            return self.call_with_http_info(**kwargs)
+            return cast(None, self.call_with_http_info(**kwargs))
 
         self.delete_project = _Endpoint(
             settings={
@@ -252,7 +252,7 @@ class ProjectsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
-            return self.call_with_http_info(**kwargs)
+            return cast(Project | ApplyResult[Project], self.call_with_http_info(**kwargs))
 
         self.fetch_project = _Endpoint(
             settings={
@@ -326,7 +326,7 @@ class ProjectsApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(ProjectList | ApplyResult[ProjectList], self.call_with_http_info(**kwargs))
 
         self.list_projects = _Endpoint(
             settings={
@@ -405,7 +405,7 @@ class ProjectsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
             kwargs["update_project_request"] = update_project_request
-            return self.call_with_http_info(**kwargs)
+            return cast(Project | ApplyResult[Project], self.call_with_http_info(**kwargs))
 
         self.update_project = _Endpoint(
             settings={
@@ -494,7 +494,7 @@ class AsyncioProjectsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_project_request"] = create_project_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(Project, await self.call_with_http_info(**kwargs))
 
         self.create_project = _AsyncioEndpoint(
             settings={
@@ -566,7 +566,7 @@ class AsyncioProjectsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(None, await self.call_with_http_info(**kwargs))
 
         self.delete_project = _AsyncioEndpoint(
             settings={
@@ -635,7 +635,7 @@ class AsyncioProjectsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(Project, await self.call_with_http_info(**kwargs))
 
         self.fetch_project = _AsyncioEndpoint(
             settings={
@@ -700,7 +700,7 @@ class AsyncioProjectsApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(ProjectList, await self.call_with_http_info(**kwargs))
 
         self.list_projects = _AsyncioEndpoint(
             settings={
@@ -768,7 +768,7 @@ class AsyncioProjectsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["project_id"] = project_id
             kwargs["update_project_request"] = update_project_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(Project, await self.call_with_http_info(**kwargs))
 
         self.update_project = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/admin/model/api_key_with_secret.py
+++ b/pinecone/core/openapi/admin/model/api_key_with_secret.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.admin.model.api_key import APIKey
+
 
 def lazy_import():
     from pinecone.core.openapi.admin.model.api_key import APIKey

--- a/pinecone/core/openapi/admin/model/error_response.py
+++ b/pinecone/core/openapi/admin/model/error_response.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.admin.model.error_response_error import ErrorResponseError
+
 
 def lazy_import():
     from pinecone.core.openapi.admin.model.error_response_error import ErrorResponseError

--- a/pinecone/core/openapi/admin/model/list_api_keys_response.py
+++ b/pinecone/core/openapi/admin/model/list_api_keys_response.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.admin.model.api_key import APIKey
+
 
 def lazy_import():
     from pinecone.core.openapi.admin.model.api_key import APIKey

--- a/pinecone/core/openapi/admin/model/organization_list.py
+++ b/pinecone/core/openapi/admin/model/organization_list.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.admin.model.organization import Organization
+
 
 def lazy_import():
     from pinecone.core.openapi.admin.model.organization import Organization

--- a/pinecone/core/openapi/admin/model/project_list.py
+++ b/pinecone/core/openapi/admin/model/project_list.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.admin.model.project import Project
+
 
 def lazy_import():
     from pinecone.core.openapi.admin.model.project import Project

--- a/pinecone/core/openapi/db_control/api/manage_indexes_api.py
+++ b/pinecone/core/openapi/db_control/api/manage_indexes_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -111,7 +111,7 @@ class ManageIndexesApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
             kwargs["configure_index_request"] = configure_index_request
-            return self.call_with_http_info(**kwargs)
+            return cast(IndexModel | ApplyResult[IndexModel], self.call_with_http_info(**kwargs))
 
         self.configure_index = _Endpoint(
             settings={
@@ -201,7 +201,7 @@ class ManageIndexesApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
             kwargs["create_backup_request"] = create_backup_request
-            return self.call_with_http_info(**kwargs)
+            return cast(BackupModel | ApplyResult[BackupModel], self.call_with_http_info(**kwargs))
 
         self.create_backup = _Endpoint(
             settings={
@@ -288,7 +288,9 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_collection_request"] = create_collection_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                CollectionModel | ApplyResult[CollectionModel], self.call_with_http_info(**kwargs)
+            )
 
         self.create_collection = _Endpoint(
             settings={
@@ -370,7 +372,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_index_request"] = create_index_request
-            return self.call_with_http_info(**kwargs)
+            return cast(IndexModel | ApplyResult[IndexModel], self.call_with_http_info(**kwargs))
 
         self.create_index = _Endpoint(
             settings={
@@ -452,7 +454,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_index_for_model_request"] = create_index_for_model_request
-            return self.call_with_http_info(**kwargs)
+            return cast(IndexModel | ApplyResult[IndexModel], self.call_with_http_info(**kwargs))
 
         self.create_index_for_model = _Endpoint(
             settings={
@@ -537,7 +539,10 @@ class ManageIndexesApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["backup_id"] = backup_id
             kwargs["create_index_from_backup_request"] = create_index_from_backup_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                CreateIndexFromBackupResponse | ApplyResult[CreateIndexFromBackupResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.create_index_from_backup_operation = _Endpoint(
             settings={
@@ -628,7 +633,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["backup_id"] = backup_id
-            return self.call_with_http_info(**kwargs)
+            return cast(None, self.call_with_http_info(**kwargs))
 
         self.delete_backup = _Endpoint(
             settings={
@@ -707,7 +712,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["collection_name"] = collection_name
-            return self.call_with_http_info(**kwargs)
+            return cast(None, self.call_with_http_info(**kwargs))
 
         self.delete_collection = _Endpoint(
             settings={
@@ -786,7 +791,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
-            return self.call_with_http_info(**kwargs)
+            return cast(None, self.call_with_http_info(**kwargs))
 
         self.delete_index = _Endpoint(
             settings={
@@ -865,7 +870,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["backup_id"] = backup_id
-            return self.call_with_http_info(**kwargs)
+            return cast(BackupModel | ApplyResult[BackupModel], self.call_with_http_info(**kwargs))
 
         self.describe_backup = _Endpoint(
             settings={
@@ -944,7 +949,9 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["collection_name"] = collection_name
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                CollectionModel | ApplyResult[CollectionModel], self.call_with_http_info(**kwargs)
+            )
 
         self.describe_collection = _Endpoint(
             settings={
@@ -1023,7 +1030,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
-            return self.call_with_http_info(**kwargs)
+            return cast(IndexModel | ApplyResult[IndexModel], self.call_with_http_info(**kwargs))
 
         self.describe_index = _Endpoint(
             settings={
@@ -1102,7 +1109,9 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["job_id"] = job_id
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                RestoreJobModel | ApplyResult[RestoreJobModel], self.call_with_http_info(**kwargs)
+            )
 
         self.describe_restore_job = _Endpoint(
             settings={
@@ -1176,7 +1185,9 @@ class ManageIndexesApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                CollectionList | ApplyResult[CollectionList], self.call_with_http_info(**kwargs)
+            )
 
         self.list_collections = _Endpoint(
             settings={
@@ -1254,7 +1265,7 @@ class ManageIndexesApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
-            return self.call_with_http_info(**kwargs)
+            return cast(BackupList | ApplyResult[BackupList], self.call_with_http_info(**kwargs))
 
         self.list_index_backups = _Endpoint(
             settings={
@@ -1340,7 +1351,7 @@ class ManageIndexesApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(IndexList | ApplyResult[IndexList], self.call_with_http_info(**kwargs))
 
         self.list_indexes = _Endpoint(
             settings={
@@ -1413,7 +1424,7 @@ class ManageIndexesApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(BackupList | ApplyResult[BackupList], self.call_with_http_info(**kwargs))
 
         self.list_project_backups = _Endpoint(
             settings={
@@ -1498,7 +1509,9 @@ class ManageIndexesApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                RestoreJobList | ApplyResult[RestoreJobList], self.call_with_http_info(**kwargs)
+            )
 
         self.list_restore_jobs = _Endpoint(
             settings={
@@ -1594,7 +1607,7 @@ class AsyncioManageIndexesApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
             kwargs["configure_index_request"] = configure_index_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(IndexModel, await self.call_with_http_info(**kwargs))
 
         self.configure_index = _AsyncioEndpoint(
             settings={
@@ -1677,7 +1690,7 @@ class AsyncioManageIndexesApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
             kwargs["create_backup_request"] = create_backup_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(BackupModel, await self.call_with_http_info(**kwargs))
 
         self.create_backup = _AsyncioEndpoint(
             settings={
@@ -1754,7 +1767,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_collection_request"] = create_collection_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(CollectionModel, await self.call_with_http_info(**kwargs))
 
         self.create_collection = _AsyncioEndpoint(
             settings={
@@ -1826,7 +1839,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_index_request"] = create_index_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(IndexModel, await self.call_with_http_info(**kwargs))
 
         self.create_index = _AsyncioEndpoint(
             settings={
@@ -1898,7 +1911,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_index_for_model_request"] = create_index_for_model_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(IndexModel, await self.call_with_http_info(**kwargs))
 
         self.create_index_for_model = _AsyncioEndpoint(
             settings={
@@ -1976,7 +1989,7 @@ class AsyncioManageIndexesApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["backup_id"] = backup_id
             kwargs["create_index_from_backup_request"] = create_index_from_backup_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(CreateIndexFromBackupResponse, await self.call_with_http_info(**kwargs))
 
         self.create_index_from_backup_operation = _AsyncioEndpoint(
             settings={
@@ -2057,7 +2070,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["backup_id"] = backup_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(None, await self.call_with_http_info(**kwargs))
 
         self.delete_backup = _AsyncioEndpoint(
             settings={
@@ -2126,7 +2139,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["collection_name"] = collection_name
-            return await self.call_with_http_info(**kwargs)
+            return cast(None, await self.call_with_http_info(**kwargs))
 
         self.delete_collection = _AsyncioEndpoint(
             settings={
@@ -2195,7 +2208,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
-            return await self.call_with_http_info(**kwargs)
+            return cast(None, await self.call_with_http_info(**kwargs))
 
         self.delete_index = _AsyncioEndpoint(
             settings={
@@ -2264,7 +2277,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["backup_id"] = backup_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(BackupModel, await self.call_with_http_info(**kwargs))
 
         self.describe_backup = _AsyncioEndpoint(
             settings={
@@ -2333,7 +2346,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["collection_name"] = collection_name
-            return await self.call_with_http_info(**kwargs)
+            return cast(CollectionModel, await self.call_with_http_info(**kwargs))
 
         self.describe_collection = _AsyncioEndpoint(
             settings={
@@ -2402,7 +2415,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
-            return await self.call_with_http_info(**kwargs)
+            return cast(IndexModel, await self.call_with_http_info(**kwargs))
 
         self.describe_index = _AsyncioEndpoint(
             settings={
@@ -2471,7 +2484,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["job_id"] = job_id
-            return await self.call_with_http_info(**kwargs)
+            return cast(RestoreJobModel, await self.call_with_http_info(**kwargs))
 
         self.describe_restore_job = _AsyncioEndpoint(
             settings={
@@ -2538,7 +2551,7 @@ class AsyncioManageIndexesApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(CollectionList, await self.call_with_http_info(**kwargs))
 
         self.list_collections = _AsyncioEndpoint(
             settings={
@@ -2606,7 +2619,7 @@ class AsyncioManageIndexesApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["index_name"] = index_name
-            return await self.call_with_http_info(**kwargs)
+            return cast(BackupList, await self.call_with_http_info(**kwargs))
 
         self.list_index_backups = _AsyncioEndpoint(
             settings={
@@ -2685,7 +2698,7 @@ class AsyncioManageIndexesApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(IndexList, await self.call_with_http_info(**kwargs))
 
         self.list_indexes = _AsyncioEndpoint(
             settings={
@@ -2751,7 +2764,7 @@ class AsyncioManageIndexesApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(BackupList, await self.call_with_http_info(**kwargs))
 
         self.list_project_backups = _AsyncioEndpoint(
             settings={
@@ -2829,7 +2842,7 @@ class AsyncioManageIndexesApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(RestoreJobList, await self.call_with_http_info(**kwargs))
 
         self.list_restore_jobs = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/db_control/model/backup_list.py
+++ b/pinecone/core/openapi/db_control/model/backup_list.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.backup_model import BackupModel
+    from pinecone.core.openapi.db_control.model.pagination_response import PaginationResponse
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.backup_model import BackupModel

--- a/pinecone/core/openapi/db_control/model/backup_model.py
+++ b/pinecone/core/openapi/db_control/model/backup_model.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.index_tags import IndexTags
+    from pinecone.core.openapi.db_control.model.schema import Schema
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.index_tags import IndexTags

--- a/pinecone/core/openapi/db_control/model/collection_list.py
+++ b/pinecone/core/openapi/db_control/model/collection_list.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.collection_model import CollectionModel
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.collection_model import CollectionModel

--- a/pinecone/core/openapi/db_control/model/configure_index_request.py
+++ b/pinecone/core/openapi/db_control/model/configure_index_request.py
@@ -26,6 +26,14 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.deployment import Deployment
+    from pinecone.core.openapi.db_control.model.index_tags import IndexTags
+    from pinecone.core.openapi.db_control.model.read_capacity import ReadCapacity
+    from pinecone.core.openapi.db_control.model.schema import Schema
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.deployment import Deployment

--- a/pinecone/core/openapi/db_control/model/create_index_for_model_request.py
+++ b/pinecone/core/openapi/db_control/model/create_index_for_model_request.py
@@ -26,6 +26,16 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.create_index_for_model_request_embed import (
+        CreateIndexForModelRequestEmbed,
+    )
+    from pinecone.core.openapi.db_control.model.index_tags import IndexTags
+    from pinecone.core.openapi.db_control.model.read_capacity import ReadCapacity
+    from pinecone.core.openapi.db_control.model.schema import Schema
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.create_index_for_model_request_embed import (

--- a/pinecone/core/openapi/db_control/model/create_index_from_backup_request.py
+++ b/pinecone/core/openapi/db_control/model/create_index_from_backup_request.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.index_tags import IndexTags
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.index_tags import IndexTags

--- a/pinecone/core/openapi/db_control/model/create_index_request.py
+++ b/pinecone/core/openapi/db_control/model/create_index_request.py
@@ -26,6 +26,14 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.deployment import Deployment
+    from pinecone.core.openapi.db_control.model.index_tags import IndexTags
+    from pinecone.core.openapi.db_control.model.read_capacity import ReadCapacity
+    from pinecone.core.openapi.db_control.model.schema import Schema
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.deployment import Deployment

--- a/pinecone/core/openapi/db_control/model/deployment.py
+++ b/pinecone/core/openapi/db_control/model/deployment.py
@@ -26,6 +26,16 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.byoc_deployment import ByocDeployment
+    from pinecone.core.openapi.db_control.model.pod_deployment import PodDeployment
+    from pinecone.core.openapi.db_control.model.pod_deployment_metadata_config import (
+        PodDeploymentMetadataConfig,
+    )
+    from pinecone.core.openapi.db_control.model.serverless_deployment import ServerlessDeployment
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.byoc_deployment import ByocDeployment
@@ -361,7 +371,7 @@ class Deployment(ModelComposed):
                 )
 
     @cached_property
-    def _composed_schemas():  # type: ignore
+    def _composed_schemas():
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class

--- a/pinecone/core/openapi/db_control/model/error_response.py
+++ b/pinecone/core/openapi/db_control/model/error_response.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.error_response_error import ErrorResponseError
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.error_response_error import ErrorResponseError

--- a/pinecone/core/openapi/db_control/model/index_list.py
+++ b/pinecone/core/openapi/db_control/model/index_list.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.index_model import IndexModel
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.index_model import IndexModel

--- a/pinecone/core/openapi/db_control/model/index_model.py
+++ b/pinecone/core/openapi/db_control/model/index_model.py
@@ -26,6 +26,15 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.deployment import Deployment
+    from pinecone.core.openapi.db_control.model.index_model_status import IndexModelStatus
+    from pinecone.core.openapi.db_control.model.index_tags import IndexTags
+    from pinecone.core.openapi.db_control.model.read_capacity_response import ReadCapacityResponse
+    from pinecone.core.openapi.db_control.model.schema import Schema
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.deployment import Deployment

--- a/pinecone/core/openapi/db_control/model/pod_deployment.py
+++ b/pinecone/core/openapi/db_control/model/pod_deployment.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.pod_deployment_metadata_config import (
+        PodDeploymentMetadataConfig,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.pod_deployment_metadata_config import (

--- a/pinecone/core/openapi/db_control/model/read_capacity.py
+++ b/pinecone/core/openapi/db_control/model/read_capacity.py
@@ -26,6 +26,19 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec import (
+        ReadCapacityDedicatedSpec,
+    )
+    from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response_scaling import (
+        ReadCapacityDedicatedSpecResponseScaling,
+    )
+    from pinecone.core.openapi.db_control.model.read_capacity_on_demand_spec import (
+        ReadCapacityOnDemandSpec,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec import (
@@ -329,7 +342,7 @@ class ReadCapacity(ModelComposed):
                 )
 
     @cached_property
-    def _composed_schemas():  # type: ignore
+    def _composed_schemas():
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class

--- a/pinecone/core/openapi/db_control/model/read_capacity_dedicated_spec.py
+++ b/pinecone/core/openapi/db_control/model/read_capacity_dedicated_spec.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response_scaling import (
+        ReadCapacityDedicatedSpecResponseScaling,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response_scaling import (

--- a/pinecone/core/openapi/db_control/model/read_capacity_dedicated_spec_response.py
+++ b/pinecone/core/openapi/db_control/model/read_capacity_dedicated_spec_response.py
@@ -26,6 +26,14 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response_scaling import (
+        ReadCapacityDedicatedSpecResponseScaling,
+    )
+    from pinecone.core.openapi.db_control.model.read_capacity_status import ReadCapacityStatus
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response_scaling import (

--- a/pinecone/core/openapi/db_control/model/read_capacity_on_demand_spec_response.py
+++ b/pinecone/core/openapi/db_control/model/read_capacity_on_demand_spec_response.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.read_capacity_status import ReadCapacityStatus
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.read_capacity_status import ReadCapacityStatus

--- a/pinecone/core/openapi/db_control/model/read_capacity_response.py
+++ b/pinecone/core/openapi/db_control/model/read_capacity_response.py
@@ -26,6 +26,20 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response import (
+        ReadCapacityDedicatedSpecResponse,
+    )
+    from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response_scaling import (
+        ReadCapacityDedicatedSpecResponseScaling,
+    )
+    from pinecone.core.openapi.db_control.model.read_capacity_on_demand_spec_response import (
+        ReadCapacityOnDemandSpecResponse,
+    )
+    from pinecone.core.openapi.db_control.model.read_capacity_status import ReadCapacityStatus
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.read_capacity_dedicated_spec_response import (
@@ -335,7 +349,7 @@ class ReadCapacityResponse(ModelComposed):
                 )
 
     @cached_property
-    def _composed_schemas():  # type: ignore
+    def _composed_schemas():
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class

--- a/pinecone/core/openapi/db_control/model/restore_job_list.py
+++ b/pinecone/core/openapi/db_control/model/restore_job_list.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.pagination_response import PaginationResponse
+    from pinecone.core.openapi.db_control.model.restore_job_model import RestoreJobModel
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.pagination_response import PaginationResponse

--- a/pinecone/core/openapi/db_control/model/schema.py
+++ b/pinecone/core/openapi/db_control/model/schema.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_control.model.schema_fields import SchemaFields
+
 
 def lazy_import():
     from pinecone.core.openapi.db_control.model.schema_fields import SchemaFields

--- a/pinecone/core/openapi/db_data/api/bulk_operations_api.py
+++ b/pinecone/core/openapi/db_data/api/bulk_operations_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -88,7 +88,9 @@ class BulkOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["id"] = id
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                Dict[str, Any] | ApplyResult[Dict[str, Any]], self.call_with_http_info(**kwargs)
+            )
 
         self.cancel_bulk_import = _Endpoint(
             settings={
@@ -161,7 +163,7 @@ class BulkOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["id"] = id
-            return self.call_with_http_info(**kwargs)
+            return cast(ImportModel | ApplyResult[ImportModel], self.call_with_http_info(**kwargs))
 
         self.describe_bulk_import = _Endpoint(
             settings={
@@ -234,7 +236,10 @@ class BulkOperationsApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                ListImportsResponse | ApplyResult[ListImportsResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.list_bulk_imports = _Endpoint(
             settings={
@@ -322,7 +327,10 @@ class BulkOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["start_import_request"] = start_import_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                StartImportResponse | ApplyResult[StartImportResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.start_bulk_import = _Endpoint(
             settings={
@@ -406,7 +414,7 @@ class AsyncioBulkOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["id"] = id
-            return await self.call_with_http_info(**kwargs)
+            return cast(Dict[str, Any], await self.call_with_http_info(**kwargs))
 
         self.cancel_bulk_import = _AsyncioEndpoint(
             settings={
@@ -472,7 +480,7 @@ class AsyncioBulkOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["id"] = id
-            return await self.call_with_http_info(**kwargs)
+            return cast(ImportModel, await self.call_with_http_info(**kwargs))
 
         self.describe_bulk_import = _AsyncioEndpoint(
             settings={
@@ -538,7 +546,7 @@ class AsyncioBulkOperationsApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(ListImportsResponse, await self.call_with_http_info(**kwargs))
 
         self.list_bulk_imports = _AsyncioEndpoint(
             settings={
@@ -616,7 +624,7 @@ class AsyncioBulkOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["start_import_request"] = start_import_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(StartImportResponse, await self.call_with_http_info(**kwargs))
 
         self.start_bulk_import = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/db_data/api/document_operations_api.py
+++ b/pinecone/core/openapi/db_data/api/document_operations_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -94,7 +94,10 @@ class DocumentOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["document_search_request"] = document_search_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                DocumentSearchResponse | ApplyResult[DocumentSearchResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.search_documents = _Endpoint(
             settings={
@@ -184,7 +187,10 @@ class DocumentOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["document_upsert_request"] = document_upsert_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                DocumentUpsertResponse | ApplyResult[DocumentUpsertResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.upsert_documents = _Endpoint(
             settings={
@@ -279,7 +285,7 @@ class AsyncioDocumentOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["document_search_request"] = document_search_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(DocumentSearchResponse, await self.call_with_http_info(**kwargs))
 
         self.search_documents = _AsyncioEndpoint(
             settings={
@@ -362,7 +368,7 @@ class AsyncioDocumentOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["document_upsert_request"] = document_upsert_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(DocumentUpsertResponse, await self.call_with_http_info(**kwargs))
 
         self.upsert_documents = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/db_data/api/namespace_operations_api.py
+++ b/pinecone/core/openapi/db_data/api/namespace_operations_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -90,7 +90,10 @@ class NamespaceOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_namespace_request"] = create_namespace_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                NamespaceDescription | ApplyResult[NamespaceDescription],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.create_namespace = _Endpoint(
             settings={
@@ -172,7 +175,9 @@ class NamespaceOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                Dict[str, Any] | ApplyResult[Dict[str, Any]], self.call_with_http_info(**kwargs)
+            )
 
         self.delete_namespace = _Endpoint(
             settings={
@@ -251,7 +256,10 @@ class NamespaceOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                NamespaceDescription | ApplyResult[NamespaceDescription],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.describe_namespace = _Endpoint(
             settings={
@@ -328,7 +336,10 @@ class NamespaceOperationsApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                ListNamespacesResponse | ApplyResult[ListNamespacesResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.list_namespaces_operation = _Endpoint(
             settings={
@@ -421,7 +432,7 @@ class AsyncioNamespaceOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["create_namespace_request"] = create_namespace_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(NamespaceDescription, await self.call_with_http_info(**kwargs))
 
         self.create_namespace = _AsyncioEndpoint(
             settings={
@@ -493,7 +504,7 @@ class AsyncioNamespaceOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
-            return await self.call_with_http_info(**kwargs)
+            return cast(Dict[str, Any], await self.call_with_http_info(**kwargs))
 
         self.delete_namespace = _AsyncioEndpoint(
             settings={
@@ -562,7 +573,7 @@ class AsyncioNamespaceOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
-            return await self.call_with_http_info(**kwargs)
+            return cast(NamespaceDescription, await self.call_with_http_info(**kwargs))
 
         self.describe_namespace = _AsyncioEndpoint(
             settings={
@@ -632,7 +643,7 @@ class AsyncioNamespaceOperationsApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(ListNamespacesResponse, await self.call_with_http_info(**kwargs))
 
         self.list_namespaces_operation = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/db_data/api/vector_operations_api.py
+++ b/pinecone/core/openapi/db_data/api/vector_operations_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -105,7 +105,9 @@ class VectorOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["delete_request"] = delete_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                Dict[str, Any] | ApplyResult[Dict[str, Any]], self.call_with_http_info(**kwargs)
+            )
 
         self.delete_vectors = _Endpoint(
             settings={
@@ -184,7 +186,9 @@ class VectorOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["describe_index_stats_request"] = describe_index_stats_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                IndexDescription | ApplyResult[IndexDescription], self.call_with_http_info(**kwargs)
+            )
 
         self.describe_index_stats = _Endpoint(
             settings={
@@ -264,7 +268,9 @@ class VectorOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["ids"] = ids
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                FetchResponse | ApplyResult[FetchResponse], self.call_with_http_info(**kwargs)
+            )
 
         self.fetch_vectors = _Endpoint(
             settings={
@@ -352,7 +358,10 @@ class VectorOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["fetch_by_metadata_request"] = fetch_by_metadata_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                FetchByMetadataResponse | ApplyResult[FetchByMetadataResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.fetch_vectors_by_metadata = _Endpoint(
             settings={
@@ -433,7 +442,9 @@ class VectorOperationsApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                ListResponse | ApplyResult[ListResponse], self.call_with_http_info(**kwargs)
+            )
 
         self.list_vectors = _Endpoint(
             settings={
@@ -533,7 +544,9 @@ class VectorOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["query_request"] = query_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                QueryResponse | ApplyResult[QueryResponse], self.call_with_http_info(**kwargs)
+            )
 
         self.query_vectors = _Endpoint(
             settings={
@@ -615,7 +628,10 @@ class VectorOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["search_records_request"] = search_records_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                SearchRecordsResponse | ApplyResult[SearchRecordsResponse],
+                self.call_with_http_info(**kwargs),
+            )
 
         self.search_records_namespace = _Endpoint(
             settings={
@@ -702,7 +718,9 @@ class VectorOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["update_request"] = update_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                UpdateResponse | ApplyResult[UpdateResponse], self.call_with_http_info(**kwargs)
+            )
 
         self.update_vector = _Endpoint(
             settings={
@@ -784,7 +802,7 @@ class VectorOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["upsert_record"] = upsert_record
-            return self.call_with_http_info(**kwargs)
+            return cast(None, self.call_with_http_info(**kwargs))
 
         self.upsert_records_namespace = _Endpoint(
             settings={
@@ -871,7 +889,9 @@ class VectorOperationsApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["upsert_request"] = upsert_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                UpsertResponse | ApplyResult[UpsertResponse], self.call_with_http_info(**kwargs)
+            )
 
         self.upsert_vectors = _Endpoint(
             settings={
@@ -952,7 +972,7 @@ class AsyncioVectorOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["delete_request"] = delete_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(Dict[str, Any], await self.call_with_http_info(**kwargs))
 
         self.delete_vectors = _AsyncioEndpoint(
             settings={
@@ -1021,7 +1041,7 @@ class AsyncioVectorOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["describe_index_stats_request"] = describe_index_stats_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(IndexDescription, await self.call_with_http_info(**kwargs))
 
         self.describe_index_stats = _AsyncioEndpoint(
             settings={
@@ -1094,7 +1114,7 @@ class AsyncioVectorOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["ids"] = ids
-            return await self.call_with_http_info(**kwargs)
+            return cast(FetchResponse, await self.call_with_http_info(**kwargs))
 
         self.fetch_vectors = _AsyncioEndpoint(
             settings={
@@ -1172,7 +1192,7 @@ class AsyncioVectorOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["fetch_by_metadata_request"] = fetch_by_metadata_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(FetchByMetadataResponse, await self.call_with_http_info(**kwargs))
 
         self.fetch_vectors_by_metadata = _AsyncioEndpoint(
             settings={
@@ -1246,7 +1266,7 @@ class AsyncioVectorOperationsApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(ListResponse, await self.call_with_http_info(**kwargs))
 
         self.list_vectors = _AsyncioEndpoint(
             settings={
@@ -1336,7 +1356,7 @@ class AsyncioVectorOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["query_request"] = query_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(QueryResponse, await self.call_with_http_info(**kwargs))
 
         self.query_vectors = _AsyncioEndpoint(
             settings={
@@ -1411,7 +1431,7 @@ class AsyncioVectorOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["search_records_request"] = search_records_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(SearchRecordsResponse, await self.call_with_http_info(**kwargs))
 
         self.search_records_namespace = _AsyncioEndpoint(
             settings={
@@ -1488,7 +1508,7 @@ class AsyncioVectorOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["update_request"] = update_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(UpdateResponse, await self.call_with_http_info(**kwargs))
 
         self.update_vector = _AsyncioEndpoint(
             settings={
@@ -1559,7 +1579,7 @@ class AsyncioVectorOperationsApi:
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["namespace"] = namespace
             kwargs["upsert_record"] = upsert_record
-            return await self.call_with_http_info(**kwargs)
+            return cast(None, await self.call_with_http_info(**kwargs))
 
         self.upsert_records_namespace = _AsyncioEndpoint(
             settings={
@@ -1636,7 +1656,7 @@ class AsyncioVectorOperationsApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["upsert_request"] = upsert_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(UpsertResponse, await self.call_with_http_info(**kwargs))
 
         self.upsert_vectors = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/db_data/model/create_namespace_request.py
+++ b/pinecone/core/openapi/db_data/model/create_namespace_request.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.create_namespace_request_schema import (
+        CreateNamespaceRequestSchema,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.create_namespace_request_schema import (

--- a/pinecone/core/openapi/db_data/model/create_namespace_request_schema.py
+++ b/pinecone/core/openapi/db_data/model/create_namespace_request_schema.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.create_namespace_request_schema_fields import (
+        CreateNamespaceRequestSchemaFields,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.create_namespace_request_schema_fields import (

--- a/pinecone/core/openapi/db_data/model/document_search_request.py
+++ b/pinecone/core/openapi/db_data/model/document_search_request.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.filter_expression import FilterExpression
+    from pinecone.core.openapi.db_data.model.score_by_query import ScoreByQuery
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.filter_expression import FilterExpression

--- a/pinecone/core/openapi/db_data/model/document_search_response.py
+++ b/pinecone/core/openapi/db_data/model/document_search_response.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.document import Document
+    from pinecone.core.openapi.db_data.model.usage import Usage
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.document import Document

--- a/pinecone/core/openapi/db_data/model/fetch_by_metadata_response.py
+++ b/pinecone/core/openapi/db_data/model/fetch_by_metadata_response.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.pagination import Pagination
+    from pinecone.core.openapi.db_data.model.usage import Usage
+    from pinecone.core.openapi.db_data.model.vector import Vector
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.pagination import Pagination

--- a/pinecone/core/openapi/db_data/model/fetch_response.py
+++ b/pinecone/core/openapi/db_data/model/fetch_response.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.usage import Usage
+    from pinecone.core.openapi.db_data.model.vector import Vector
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.usage import Usage

--- a/pinecone/core/openapi/db_data/model/index_description.py
+++ b/pinecone/core/openapi/db_data/model/index_description.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.namespace_summary import NamespaceSummary
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.namespace_summary import NamespaceSummary

--- a/pinecone/core/openapi/db_data/model/list_imports_response.py
+++ b/pinecone/core/openapi/db_data/model/list_imports_response.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.import_model import ImportModel
+    from pinecone.core.openapi.db_data.model.pagination import Pagination
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.import_model import ImportModel

--- a/pinecone/core/openapi/db_data/model/list_namespaces_response.py
+++ b/pinecone/core/openapi/db_data/model/list_namespaces_response.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.namespace_description import NamespaceDescription
+    from pinecone.core.openapi.db_data.model.pagination import Pagination
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.namespace_description import NamespaceDescription

--- a/pinecone/core/openapi/db_data/model/list_response.py
+++ b/pinecone/core/openapi/db_data/model/list_response.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.list_item import ListItem
+    from pinecone.core.openapi.db_data.model.pagination import Pagination
+    from pinecone.core.openapi.db_data.model.usage import Usage
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.list_item import ListItem

--- a/pinecone/core/openapi/db_data/model/namespace_description.py
+++ b/pinecone/core/openapi/db_data/model/namespace_description.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.create_namespace_request_schema import (
+        CreateNamespaceRequestSchema,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.create_namespace_request_schema import (

--- a/pinecone/core/openapi/db_data/model/query_request.py
+++ b/pinecone/core/openapi/db_data/model/query_request.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.query_vector import QueryVector
+    from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.query_vector import QueryVector

--- a/pinecone/core/openapi/db_data/model/query_response.py
+++ b/pinecone/core/openapi/db_data/model/query_response.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.scored_vector import ScoredVector
+    from pinecone.core.openapi.db_data.model.single_query_results import SingleQueryResults
+    from pinecone.core.openapi.db_data.model.usage import Usage
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.scored_vector import ScoredVector

--- a/pinecone/core/openapi/db_data/model/query_vector.py
+++ b/pinecone/core/openapi/db_data/model/query_vector.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.sparse_values import SparseValues

--- a/pinecone/core/openapi/db_data/model/rpc_status.py
+++ b/pinecone/core/openapi/db_data/model/rpc_status.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.protobuf_any import ProtobufAny
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.protobuf_any import ProtobufAny

--- a/pinecone/core/openapi/db_data/model/score_by_query.py
+++ b/pinecone/core/openapi/db_data/model/score_by_query.py
@@ -26,6 +26,13 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
+    from pinecone.core.openapi.db_data.model.text_query import TextQuery
+    from pinecone.core.openapi.db_data.model.vector_query import VectorQuery
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
@@ -331,7 +338,7 @@ class ScoreByQuery(ModelComposed):
                 )
 
     @cached_property
-    def _composed_schemas():  # type: ignore
+    def _composed_schemas():
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class

--- a/pinecone/core/openapi/db_data/model/scored_vector.py
+++ b/pinecone/core/openapi/db_data/model/scored_vector.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.sparse_values import SparseValues

--- a/pinecone/core/openapi/db_data/model/search_records_request.py
+++ b/pinecone/core/openapi/db_data/model/search_records_request.py
@@ -26,6 +26,16 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.search_records_request_query import (
+        SearchRecordsRequestQuery,
+    )
+    from pinecone.core.openapi.db_data.model.search_records_request_rerank import (
+        SearchRecordsRequestRerank,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.search_records_request_query import (

--- a/pinecone/core/openapi/db_data/model/search_records_request_query.py
+++ b/pinecone/core/openapi/db_data/model/search_records_request_query.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.search_match_terms import SearchMatchTerms
+    from pinecone.core.openapi.db_data.model.search_records_vector import SearchRecordsVector
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.search_match_terms import SearchMatchTerms

--- a/pinecone/core/openapi/db_data/model/search_records_response.py
+++ b/pinecone/core/openapi/db_data/model/search_records_response.py
@@ -26,6 +26,14 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.search_records_response_result import (
+        SearchRecordsResponseResult,
+    )
+    from pinecone.core.openapi.db_data.model.search_usage import SearchUsage
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.search_records_response_result import (

--- a/pinecone/core/openapi/db_data/model/search_records_response_result.py
+++ b/pinecone/core/openapi/db_data/model/search_records_response_result.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.hit import Hit
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.hit import Hit

--- a/pinecone/core/openapi/db_data/model/search_records_vector.py
+++ b/pinecone/core/openapi/db_data/model/search_records_vector.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.vector_values import VectorValues
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.vector_values import VectorValues

--- a/pinecone/core/openapi/db_data/model/single_query_results.py
+++ b/pinecone/core/openapi/db_data/model/single_query_results.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.scored_vector import ScoredVector
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.scored_vector import ScoredVector

--- a/pinecone/core/openapi/db_data/model/start_import_request.py
+++ b/pinecone/core/openapi/db_data/model/start_import_request.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.import_error_mode import ImportErrorMode
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.import_error_mode import ImportErrorMode

--- a/pinecone/core/openapi/db_data/model/update_request.py
+++ b/pinecone/core/openapi/db_data/model/update_request.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.sparse_values import SparseValues

--- a/pinecone/core/openapi/db_data/model/upsert_request.py
+++ b/pinecone/core/openapi/db_data/model/upsert_request.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.vector import Vector
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.vector import Vector

--- a/pinecone/core/openapi/db_data/model/vector.py
+++ b/pinecone/core/openapi/db_data/model/vector.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.sparse_values import SparseValues

--- a/pinecone/core/openapi/db_data/model/vector_query.py
+++ b/pinecone/core/openapi/db_data/model/vector_query.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.db_data.model.sparse_values import SparseValues
+
 
 def lazy_import():
     from pinecone.core.openapi.db_data.model.sparse_values import SparseValues

--- a/pinecone/core/openapi/inference/api/inference_api.py
+++ b/pinecone/core/openapi/inference/api/inference_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -89,7 +89,9 @@ class InferenceApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                EmbeddingsList | ApplyResult[EmbeddingsList], self.call_with_http_info(**kwargs)
+            )
 
         self.embed = _Endpoint(
             settings={
@@ -168,7 +170,7 @@ class InferenceApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["model_name"] = model_name
-            return self.call_with_http_info(**kwargs)
+            return cast(ModelInfo | ApplyResult[ModelInfo], self.call_with_http_info(**kwargs))
 
         self.get_model = _Endpoint(
             settings={
@@ -244,7 +246,9 @@ class InferenceApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                ModelInfoList | ApplyResult[ModelInfoList], self.call_with_http_info(**kwargs)
+            )
 
         self.list_models = _Endpoint(
             settings={
@@ -328,7 +332,9 @@ class InferenceApi:
             """
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                RerankResult | ApplyResult[RerankResult], self.call_with_http_info(**kwargs)
+            )
 
         self.rerank = _Endpoint(
             settings={
@@ -406,7 +412,7 @@ class AsyncioInferenceApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(EmbeddingsList, await self.call_with_http_info(**kwargs))
 
         self.embed = _AsyncioEndpoint(
             settings={
@@ -475,7 +481,7 @@ class AsyncioInferenceApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["model_name"] = model_name
-            return await self.call_with_http_info(**kwargs)
+            return cast(ModelInfo, await self.call_with_http_info(**kwargs))
 
         self.get_model = _AsyncioEndpoint(
             settings={
@@ -542,7 +548,7 @@ class AsyncioInferenceApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(ModelInfoList, await self.call_with_http_info(**kwargs))
 
         self.list_models = _AsyncioEndpoint(
             settings={
@@ -617,7 +623,7 @@ class AsyncioInferenceApi:
             """
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
-            return await self.call_with_http_info(**kwargs)
+            return cast(RerankResult, await self.call_with_http_info(**kwargs))
 
         self.rerank = _AsyncioEndpoint(
             settings={

--- a/pinecone/core/openapi/inference/model/embed_request.py
+++ b/pinecone/core/openapi/inference/model/embed_request.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.embed_request_inputs import EmbedRequestInputs
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.embed_request_inputs import EmbedRequestInputs

--- a/pinecone/core/openapi/inference/model/embedding.py
+++ b/pinecone/core/openapi/inference/model/embedding.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.dense_embedding import DenseEmbedding
+    from pinecone.core.openapi.inference.model.sparse_embedding import SparseEmbedding
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.dense_embedding import DenseEmbedding
@@ -329,7 +335,7 @@ class Embedding(ModelComposed):
                 )
 
     @cached_property
-    def _composed_schemas():  # type: ignore
+    def _composed_schemas():
         # we need this here to make our import statements work
         # we must store _composed_schemas in here so the code is only run
         # when we invoke this method. If we kept this at the class

--- a/pinecone/core/openapi/inference/model/embeddings_list.py
+++ b/pinecone/core/openapi/inference/model/embeddings_list.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.embedding import Embedding
+    from pinecone.core.openapi.inference.model.embeddings_list_usage import EmbeddingsListUsage
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.embedding import Embedding

--- a/pinecone/core/openapi/inference/model/error_response.py
+++ b/pinecone/core/openapi/inference/model/error_response.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.error_response_error import ErrorResponseError
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.error_response_error import ErrorResponseError

--- a/pinecone/core/openapi/inference/model/model_info.py
+++ b/pinecone/core/openapi/inference/model/model_info.py
@@ -26,6 +26,16 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.model_info_supported_metrics import (
+        ModelInfoSupportedMetrics,
+    )
+    from pinecone.core.openapi.inference.model.model_info_supported_parameter import (
+        ModelInfoSupportedParameter,
+    )
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.model_info_supported_metrics import (

--- a/pinecone/core/openapi/inference/model/model_info_list.py
+++ b/pinecone/core/openapi/inference/model/model_info_list.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.model_info import ModelInfo
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.model_info import ModelInfo

--- a/pinecone/core/openapi/inference/model/ranked_document.py
+++ b/pinecone/core/openapi/inference/model/ranked_document.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.document import Document
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.document import Document

--- a/pinecone/core/openapi/inference/model/rerank_request.py
+++ b/pinecone/core/openapi/inference/model/rerank_request.py
@@ -26,6 +26,11 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.document import Document
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.document import Document

--- a/pinecone/core/openapi/inference/model/rerank_result.py
+++ b/pinecone/core/openapi/inference/model/rerank_result.py
@@ -26,6 +26,12 @@ from pinecone.openapi_support.model_utils import (  # noqa: F401
 )
 from pinecone.openapi_support.exceptions import PineconeApiAttributeError
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pinecone.core.openapi.inference.model.ranked_document import RankedDocument
+    from pinecone.core.openapi.inference.model.rerank_result_usage import RerankResultUsage
+
 
 def lazy_import():
     from pinecone.core.openapi.inference.model.ranked_document import RankedDocument

--- a/pinecone/core/openapi/oauth/api/o_auth_api.py
+++ b/pinecone/core/openapi/oauth/api/o_auth_api.py
@@ -11,7 +11,7 @@ Contact: support@pinecone.io
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, cast
 from multiprocessing.pool import ApplyResult
 
 from pinecone.openapi_support import ApiClient, AsyncioApiClient
@@ -89,7 +89,9 @@ class OAuthApi:
             kwargs = self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["token_request"] = token_request
-            return self.call_with_http_info(**kwargs)
+            return cast(
+                TokenResponse | ApplyResult[TokenResponse], self.call_with_http_info(**kwargs)
+            )
 
         self.get_token = _Endpoint(
             settings={
@@ -173,7 +175,7 @@ class AsyncioOAuthApi:
             self._process_openapi_kwargs(kwargs)
             kwargs["x_pinecone_api_version"] = x_pinecone_api_version
             kwargs["token_request"] = token_request
-            return await self.call_with_http_info(**kwargs)
+            return cast(TokenResponse, await self.call_with_http_info(**kwargs))
 
         self.get_token = _AsyncioEndpoint(
             settings={

--- a/pinecone/openapi_support/api_version.py
+++ b/pinecone/openapi_support/api_version.py
@@ -4,4 +4,4 @@
 # This version is used by gRPC clients (data plane only)
 
 API_VERSION = "2026-01.alpha"
-APIS_REPO_SHA = "d5ac93191def1d9666946d2c0e67edd3140b0f0d"
+APIS_REPO_SHA = "4eac4da9fe2083c9cce5e3cf494b582d637cd8a3"


### PR DESCRIPTION
## Summary

- Regenerate all OpenAPI clients using updated Mustache templates that add `TYPE_CHECKING` blocks for static type analysis
- This fixes mypy errors in generated code where model references were not recognized
- The template submodule (`codegen/python-oas-templates`) has been updated to include proper `TYPE_CHECKING` imports

## Problem

Generated OpenAPI code in `pinecone/core/openapi/` had multiple mypy errors:
1. Missing type imports (`Dict`, `Any` from `typing`)
2. Undefined model references (`SparseValues`, `ErrorResponseError`, `Document`, etc.)
3. Return type annotation issues

## Solution

Updated the Mustache templates to add `TYPE_CHECKING` blocks that allow mypy to see type annotations while avoiding circular import issues at runtime:

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from .model.some_model import SomeModel

def lazy_import():
    from .model.some_model import SomeModel
    globals()["SomeModel"] = SomeModel
```

## Verification

```bash
uv run mypy pinecone/core/openapi  # No errors in generated code
```

## Notes

There are pre-existing issues on the `fts` branch where SDK code imports non-existent models (e.g., `ConfigureIndexRequestEmbed`, `IndexSpec`). These imports reference models that don't exist in the current API spec and are **not** caused by this change - they are a separate issue that pre-dates this PR.

## Related

- Blocks: SDK-116 (Re-enable CI linting and unit tests for fts branch)
- Linear: https://linear.app/pinecone-io/issue/SDK-270

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to generated OpenAPI client/model code and mainly add `cast`/`TYPE_CHECKING` imports for static typing; runtime behavior should be unchanged aside from type-hint surfaces.
> 
> **Overview**
> Regenerates the OpenAPI Python clients/models to be more mypy-friendly by adding `TYPE_CHECKING` import blocks for referenced models and tightening return type annotations via `typing.cast` (including `ApplyResult[...]` unions for `async_req`).
> 
> Also removes a few `# type: ignore` markers on `_composed_schemas` helpers and updates the generated `APIS_REPO_SHA` in `openapi_support/api_version.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d699e3c9256193e5c8c673bc8f88342378b1d129. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->