### PR TITLE
fix: prevent logging sensitive API key data in test

### DIFF
--- a/tests/integration/rest_sync/admin/test_api_key.py
+++ b/tests/integration/rest_sync/admin/test_api_key.py
@@ -112,11 +112,11 @@ class TestAdminApiKey:
 
             # Fetch the API key using the aliases
             key_response_by_id = admin.api_key.fetch(api_key_id=key_response.key.id)
-            logger.info(f"API key by id: {key_response_by_id}")
+            logger.info(f"API key fetched with id: {key_response_by_id.id}")
             assert key_response_by_id.id == key_response.key.id
 
             get_key_response = admin.api_key.get(api_key_id=key_response.key.id)
-            logger.info(f"API key by name: {get_key_response}")
+            logger.info(f"API key fetched with id: {get_key_response.id}")
             assert get_key_response.id == key_response.key.id
 
             described_key_response = admin.api_key.describe(api_key_id=key_response.key.id)


### PR DESCRIPTION
## Summary
Fixed security vulnerability where API key response objects containing sensitive data were being logged in clear text in test files.

## Changes
- Modified `tests/integration/rest_sync/admin/test_api_key.py` to log only non-sensitive API key IDs instead of full response objects
- This prevents exposure of sensitive data (passwords/API key values) in logs

## Security Impact
- Resolves code scanning alert #72: https://github.com/pinecone-io/pinecone-python-client/security/code-scanning/72
- Addresses CWE-312 (Cleartext Storage of Sensitive Information)
- Addresses CWE-532 (Insertion of Sensitive Information into Log File)
- Security severity: High

## Testing
- Existing tests continue to pass
- Pre-commit hooks passed


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that reduces exposure of sensitive API key material in logs; no runtime behavior is affected.
> 
> **Overview**
> Updates the admin API key integration test to **stop logging full API key response objects** and instead log only non-sensitive identifiers (the key `id`) when fetching via `fetch`/`get` aliases, preventing accidental leakage of API key values in test logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5cf44f6aa34f35b4b35004c69149c20f0304a26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->