### PR TITLE
fix(ci): widen resolve-dev-version search window for quiet main

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -58,11 +58,14 @@ jobs:
           # uploaded a 'dev-version' artifact. The check-changes gate skips the
           # version job (and so the upload) when there are no new commits, but
           # such runs still complete as success — those must be ignored.
+          # Use a wide window (100 candidates ≈ ~4 days at hourly cadence) so a
+          # quiet main (no new commits for >10h) does not exhaust the window
+          # before finding a real publish run.
           mapfile -t candidates < <(gh run list \
             --workflow dev-publish.yml \
             --branch main \
             --status success \
-            --limit 10 \
+            --limit 100 \
             --json databaseId \
             --jq '.[].databaseId')
 


### PR DESCRIPTION
## Summary

- Increases `--limit` from 10 to 100 in the `resolve-dev-version` job's `gh run list` call
- At hourly cadence, 100 candidates covers ~4 days of quiet `main` (no new commits → check-changes skip → success without artifact)
- Fixes false-positive CI failures when `main` is quiet for >~10 hours

## Root cause

`resolve-dev-version` listed only the 10 most recent successful Dev Build & Publish runs. When `main` has had no new commits for >10 hours, all recent runs are no-op skips (check-changes gate completes as `success` without uploading a `dev-version` artifact). The resolver exhausted its 10-candidate window and errored as if the dev pipeline was broken. (CI-0061)

## Verification

Release Readiness run on this branch with `skip_integration=true`:
https://github.com/pinecone-io/python-sdk/actions/runs/25576424039

`Resolve latest dev wheel version` job completed successfully. All wheel build jobs green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow logic to scan more past successful runs, reducing false CI failures without touching product code.
> 
> **Overview**
> **Improves `release-readiness` robustness when `main` is quiet.** The `resolve-dev-version` step now searches a larger set of recent successful `dev-publish` runs (limit **10 → 100**) when looking for the `dev-version` artifact, and documents the rationale.
> 
> This prevents the workflow from failing when recent successful runs were no-op skips that didn’t upload the artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41c5c44cd0e76924ed3c55c1ffeca7f1d92f42a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->