### PR TITLE
Bump actions/checkout v4 → v6 and actions/setup-python v5 → v6

### DIFF
--- a/.github/actions/project-create/action.yml
+++ b/.github/actions/project-create/action.yml
@@ -38,7 +38,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/.github/actions/project-delete/action.yml
+++ b/.github/actions/project-delete/action.yml
@@ -26,7 +26,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
 

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -30,7 +30,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python_version }}
 

--- a/.github/workflows/build-and-publish-docs.yaml
+++ b/.github/workflows/build-and-publish-docs.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate sphinx documentation
         uses: ./.github/actions/build-docs

--- a/.github/workflows/cleanup-nightly.yaml
+++ b/.github/workflows/cleanup-nightly.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Cleanup all indexes/collections
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Cleanup all
         uses: ./.github/actions/cleanup-all
         with:

--- a/.github/workflows/on-merge.yaml
+++ b/.github/workflows/on-merge.yaml
@@ -85,7 +85,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build docs with pdoc
         uses: './.github/actions/build-docs'
         with:

--- a/.github/workflows/project-cleanup.yaml
+++ b/.github/workflows/project-cleanup.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-uv
         with:
           python_version: '3.10'

--- a/.github/workflows/project-setup.yaml
+++ b/.github/workflows/project-setup.yaml
@@ -29,7 +29,7 @@ jobs:
       index_host_dense: ${{ steps.create-index-dense.outputs.index_host }}
       index_host_sparse: ${{ steps.create-index-sparse.outputs.index_host }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-uv
         with:
           python_version: '3.10'

--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Need full history and tags to compute list of commits in release
           ref: ${{ inputs.ref }}

--- a/.github/workflows/testing-dependency-asyncio.yaml
+++ b/.github/workflows/testing-dependency-asyncio.yaml
@@ -27,7 +27,7 @@ jobs:
           - 3.10.0
           - 3.11.5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:

--- a/.github/workflows/testing-dependency-grpc.yaml
+++ b/.github/workflows/testing-dependency-grpc.yaml
@@ -53,7 +53,7 @@ jobs:
         googleapis_common_protos_version:
           - 1.72.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:
@@ -92,7 +92,7 @@ jobs:
         googleapis_common_protos_version:
           - 1.72.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:
@@ -130,7 +130,7 @@ jobs:
         googleapis_common_protos_version:
           - 1.72.0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:

--- a/.github/workflows/testing-dependency-rest.yaml
+++ b/.github/workflows/testing-dependency-rest.yaml
@@ -30,7 +30,7 @@ jobs:
           # - 2.0.2
           - 2.2.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:
@@ -59,7 +59,7 @@ jobs:
           # - 2.0.2
           - 2.2.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:
@@ -87,7 +87,7 @@ jobs:
           # - 2.0.2
           - 2.2.1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:

--- a/.github/workflows/testing-dependency.yaml
+++ b/.github/workflows/testing-dependency.yaml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       index_name: ${{ steps.setup-index.outputs.index_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:
@@ -68,7 +68,7 @@ jobs:
       - dependency-test-asyncio
       - dependency-test-grpc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/secret-decrypt
         id: decrypt-secret
         with:

--- a/.github/workflows/testing-install.yaml
+++ b/.github/workflows/testing-install.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -72,10 +72,10 @@ jobs:
         python: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/testing-integration.yaml
+++ b/.github/workflows/testing-integration.yaml
@@ -30,7 +30,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         total_shards: [10]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:
@@ -59,7 +59,7 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
         total_shards: [8]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:
@@ -86,7 +86,7 @@ jobs:
       matrix:
         python_version: ${{ fromJson(inputs.python_versions_json) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:

--- a/.github/workflows/testing-lint.yaml
+++ b/.github/workflows/testing-lint.yaml
@@ -8,5 +8,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: chartboost/ruff-action@v1

--- a/.github/workflows/testing-unit.yaml
+++ b/.github/workflows/testing-unit.yaml
@@ -20,7 +20,7 @@ jobs:
           - true
           - false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:
@@ -39,7 +39,7 @@ jobs:
       matrix:
         python-version: ${{ fromJson(inputs.python_versions_json) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:
@@ -58,7 +58,7 @@ jobs:
       matrix:
         python-version: ${{ fromJson(inputs.python_versions_json) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup uv
         uses: ./.github/actions/setup-uv
         with:


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from v4 to v6 and `actions/setup-python` from v5 to v6 across all workflow files
- Both upgrades move to Node.js 24, resolving the Node.js 20 deprecation warnings in CI

## Test plan
- [ ] Verify CI workflows pass with the updated action versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since this only changes GitHub Actions versions, but it can impact CI behavior if `actions/checkout@v6` or `actions/setup-python@v6` introduce breaking changes or different defaults.
> 
> **Overview**
> **Updates CI action dependencies** by bumping `actions/checkout` from `v4` to `v6` across all workflows.
> 
> **Updates Python runtime setup** by bumping `actions/setup-python` from `v5` to `v6` in composite actions and install test workflows, keeping existing Python version matrices unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c2449108f297f23521bec4d13718e711b9ee131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->