### PR TITLE
fix(types): accept Sequence[float] for vector values in VectorTuple

### DIFF
--- a/pinecone/db_data/types/vector_tuple.py
+++ b/pinecone/db_data/types/vector_tuple.py
@@ -1,4 +1,6 @@
+from collections.abc import Sequence
+
 from .vector_metadata_dict import VectorMetadataTypedDict
 
-VectorTuple = tuple[str, list[float]]
-VectorTupleWithMetadata = tuple[str, list[float], VectorMetadataTypedDict]
+VectorTuple = tuple[str, Sequence[float]]
+VectorTupleWithMetadata = tuple[str, Sequence[float], VectorMetadataTypedDict]

--- a/tests/unit/db_data/test_vector_factory.py
+++ b/tests/unit/db_data/test_vector_factory.py
@@ -1,0 +1,38 @@
+"""Unit tests for VectorFactory in the db_data module."""
+
+from array import array
+
+import pytest
+
+from pinecone.db_data.vector_factory import VectorFactory
+
+
+class TestVectorFactoryTupleInput:
+    """Tests for VectorFactory.build() with tuple input."""
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [0.1, 0.2, 0.3],
+            array("f", [0.1, 0.2, 0.3]),
+        ],
+    )
+    def test_build_tuple_two_values(self, values):
+        """VectorFactory accepts list[float] and array[float] in a two-element tuple."""
+        result = VectorFactory.build(("id1", values))
+        assert result.id == "id1"
+        assert len(result.values) == 3
+
+    @pytest.mark.parametrize(
+        "values",
+        [
+            [0.1, 0.2, 0.3],
+            array("f", [0.1, 0.2, 0.3]),
+        ],
+    )
+    def test_build_tuple_three_values(self, values):
+        """VectorFactory accepts list[float] and array[float] in a three-element tuple."""
+        result = VectorFactory.build(("id1", values, {"genre": "comedy"}))
+        assert result.id == "id1"
+        assert len(result.values) == 3
+        assert result.metadata == {"genre": "comedy"}


### PR DESCRIPTION
## Problem

`VectorTuple` and `VectorTupleWithMetadata` are typed as `tuple[str, list[float]]`,
which causes type-checker errors when passing `array[float]` or other sequence
types that are valid at runtime:

```
error: Argument of type "list[tuple[str, array[float]]]" cannot be assigned to
parameter "vectors" of type "List[VectorTuple] | ..."
```

Fixes #511.

## Solution

Change `list[float]` to `Sequence[float]` in `pinecone/db_data/types/vector_tuple.py`.
`Sequence[float]` accepts `list[float]`, `array[float]`, and any other indexed float
sequence. The runtime behaviour is unchanged — `VectorFactory` already calls
`convert_to_list()` on the values before forwarding them to the API.

The `grpc` module is also covered automatically since `vector_factory_grpc.py`
imports `VectorTuple` from `db_data.types`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above

## Test plan

Added `tests/unit/db_data/test_vector_factory.py` with parametrized tests
covering both `list[float]` and `array[float]` for two- and three-element
tuple formats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a typing-only widening from `list[float]` to `Sequence[float]` plus small unit tests, with no runtime logic changes.
> 
> **Overview**
> Updates `VectorTuple`/`VectorTupleWithMetadata` typing to accept `Sequence[float]` instead of only `list[float]`, allowing tuple-based vectors to be passed with `array('f')` and other float sequences without type-checker errors.
> 
> Adds unit tests for `VectorFactory.build()` confirming tuple inputs work with both `list` and `array` values for 2- and 3-element tuple forms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5c4cefbda0934ddd0a495b1406bdd4a6e910daf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->