### PR TITLE
Fix on-merge workflow permissions for dependency tests

### DIFF
--- a/.github/workflows/on-merge.yaml
+++ b/.github/workflows/on-merge.yaml
@@ -21,7 +21,8 @@ on:
       - '*.example'
   workflow_dispatch: {}
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: 'ci-${{ github.workflow }}-${{ github.ref }}'


### PR DESCRIPTION
## Summary
- PR #629 added `permissions: {}` to `on-merge.yaml`, which grants zero permissions to called workflows
- `testing-dependency.yaml` and its sub-workflows (`testing-dependency-rest`, `testing-dependency-asyncio`, `testing-dependency-grpc`) all require `contents: read`
- GitHub Actions enforces that called workflows cannot exceed the caller's permissions, so the entire run fails with `startup_failure` before any jobs execute
- Fixes this by granting `contents: read` at the caller level — the minimum permission needed

## Test plan
- [x] Verify the on-merge workflow passes on this branch after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts GitHub Actions workflow permissions and should mainly affect whether CI can start successfully.
> 
> **Overview**
> Fixes the `on-merge.yaml` caller workflow permissions so reusable workflows can run.
> 
> Replaces `permissions: {}` (no permissions) with the minimal required `permissions: contents: read`, preventing `startup_failure` when invoking downstream dependency test workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dcd48b2edee955460962465d691ef43a01dbe80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->