### PR TITLE
[Bug] Fix FilterTypedDict to accept field-based filters

### DIFF
--- a/pinecone/db_data/types/query_filter.py
+++ b/pinecone/db_data/types/query_filter.py
@@ -17,6 +17,22 @@ InFilter = dict[Literal["$in"], list[FieldValue]]
 NinFilter = dict[Literal["$nin"], list[FieldValue]]
 ExistsFilter = dict[Literal["$exists"], bool]
 
+# Operator-only filters (e.g., {"$eq": "value"})
+OperatorFilter = (
+    EqFilter
+    | NeFilter
+    | GtFilter
+    | GteFilter
+    | LtFilter
+    | LteFilter
+    | InFilter
+    | NinFilter
+    | ExistsFilter
+)
+
+# Field-level filters that can use operators or exact match (e.g., {"field": {"$eq": "value"}})
+FieldFilter = dict[str, OperatorFilter | FieldValue]
+
 SimpleFilter = (
     ExactMatchFilter
     | EqFilter
@@ -28,6 +44,7 @@ SimpleFilter = (
     | InFilter
     | NinFilter
     | ExistsFilter
+    | FieldFilter
 )
 AndFilter = dict[Literal["$and"], list[SimpleFilter]]
 OrFilter = dict[Literal["$or"], list[SimpleFilter]]


### PR DESCRIPTION
## Summary
Fixes #461

This PR corrects the typing for the `filter` parameter in `IndexAsyncio.query()` and `Index.query()` methods.

## Problem
The `FilterTypedDict` type was incorrectly defined to only accept operator-only filters like:
```python
{"$eq": "value"}  # Only this was allowed by type checker
```

However, Pinecone's actual filter API requires field names in the filter structure:
```python
{"field": {"$eq": "value"}}  # This is the correct syntax but caused type errors
```

This discrepancy caused IDEs and type checkers (like Pylance, mypy) to show false positive errors when using the correct filter format, making the developer experience frustrating with "red squiggly lines" despite the code working correctly at runtime.

## Solution
Updated `FilterTypedDict` to support both formats:
- Added `FieldFilter` type: `dict[str, OperatorFilter | FieldValue]` to support `{"field": {"$eq": "value"}}`
- Created `OperatorFilter` type alias for clarity
- Included `FieldFilter` in the `SimpleFilter` union

The fix maintains full backward compatibility while allowing the proper nested filter syntax.

## Examples
After this fix, all these filter formats are correctly typed:

```python
# Field-based filters (now properly supported)
filter={"entity": {"$eq": "user123"}}
filter={"year": {"$gt": 2000}}
filter={"status": {"$in": ["active", "pending"]}}

# Operator-only filters (still supported)
filter={"$ne": "something"}

# Exact match filters (still supported)
filter={"field": "value"}

# Complex filters (still supported)
filter={"$and": [{"field1": {"$eq": "val"}}, {"field2": {"$gt": 10}}]}
```

## Test Plan
- Type definitions validated against Pinecone's filter documentation
- Maintains backward compatibility with existing filter patterns
- No runtime behavior changes (pure typing fix)

## Documentation
The fix aligns with Pinecone's official filter documentation and the examples shown in the method docstrings, which already demonstrate the field-based syntax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change broadening accepted filter shapes; no runtime logic changes, but could mask some invalid filter structures for type checkers.
> 
> **Overview**
> Fixes the `query`/`delete` filter typing to accept Pinecone’s actual field-based filter shape (e.g., `{"field": {"$eq": "value"}}`) rather than only operator-only dictionaries.
> 
> Introduces `OperatorFilter` and `FieldFilter` type aliases and expands `SimpleFilter`/`FilterTypedDict` unions to include nested, field-keyed operator filters while keeping existing operator-only and exact-match forms valid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f9033dfd7a436808f2ac8fb6b556fc72067b19f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->