### PR TITLE
fix: avoid ImportError when pinecone loads as a namespace package

### DIFF
--- a/pinecone/__init__.py
+++ b/pinecone/__init__.py
@@ -49,6 +49,8 @@ from __future__ import annotations
 
 import os as _os
 
+from pinecone._version import __version__  # noqa: F401  (re-exported as public API)
+
 # Avoid importing typing at runtime — its transitive deps (re, enum,
 # collections, contextlib, functools, warnings) add ~28ms to cold import.
 # All annotations use PEP 563 (from __future__ import annotations), so
@@ -200,8 +202,6 @@ if TYPE_CHECKING:
     from pinecone.models.vectors.sparse import SparseValues
     from pinecone.models.vectors.vector import ScoredVector, Vector
     from pinecone.utils.filter_builder import Field, FilterBuilder
-
-__version__ = "9.0.0"
 
 if _os.environ.get("PINECONE_DEBUG"):
     import logging as _logging

--- a/pinecone/_internal/http_client.py
+++ b/pinecone/_internal/http_client.py
@@ -17,7 +17,7 @@ from urllib.parse import urlsplit
 import httpx
 import orjson
 
-from pinecone import __version__
+from pinecone._version import __version__
 from pinecone._internal.config import PineconeConfig, RetryConfig
 from pinecone._internal.constants import API_VERSION_HEADER, DEFAULT_BASE_URL
 from pinecone._internal.user_agent import build_user_agent

--- a/pinecone/_version.py
+++ b/pinecone/_version.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+
+__version__ = "9.0.0"

--- a/pinecone/admin/admin.py
+++ b/pinecone/admin/admin.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import orjson
 
-from pinecone import __version__
+from pinecone._version import __version__
 from pinecone._internal.config import PineconeConfig
 from pinecone._internal.constants import ADMIN_API_VERSION, API_VERSION_HEADER, DEFAULT_BASE_URL
 from pinecone._internal.http_client import HTTPClient, _build_socket_options, _RetryTransport

--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -164,7 +164,7 @@ class GrpcIndex:
         # Build gRPC endpoint and create the Rust-backed channel
         endpoint = _build_grpc_endpoint(self._host, secure)
 
-        from pinecone import __version__
+        from pinecone._version import __version__
         from pinecone._grpc import GrpcChannel  # type: ignore[import-not-found]
 
         self._channel: GrpcChannelProtocol = GrpcChannel(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ Issues = "https://github.com/pinecone-io/python-sdk/issues"
 manifest-path = "rust/Cargo.toml"
 module-name = "pinecone._grpc"
 python-source = "."
+python-packages = ["pinecone"]
 # maturin 1.7.x doesn't auto-include the LICENSE file in the sdist even though
 # it adds `License-File: LICENSE` to PKG-INFO from the SPDX license expression.
 # The mismatch makes PyPI reject the sdist. Explicit include fixes both forms.


### PR DESCRIPTION
## Problem

On Python 3.11/3.12, in certain environments (stale `pinecone-client`
install, partial pip unpack, or installer edge cases), the `pinecone`
package can be resolved as a **namespace package** — where
`pinecone.__file__ is None` and `dir(pinecone)` shows only stdlib dunders.

In this state, three internal callsites crash at instantiation time:

ImportError: cannot import name 'version' from 'pinecone' (unknown location)


Affected files:
- `pinecone/_internal/http_client.py:20`
- `pinecone/admin/admin.py:11`
- `pinecone/grpc/__init__.py:167`

The failure is deceptive: `import pinecone` and `from pinecone import Pinecone`
both succeed, but the crash only surfaces when `Pinecone(api_key=...)` is
first called.

## Fix

Extract `__version__` into `pinecone/_version.py` (single source of truth)
and redirect all three callsites to `from pinecone._version import __version__`.

Submodule imports resolve via `_NamespacePath` even when `__init__.py` is
not the active package root, so this import is robust to the namespace
package failure mode.

`pinecone/__init__.py` re-exports `__version__` from `_version.py` — no
behaviour change for normal installs.

Also adds `python-packages = ["pinecone"]` to `[tool.maturin]` to make
package inclusion explicit rather than relying on auto-discovery.

## Files changed

| File | Change |
|------|--------|
| `pinecone/_version.py` | New — `__version__ = "9.0.0"` |
| `pinecone/__init__.py` | Import from `_version` instead of hardcoding |
| `pinecone/_internal/http_client.py` | `from pinecone._version import __version__` |
| `pinecone/admin/admin.py` | Same |
| `pinecone/grpc/__init__.py` | Same |
| `pyproject.toml` | `python-packages = ["pinecone"]` |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to how `__version__` is defined/imported and a packaging config tweak; runtime behavior should be unchanged except avoiding ImportError in edge-case installs.
> 
> **Overview**
> Fixes a startup crash in certain Python 3.11/3.12 edge-case installs where `pinecone` can be resolved as a namespace package by moving `__version__` into a dedicated `pinecone/_version.py` module.
> 
> All internal callsites that used `from pinecone import __version__` (HTTP client, Admin client, and gRPC client) now import `__version__` from `pinecone._version`, while `pinecone/__init__.py` re-exports it for backward compatibility. Packaging is also tightened by explicitly listing `python-packages = ["pinecone"]` in the `maturin` config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23476836bd129eae6aabda3d8ea1cdf0a371913c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->