### PR TITLE
Add requests>=2.33.0 lower bound (insecure temp file reuse)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pinecone-plugin-interface>=0.0.7,<0.1.0",
     "python-dateutil>=2.5.3",
     "pinecone-plugin-assistant>=3.0.1,<4.0.0",
+    "requests>=2.33.0",
     "urllib3>=1.26.0; python_version<'3.12'",
     "urllib3>=1.26.5; python_version>='3.12'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1588,6 +1588,7 @@ dependencies = [
     { name = "pinecone-plugin-assistant" },
     { name = "pinecone-plugin-interface" },
     { name = "python-dateutil" },
+    { name = "requests" },
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
@@ -1673,6 +1674,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.2.0" },
     { name = "python-dateutil", specifier = ">=2.5.3" },
     { name = "python-dotenv", marker = "extra == 'dev'", specifier = ">=1.1.0,<2.0.0" },
+    { name = "requests", specifier = ">=2.33.0" },
     { name = "responses", marker = "extra == 'dev'", specifier = ">=0.8.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.3,<0.10.0" },
     { name = "sphinx", marker = "python_full_version >= '3.11' and extra == 'dev'", specifier = ">=8.2.3,<9.0.0" },
@@ -2119,7 +2121,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2127,9 +2129,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `requests>=2.33.0` as a direct dependency to constrain the transitive version pulled in by `pinecone-plugin-assistant`
- Addresses insecure temp file reuse in `extract_zipped_paths()` (requests < 2.33.0)
- Resolves [Dependabot alert #62](https://github.com/pinecone-io/pinecone-python-client/security/dependabot/62)

## Test plan
- [x] Unit tests pass (210 passed)
- [x] Ruff lint clean
- [x] Mypy type checks clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a dependency constraint change only, but it can affect downstream environments if they previously resolved older `requests` versions.
> 
> **Overview**
> Adds `requests>=2.33.0` as a **direct runtime dependency** in `pyproject.toml` to ensure the project does not resolve vulnerable older `requests` versions via transitive dependencies.
> 
> Updates `uv.lock` accordingly, including bumping the locked `requests` version to `2.33.1` and recording it in the `pinecone` dependency set (and metadata).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bebf93639cb0a8226137d6025712dc40484b0416. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->