### PR TITLE
fix(grpc): add GrpcIndex.create_namespace + fix namespace test races

### DIFF
--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -1429,6 +1429,57 @@ class GrpcIndex:
             else:
                 break
 
+    def create_namespace(
+        self,
+        *,
+        name: str,
+        schema: dict[str, Any] | None = None,
+        timeout: float | None = None,
+    ) -> NamespaceDescription:
+        """Create a named namespace in the index via gRPC.
+
+        Args:
+            name (str): Name for the new namespace (must be non-empty).
+            schema (dict[str, Any] | None): Optional schema configuration
+                with metadata field indexing settings.
+            timeout (float | None): Per-call timeout in seconds.
+
+        Returns:
+            :class:`NamespaceDescription` with the namespace name and record count.
+
+        Raises:
+            :exc:`ValidationError`: If the name is not a string or is empty/whitespace.
+        """
+        if not isinstance(name, str):
+            raise ValidationError("namespace name must be a string")
+        if not name or not name.strip():
+            raise ValidationError("namespace name must be a non-empty string")
+
+        logger.info("Creating namespace %r via gRPC", name)
+        result = self._channel.create_namespace(name, schema, timeout_s=timeout)
+
+        schema_obj: NamespaceSchema | None = None
+        raw_schema = result.get("schema")
+        if raw_schema is not None:
+            schema_obj = NamespaceSchema(
+                fields={
+                    k: NamespaceFieldConfig(filterable=v["filterable"])
+                    for k, v in raw_schema.get("fields", {}).items()
+                }
+            )
+
+        indexed_fields: IndexedFields | None = None
+        raw_indexed = result.get("indexed_fields")
+        if raw_indexed is not None:
+            indexed_fields = IndexedFields(fields=list(raw_indexed))
+
+        return NamespaceDescription(
+            name=result.get("name", ""),
+            record_count=result.get("record_count", 0),
+            schema=schema_obj,
+            indexed_fields=indexed_fields,
+        )
+
     def describe_namespace(
         self,
         *,

--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -117,6 +117,36 @@ def _dict_to_usage(data: dict[str, Any] | None) -> Usage | None:
     return Usage(read_units=data.get("read_units", 0))
 
 
+def _dict_to_namespace_description(data: dict[str, Any]) -> NamespaceDescription:
+    """Convert a GrpcChannel namespace dict to a NamespaceDescription model.
+
+    Shared by create_namespace, describe_namespace, and list_namespaces_paginated
+    to convert the dict payload returned by the Rust-backed GrpcChannel into a
+    typed NamespaceDescription, including optional schema and indexed_fields.
+    """
+    schema: NamespaceSchema | None = None
+    raw_schema = data.get("schema")
+    if raw_schema is not None:
+        schema = NamespaceSchema(
+            fields={
+                k: NamespaceFieldConfig(filterable=v["filterable"])
+                for k, v in raw_schema.get("fields", {}).items()
+            }
+        )
+
+    indexed_fields: IndexedFields | None = None
+    raw_indexed = data.get("indexed_fields")
+    if raw_indexed is not None:
+        indexed_fields = IndexedFields(fields=list(raw_indexed))
+
+    return NamespaceDescription(
+        name=data.get("name", ""),
+        record_count=data.get("record_count", 0),
+        schema=schema,
+        indexed_fields=indexed_fields,
+    )
+
+
 class GrpcIndex:
     """Synchronous gRPC data plane client targeting a specific Pinecone index.
 
@@ -1351,29 +1381,9 @@ class GrpcIndex:
             timeout_s=timeout,
         )
 
-        namespaces: list[NamespaceDescription] = []
-        for ns_data in result.get("namespaces", []):
-            schema: NamespaceSchema | None = None
-            raw_schema = ns_data.get("schema")
-            if raw_schema is not None:
-                schema = NamespaceSchema(
-                    fields={
-                        k: NamespaceFieldConfig(filterable=v["filterable"])
-                        for k, v in raw_schema.get("fields", {}).items()
-                    }
-                )
-            indexed_fields: IndexedFields | None = None
-            raw_indexed = ns_data.get("indexed_fields")
-            if raw_indexed is not None:
-                indexed_fields = IndexedFields(fields=list(raw_indexed))
-            namespaces.append(
-                NamespaceDescription(
-                    name=ns_data.get("name", ""),
-                    record_count=ns_data.get("record_count", 0),
-                    schema=schema,
-                    indexed_fields=indexed_fields,
-                )
-            )
+        namespaces = [
+            _dict_to_namespace_description(ns_data) for ns_data in result.get("namespaces", [])
+        ]
 
         pagination: Pagination | None = None
         raw_pag = result.get("pagination")
@@ -1457,28 +1467,7 @@ class GrpcIndex:
 
         logger.info("Creating namespace %r via gRPC", name)
         result = self._channel.create_namespace(name, schema, timeout_s=timeout)
-
-        schema_obj: NamespaceSchema | None = None
-        raw_schema = result.get("schema")
-        if raw_schema is not None:
-            schema_obj = NamespaceSchema(
-                fields={
-                    k: NamespaceFieldConfig(filterable=v["filterable"])
-                    for k, v in raw_schema.get("fields", {}).items()
-                }
-            )
-
-        indexed_fields: IndexedFields | None = None
-        raw_indexed = result.get("indexed_fields")
-        if raw_indexed is not None:
-            indexed_fields = IndexedFields(fields=list(raw_indexed))
-
-        return NamespaceDescription(
-            name=result.get("name", ""),
-            record_count=result.get("record_count", 0),
-            schema=schema_obj,
-            indexed_fields=indexed_fields,
-        )
+        return _dict_to_namespace_description(result)
 
     def describe_namespace(
         self,
@@ -1516,28 +1505,7 @@ class GrpcIndex:
 
         logger.info("Describing namespace %r via gRPC", effective)
         result = self._channel.describe_namespace(effective, timeout_s=timeout)
-
-        schema: NamespaceSchema | None = None
-        raw_schema = result.get("schema")
-        if raw_schema is not None:
-            schema = NamespaceSchema(
-                fields={
-                    k: NamespaceFieldConfig(filterable=v["filterable"])
-                    for k, v in raw_schema.get("fields", {}).items()
-                }
-            )
-
-        indexed_fields: IndexedFields | None = None
-        raw_indexed = result.get("indexed_fields")
-        if raw_indexed is not None:
-            indexed_fields = IndexedFields(fields=list(raw_indexed))
-
-        return NamespaceDescription(
-            name=result.get("name", ""),
-            record_count=result.get("record_count", 0),
-            schema=schema,
-            indexed_fields=indexed_fields,
-        )
+        return _dict_to_namespace_description(result)
 
     def delete_namespace(
         self,

--- a/pinecone/grpc/_protocol.py
+++ b/pinecone/grpc/_protocol.py
@@ -101,6 +101,16 @@ class GrpcChannelProtocol(Protocol):
         """Describe index statistics."""
         ...
 
+    def create_namespace(
+        self,
+        name: str,
+        schema: Mapping[str, Any] | None = None,
+        *,
+        timeout_s: float | None = None,
+    ) -> dict[str, Any]:
+        """Create a namespace."""
+        ...
+
     def describe_namespace(
         self,
         namespace: str,

--- a/tests/integration/test_data_plane.py
+++ b/tests/integration/test_data_plane.py
@@ -936,11 +936,14 @@ def test_namespace_crud_lifecycle_rest(client: Pinecone, shared_index_dim2: str)
     result = index.delete_namespace(name=ns_name)
     assert result is None  # unified-ns-0004
 
-    # 6. After deletion, namespace no longer appears in listing
-    post_delete = index.list_namespaces_paginated(prefix=f"{ns}-", limit=100)
+    # 6. After deletion, namespace no longer appears in listing (eventual consistency)
+    post_delete = poll_until(
+        query_fn=lambda: index.list_namespaces_paginated(prefix=f"{ns}-", limit=100),
+        check_fn=lambda r: ns_name not in [ns_item.name for ns_item in r.namespaces],
+        timeout=60,
+        description=f"namespace {ns_name} removed from listing after delete",
+    )
     assert isinstance(post_delete, ListNamespacesResponse)
-    post_names = [ns_item.name for ns_item in post_delete.namespaces]
-    assert ns_name not in post_names
 
 
 # ---------------------------------------------------------------------------
@@ -970,27 +973,38 @@ def test_namespace_crud_lifecycle_grpc(client: Pinecone, shared_index_dim2: str)
     assert created.name == ns_name
     assert created.record_count == 0  # unified-ns-0002
 
-    # 2. Describe namespace — returns same details
-    described = index.describe_namespace(name=ns_name)
+    # 2. Describe namespace — poll for eventual consistency after create
+    described = poll_until(
+        query_fn=lambda: index.describe_namespace(name=ns_name),
+        check_fn=lambda r: isinstance(r, NamespaceDescription),
+        timeout=60,
+        description=f"namespace {ns_name} visible after create via gRPC",
+    )
     assert isinstance(described, NamespaceDescription)
     assert described.name == ns_name
     assert isinstance(described.record_count, int)
 
     # 3. Namespace appears in list_namespaces_paginated with prefix match
-    list_resp = index.list_namespaces_paginated(prefix=f"{ns}-", limit=100)
+    list_resp = poll_until(
+        query_fn=lambda: index.list_namespaces_paginated(prefix=f"{ns}-", limit=100),
+        check_fn=lambda r: ns_name in [ns_item.name for ns_item in r.namespaces],
+        timeout=60,
+        description=f"namespace {ns_name} visible in listing after create via gRPC",
+    )
     assert isinstance(list_resp, ListNamespacesResponse)
-    ns_names = [ns_item.name for ns_item in list_resp.namespaces]
-    assert ns_name in ns_names
 
     # 4. Delete namespace — returns None on success (unified-ns-0004)
     result = index.delete_namespace(name=ns_name)
     assert result is None
 
-    # 5. After deletion, namespace no longer appears in listing
-    post_delete = index.list_namespaces_paginated(prefix=f"{ns}-", limit=100)
+    # 5. After deletion, namespace no longer appears in listing (eventual consistency)
+    post_delete = poll_until(
+        query_fn=lambda: index.list_namespaces_paginated(prefix=f"{ns}-", limit=100),
+        check_fn=lambda r: ns_name not in [ns_item.name for ns_item in r.namespaces],
+        timeout=60,
+        description=f"namespace {ns_name} removed from listing after delete via gRPC",
+    )
     assert isinstance(post_delete, ListNamespacesResponse)
-    post_names = [ns_item.name for ns_item in post_delete.namespaces]
-    assert ns_name not in post_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_data_plane_async.py
+++ b/tests/integration/test_data_plane_async.py
@@ -978,7 +978,13 @@ async def test_create_namespace_with_schema_async(
         assert created.record_count == 0  # new namespace has no vectors
 
         # describe_namespace returns the namespace as accessible (schema was accepted)
-        described = await idx.describe_namespace(name=ns_name)
+        # Poll for eventual consistency — backend may not expose the namespace immediately after create
+        described = await async_poll_until(
+            query_fn=lambda: idx.describe_namespace(name=ns_name),
+            check_fn=lambda r: isinstance(r, NamespaceDescription),
+            timeout=60,
+            description=f"namespace {ns_name} visible after create",
+        )
         assert isinstance(described, NamespaceDescription)
         assert described.name == ns_name
         assert isinstance(described.record_count, int)

--- a/tests/unit/grpc/test_grpc_index.py
+++ b/tests/unit/grpc/test_grpc_index.py
@@ -133,6 +133,77 @@ class TestGrpcDescribeNamespace:
         mock_channel.describe_namespace.assert_called_once_with("ns1", timeout_s=5.0)
 
 
+class TestGrpcCreateNamespace:
+    def test_grpc_create_namespace_routes_to_channel(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel.create_namespace.return_value = {
+            "name": "movies",
+            "record_count": 0,
+        }
+        idx = _make_grpc_index(mock_channel)
+
+        result = idx.create_namespace(name="movies")
+
+        mock_channel.create_namespace.assert_called_once_with("movies", None, timeout_s=None)
+        assert isinstance(result, NamespaceDescription)
+        assert result.name == "movies"
+        assert result.record_count == 0
+
+    def test_grpc_create_namespace_forwards_schema(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel.create_namespace.return_value = {
+            "name": "movies",
+            "record_count": 0,
+            "schema": {"fields": {"genre": {"filterable": True}}},
+        }
+        idx = _make_grpc_index(mock_channel)
+
+        schema = {"fields": {"genre": {"filterable": True}}}
+        result = idx.create_namespace(name="movies", schema=schema)
+
+        mock_channel.create_namespace.assert_called_once_with("movies", schema, timeout_s=None)
+        assert isinstance(result, NamespaceDescription)
+        assert result.schema is not None
+        assert result.schema.fields["genre"].filterable is True
+
+    def test_grpc_create_namespace_positional_name_raises(self) -> None:
+        mock_channel = MagicMock()
+        idx = _make_grpc_index(mock_channel)
+
+        with pytest.raises(TypeError):
+            idx.create_namespace("my-ns")  # type: ignore[misc]
+
+    def test_grpc_create_namespace_empty_name_raises(self) -> None:
+        from pinecone.errors.exceptions import ValidationError
+
+        mock_channel = MagicMock()
+        idx = _make_grpc_index(mock_channel)
+
+        with pytest.raises(ValidationError, match="non-empty"):
+            idx.create_namespace(name="")
+
+        with pytest.raises(ValidationError, match="non-empty"):
+            idx.create_namespace(name="   ")
+
+    def test_grpc_create_namespace_non_string_name_raises(self) -> None:
+        from pinecone.errors.exceptions import ValidationError
+
+        mock_channel = MagicMock()
+        idx = _make_grpc_index(mock_channel)
+
+        with pytest.raises(ValidationError, match="must be a string"):
+            idx.create_namespace(name=123)  # type: ignore[arg-type]
+
+    def test_grpc_create_namespace_passes_timeout(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel.create_namespace.return_value = {"name": "ns1", "record_count": 0}
+        idx = _make_grpc_index(mock_channel)
+
+        idx.create_namespace(name="ns1", timeout=4.5)
+
+        mock_channel.create_namespace.assert_called_once_with("ns1", None, timeout_s=4.5)
+
+
 class TestGrpcDeleteNamespace:
     def test_grpc_delete_namespace_returns_none(self) -> None:
         mock_channel = MagicMock()


### PR DESCRIPTION
## Summary

The release-readiness CI run [25869803451](https://github.com/pinecone-io/python-sdk/actions/runs/25869803451) failed on three namespace tests. This PR fixes all three.

1. **`test_namespace_crud_lifecycle_grpc`** — `GrpcIndex.create_namespace` didn't exist, even though the Rust transport (`rust/src/transport.rs:1292`) implements it. The recent commits adding `describe` / `delete` / `list_namespaces` to `GrpcIndex` (`bda17a1`, `48d6dde`, `3909094`, `3a039ce`) missed `create`, so the integration test couldn't even start. **Real product gap.**
2. **`test_namespace_crud_lifecycle_rest`** — asserted immediately after `delete_namespace` that the name was gone from `list_namespaces_paginated`. The backend is eventually consistent, so the listing intermittently still returned the namespace. **Test flake.**
3. **`test_create_namespace_with_schema_async`** — asserted immediately after `create_namespace` that `describe_namespace` would succeed. Same eventual-consistency race; the sync sibling at `test_data_plane.py:1713` already polls. **Test flake.**

## Changes

### Production

- **`pinecone/grpc/_protocol.py`** — added `create_namespace(name, schema, *, timeout_s)` to `GrpcChannelProtocol` so mypy can verify the call site.
- **`pinecone/grpc/__init__.py`** — added `GrpcIndex.create_namespace(*, name, schema=None, timeout=None)`, mirroring the keyword-only signature and validation of `Index.create_namespace`. Delegates to `self._channel.create_namespace(name, schema, timeout_s=timeout)` and converts the returned dict to a `NamespaceDescription`, with optional `schema` and `indexed_fields` parsing.

### Tests

- **`tests/unit/grpc/test_grpc_index.py`** — 6 new unit tests covering channel routing, schema forwarding, positional-name `TypeError`, empty / non-string name validation, and timeout forwarding.
- **`tests/integration/test_data_plane.py`** —
  - `test_namespace_crud_lifecycle_rest`: wrap the post-delete listing assertion in `poll_until`.
  - `test_namespace_crud_lifecycle_grpc`: exercises the new `create_namespace` and applies `poll_until` to the post-create describe / list and post-delete list assertions, matching the eventual-consistency pattern used elsewhere in the file.
- **`tests/integration/test_data_plane_async.py`** — `test_create_namespace_with_schema_async`: wrap the post-create `describe_namespace` in `async_poll_until`, matching the sync sibling.

## Test plan

- [x] `uv run pytest tests/unit/grpc/test_grpc_index.py -v` — 31 passed
- [x] `uv run pytest tests/unit/ -q` — 4406 passed, 30 skipped, 1 xfailed
- [x] `uv run mypy --strict pinecone/grpc/` — clean
- [x] `uv run ruff check && ruff format --check` — clean
- [ ] Release-readiness CI re-run after merge to confirm the three failing integration tests now pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `GrpcIndex.create_namespace` API and refactors shared namespace parsing used by multiple gRPC methods, which could affect namespace CRUD responses. Test changes are low risk but may mask real backend consistency issues if timeouts are too lenient/strict.
> 
> **Overview**
> Adds `GrpcIndex.create_namespace` (plus `GrpcChannelProtocol.create_namespace`) and centralizes dict-to-`NamespaceDescription` conversion in `_dict_to_namespace_description`, which is now reused by `create_namespace`, `describe_namespace`, and `list_namespaces_paginated`.
> 
> Updates integration tests to poll for eventual consistency after namespace create/delete (REST, gRPC, and async), and adds unit coverage ensuring `create_namespace` forwards `schema`/`timeout` and validates `name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25819d41a9f57f9857e10d91b0adb985c5bdd2d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->