### PR TITLE
fix(ci): make abi3audit step OS-aware (fix Windows wheel-build job)

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -417,9 +417,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m venv /tmp/abi3audit-venv
-          /tmp/abi3audit-venv/bin/pip install --quiet abi3audit
-          /tmp/abi3audit-venv/bin/python -m abi3audit --strict --report dist/*.whl
+          VENV_DIR="${RUNNER_TEMP}/abi3audit-venv"
+          python3 -m venv "$VENV_DIR"
+          if [ -d "$VENV_DIR/Scripts" ]; then
+            VBIN="$VENV_DIR/Scripts"
+          else
+            VBIN="$VENV_DIR/bin"
+          fi
+          "$VBIN/pip" install --quiet abi3audit
+          "$VBIN/python" -m abi3audit --strict --report dist/*.whl
 
       # auditwheel show inspects ELF binaries inside each manylinux wheel and reports
       # the actual minimum glibc version. A wheel tagged manylinux_2_17 but linking


### PR DESCRIPTION
## Summary

- Replaces hardcoded `/tmp/abi3audit-venv/bin/...` paths with OS-aware equivalents
- Uses `$RUNNER_TEMP` instead of `/tmp` for the venv parent (works on all runner OSes)
- Detects `Scripts/` (Windows) vs `bin/` (Linux/macOS) for the binary directory
- Fixes exit code 127 failure on `x86_64-pc-windows-msvc` runners (CI-0060)

## Root cause

The `abi3audit` step (lines 416–422) hardcoded Unix-style paths. On Windows runners:
1. Git Bash maps `/tmp` to a runner-specific `AppData/Local/Temp` path, not `RUNNER_TEMP`
2. Windows venvs place binaries in `Scripts/`, not `bin/`

This combination caused "No such file or directory" / exit 127 on every Windows wheel build.

## Verification

Release Readiness run on this branch with `skip_integration=true`:
https://github.com/pinecone-io/python-sdk/actions/runs/25521225781

All wheel build jobs green, including `Wheel build (x86_64-pc-windows-msvc)`. CI-0037's isolation intent (separate venv for abi3audit) is preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only changes how the `abi3audit` virtualenv is created/invoked; main risk is CI regressions if path detection or `$RUNNER_TEMP` behaves unexpectedly on some runners.
> 
> **Overview**
> Fixes the `release-readiness` wheel-build job’s `abi3audit` step to work cross-platform by creating the venv under `RUNNER_TEMP` and selecting `Scripts/` (Windows) vs `bin/` (Unix) when invoking `pip`/`python`.
> 
> This removes hardcoded `/tmp/.../bin/...` paths, preventing Windows wheel builds from failing with missing executable/path errors while preserving the venv isolation intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1747670f91f146488b40fbeefc5ef62fe3cdcd37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->