### PR TITLE
Fix AttributeError on delete with non-dict response (#564)

### DIFF
--- a/pinecone/openapi_support/api_client.py
+++ b/pinecone/openapi_support/api_client.py
@@ -212,7 +212,7 @@ class ApiClient(object):
                 response_info = extract_response_info(headers)
                 if isinstance(return_data, dict):
                     return_data["_response_info"] = response_info
-                else:
+                elif hasattr(return_data, "__dict__"):
                     # Dynamic attribute assignment on OpenAPI models
                     setattr(return_data, "_response_info", response_info)
 

--- a/pinecone/openapi_support/asyncio_api_client.py
+++ b/pinecone/openapi_support/asyncio_api_client.py
@@ -177,7 +177,7 @@ class AsyncioApiClient(object):
                 response_info = extract_response_info(headers)
                 if isinstance(return_data, dict):
                     return_data["_response_info"] = response_info
-                else:
+                elif hasattr(return_data, "__dict__"):
                     # Dynamic attribute assignment on OpenAPI models
                     setattr(return_data, "_response_info", response_info)
 

--- a/scripts/test_pinecone_local_delete.py
+++ b/scripts/test_pinecone_local_delete.py
@@ -1,0 +1,83 @@
+"""One-off repro script for GitHub issue #564.
+
+Requires pinecone-local running in Docker:
+
+    docker run -it --rm \
+      --name pinecone \
+      --platform linux/amd64 \
+      -e PORT=15080 \
+      -e PINECONE_HOST=localhost \
+      -p 15080-15090:15080-15090 \
+      ghcr.io/pinecone-io/pinecone-local:latest
+
+Then run:
+
+    uv run python scripts/test_pinecone_local_delete.py
+"""
+
+import asyncio
+
+import numpy as np
+import pinecone
+
+
+async def main():
+    index_name = "test-pinecone-index"
+    pc = pinecone.Pinecone(api_key="test-api-key", host="http://localhost:15080")
+
+    if pc.has_index(index_name):
+        pc.delete_index(index_name)
+
+    pc.create_index(
+        name=index_name,
+        dimension=512,
+        metric="cosine",
+        spec=pinecone.ServerlessSpec(cloud="aws", region="us-east-1"),
+        deletion_protection="disabled",
+    )
+
+    index_host = f"http://{pc.describe_index(index_name)['host']}"
+    idx = pc.IndexAsyncio(host=index_host)
+
+    try:
+        await idx.upsert(
+            vectors=[
+                ("vec1", np.random.rand(512).astype(np.float32).tolist()),
+                ("vec2", np.random.rand(512).astype(np.float32).tolist()),
+            ],
+            namespace="test-namespace",
+        )
+
+        # This is the call that failed in issue #564
+        await idx.delete(namespace="test-namespace", delete_all=True)
+        print("PASS: async delete_all succeeded")
+
+        # Also test delete by ids
+        await idx.upsert(
+            vectors=[
+                ("vec3", np.random.rand(512).astype(np.float32).tolist()),
+            ],
+            namespace="test-namespace",
+        )
+        await idx.delete(ids=["vec3"], namespace="test-namespace")
+        print("PASS: async delete by ids succeeded")
+
+        # Test sync client too
+        sync_idx = pc.Index(host=index_host)
+        sync_idx.upsert(
+            vectors=[
+                ("vec4", np.random.rand(512).astype(np.float32).tolist()),
+            ],
+            namespace="test-namespace",
+        )
+        sync_idx.delete(namespace="test-namespace", delete_all=True)
+        print("PASS: sync delete_all succeeded")
+    finally:
+        await idx.close()
+        pc.delete_index(index_name)
+
+    print("\nAll checks passed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/integration/rest_asyncio/db/data/test_delete.py
+++ b/tests/integration/rest_asyncio/db/data/test_delete.py
@@ -1,0 +1,46 @@
+import pytest
+from .conftest import build_asyncioindex_client, poll_until_lsn_reconciled_async
+from tests.integration.helpers import random_string, embedding_values
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_namespace", [random_string(20)])
+async def test_delete_by_ids(index_host, dimension, target_namespace):
+    asyncio_idx = build_asyncioindex_client(index_host)
+    try:
+        ids = [f"del-{i}" for i in range(3)]
+        vectors = [(id, embedding_values(dimension)) for id in ids]
+        upsert_resp = await asyncio_idx.upsert(vectors=vectors, namespace=target_namespace)
+        await poll_until_lsn_reconciled_async(
+            asyncio_idx, upsert_resp._response_info, namespace=target_namespace
+        )
+
+        # Delete a subset of vectors by id
+        delete_resp = await asyncio_idx.delete(ids=ids[:2], namespace=target_namespace)
+        assert delete_resp is None or isinstance(delete_resp, dict)
+
+        # Remaining vector should still be fetchable
+        fetched = await asyncio_idx.fetch(ids=ids, namespace=target_namespace)
+        assert ids[2] in fetched.vectors
+        assert ids[0] not in fetched.vectors
+        assert ids[1] not in fetched.vectors
+    finally:
+        await asyncio_idx.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_namespace", [random_string(20)])
+async def test_delete_all(index_host, dimension, target_namespace):
+    asyncio_idx = build_asyncioindex_client(index_host)
+    try:
+        vectors = [(f"delall-{i}", embedding_values(dimension)) for i in range(3)]
+        upsert_resp = await asyncio_idx.upsert(vectors=vectors, namespace=target_namespace)
+        await poll_until_lsn_reconciled_async(
+            asyncio_idx, upsert_resp._response_info, namespace=target_namespace
+        )
+
+        # Delete all vectors in namespace — this is the exact call from issue #564
+        delete_resp = await asyncio_idx.delete(namespace=target_namespace, delete_all=True)
+        assert delete_resp is None or isinstance(delete_resp, dict)
+    finally:
+        await asyncio_idx.close()

--- a/tests/integration/rest_sync/db/data/test_delete.py
+++ b/tests/integration/rest_sync/db/data/test_delete.py
@@ -1,0 +1,40 @@
+import pytest
+from tests.integration.helpers import poll_until_lsn_reconciled, embedding_values, random_string
+
+
+@pytest.fixture(scope="session")
+def delete_by_ids_namespace():
+    return random_string(20)
+
+
+@pytest.fixture(scope="session")
+def delete_all_namespace():
+    return random_string(20)
+
+
+class TestDelete:
+    def test_delete_by_ids(self, idx, delete_by_ids_namespace):
+        ids = [f"del-{i}" for i in range(3)]
+        vectors = [(id, embedding_values()) for id in ids]
+        upsert_resp = idx.upsert(vectors=vectors, namespace=delete_by_ids_namespace)
+        poll_until_lsn_reconciled(
+            idx, upsert_resp._response_info, namespace=delete_by_ids_namespace
+        )
+
+        delete_resp = idx.delete(ids=ids[:2], namespace=delete_by_ids_namespace)
+        assert delete_resp is None or isinstance(delete_resp, dict)
+
+        fetched = idx.fetch(ids=ids, namespace=delete_by_ids_namespace)
+        assert ids[2] in fetched.vectors
+        assert ids[0] not in fetched.vectors
+        assert ids[1] not in fetched.vectors
+
+    def test_delete_all(self, idx, delete_all_namespace):
+        vectors = [(f"delall-{i}", embedding_values()) for i in range(3)]
+        upsert_resp = idx.upsert(vectors=vectors, namespace=delete_all_namespace)
+        poll_until_lsn_reconciled(
+            idx, upsert_resp._response_info, namespace=delete_all_namespace
+        )
+
+        delete_resp = idx.delete(namespace=delete_all_namespace, delete_all=True)
+        assert delete_resp is None or isinstance(delete_resp, dict)

--- a/tests/unit/db_data/test_asyncio_delete_bug.py
+++ b/tests/unit/db_data/test_asyncio_delete_bug.py
@@ -78,6 +78,20 @@ class TestAsyncioDeleteEmptyBody:
             await client.close()
 
 
+    @pytest.mark.asyncio
+    async def test_string_response_body_does_not_raise(self):
+        """Non-empty string responses (e.g. '\"ok\"') must not raise AttributeError."""
+        client = AsyncioApiClient(configuration=_make_config())
+        try:
+            with patch.object(
+                client, "request", new_callable=AsyncMock, return_value=_make_response(b'"ok"')
+            ):
+                result = await client.call_api(**{**_CALL_API_KWARGS, "response_type": (str,)})
+                assert result == "ok"
+        finally:
+            await client.close()
+
+
 class TestSyncDeleteEmptyBody:
     """Sync client: empty/whitespace response bodies should return None."""
 
@@ -93,3 +107,10 @@ class TestSyncDeleteEmptyBody:
         with patch.object(client, "request", return_value=_make_response(b"{}")):
             result = client.call_api(**_CALL_API_KWARGS)
             assert isinstance(result, dict)
+
+    def test_string_response_body_does_not_raise(self):
+        """Non-empty string responses (e.g. '\"ok\"') must not raise AttributeError."""
+        client = ApiClient(configuration=_make_config())
+        with patch.object(client, "request", return_value=_make_response(b'"ok"')):
+            result = client.call_api(**{**_CALL_API_KWARGS, "response_type": (str,)})
+            assert result == "ok"


### PR DESCRIPTION
## Summary

Reopens #564 — we previously believed this was fixed, but the earlier fix only handled the case where the server returns an **empty** response body. We missed the case where the server returns a **non-empty string** (as pinecone-local does), which still triggered the same `AttributeError: 'str' object has no attribute '_response_info'`. We didn't have integration tests covering delete at the time, so the gap went unnoticed. Sorry about that.

The root cause is the same: `setattr()` is called on the deserialized response data, which fails for primitive types like `str` that don't support dynamic attribute assignment. The fix guards with `hasattr(return_data, "__dict__")` so we only attach `_response_info` to objects that support it.

## Changes
- `pinecone/openapi_support/api_client.py` — guard setattr on response data
- `pinecone/openapi_support/asyncio_api_client.py` — same fix for async client
- `tests/unit/db_data/test_asyncio_delete_bug.py` — unit tests for string response bodies
- `tests/integration/rest_asyncio/db/data/test_delete.py` — async integration tests for delete by ids and delete_all
- `tests/integration/rest_sync/db/data/test_delete.py` — sync integration tests for delete by ids and delete_all
- `scripts/test_pinecone_local_delete.py` — one-off repro script for verifying against pinecone-local

## Test plan
- [x] Unit tests pass (14 tests in test_asyncio_delete_bug.py)
- [x] Async integration tests pass against Pinecone cloud
- [x] Sync integration tests pass against Pinecone cloud
- [x] Manual verification against pinecone-local using `scripts/test_pinecone_local_delete.py`