### PR TITLE
fix: avoid bool-checking query namespace vectors

### DIFF
--- a/pinecone/async_client/async_index.py
+++ b/pinecone/async_client/async_index.py
@@ -625,7 +625,7 @@ class AsyncIndex:
         """
         if not namespaces:
             raise ValidationError("namespaces must be a non-empty list")
-        if not vector and not sparse_vector:
+        if (vector is None or len(vector) == 0) and not sparse_vector:
             raise ValidationError("at least one of 'vector' or 'sparse_vector' must be provided")
 
         valid_metrics = {"cosine", "euclidean", "dotproduct"}

--- a/pinecone/index/__init__.py
+++ b/pinecone/index/__init__.py
@@ -736,7 +736,7 @@ class Index:
         """
         if not namespaces:
             raise ValidationError("namespaces must be a non-empty list")
-        if not vector and not sparse_vector:
+        if (vector is None or len(vector) == 0) and not sparse_vector:
             raise ValidationError("at least one of 'vector' or 'sparse_vector' must be provided")
 
         valid_metrics = {"cosine", "euclidean", "dotproduct"}

--- a/tests/unit/test_async_query_namespaces.py
+++ b/tests/unit/test_async_query_namespaces.py
@@ -15,6 +15,20 @@ from pinecone.models.vectors.vector import ScoredVector
 INDEX_HOST = "test-index-abc1234.svc.us-east1-gcp.pinecone.io"
 
 
+class _BoolAmbiguousVector:
+    def __init__(self, values: list[float]) -> None:
+        self._values = values
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __getitem__(self, index: int) -> float:
+        return self._values[index]
+
+    def __bool__(self) -> bool:
+        raise ValueError("truth value is ambiguous")
+
+
 def _make_index() -> AsyncIndex:
     return AsyncIndex(host=INDEX_HOST, api_key="test-key")
 
@@ -102,6 +116,23 @@ class TestAsyncQueryNamespacesValidation:
                 namespaces=["ns1"],
                 metric="cosine",
             )
+
+    @pytest.mark.asyncio
+    async def test_query_namespaces_does_not_bool_check_vector(self) -> None:
+        idx = _make_index()
+        response = _make_query_response([_scored("v1", 0.9)])
+        vector = _BoolAmbiguousVector([0.1, 0.2])
+
+        mock_query = AsyncMock(return_value=response)
+        with patch.object(idx, "query", mock_query):
+            await idx.query_namespaces(
+                vector=vector,
+                namespaces=["ns1"],
+                metric="cosine",
+            )
+
+        assert mock_query.await_count == 1
+        assert mock_query.call_args.kwargs["vector"] is vector
 
     @pytest.mark.asyncio
     async def test_query_namespaces_invalid_metric_raises(self) -> None:

--- a/tests/unit/test_query_namespaces.py
+++ b/tests/unit/test_query_namespaces.py
@@ -16,6 +16,20 @@ from pinecone.models.vectors.vector import ScoredVector
 INDEX_HOST = "test-index-abc1234.svc.us-east1-gcp.pinecone.io"
 
 
+class _BoolAmbiguousVector:
+    def __init__(self, values: list[float]) -> None:
+        self._values = values
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __getitem__(self, index: int) -> float:
+        return self._values[index]
+
+    def __bool__(self) -> bool:
+        raise ValueError("truth value is ambiguous")
+
+
 def _make_index() -> Index:
     return Index(host=INDEX_HOST, api_key="test-key")
 
@@ -136,6 +150,21 @@ class TestQueryNamespacesValidation:
                 namespaces=["ns1"],
                 metric="cosine",
             )
+
+    def test_query_namespaces_does_not_bool_check_vector(self) -> None:
+        idx = _make_index()
+        response = _make_query_response([_scored("v1", 0.9)])
+        vector = _BoolAmbiguousVector([0.1, 0.2])
+
+        with patch.object(idx, "query", return_value=response) as mock_query:
+            idx.query_namespaces(
+                vector=vector,
+                namespaces=["ns1"],
+                metric="cosine",
+            )
+
+        assert mock_query.call_count == 1
+        assert mock_query.call_args.kwargs["vector"] is vector
 
     def test_query_namespaces_no_vector_no_sparse_raises(self) -> None:
         idx = _make_index()


### PR DESCRIPTION
## Summary
- avoid boolean-coercing dense vectors in sync and async `query_namespaces()` validation
- preserve existing empty-vector validation while allowing sequence-like vectors with ambiguous truth values
- add sync and async regression tests that assert vectors are passed through to `query()` unchanged

## Validation
- `uv run --no-sync pytest tests/unit/test_query_namespaces.py tests/unit/test_async_query_namespaces.py tests/unit/async_client/test_async_index_query_namespaces.py -q` (34 passed)
- `uv run --no-sync ruff check pinecone/index/__init__.py pinecone/async_client/async_index.py tests/unit/test_query_namespaces.py tests/unit/test_async_query_namespaces.py`
- `uv run --no-sync ruff format --check pinecone/index/__init__.py pinecone/async_client/async_index.py tests/unit/test_query_namespaces.py tests/unit/test_async_query_namespaces.py`
- `uv run --no-sync mypy --strict pinecone/index/__init__.py pinecone/async_client/async_index.py`
- `git diff --check`

Note: a full editable project build was not run locally because this machine does not have `protoc`; CI installs `protoc` before building the Rust extension.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small validation tweak in `query_namespaces()` to treat only `None`/empty dense vectors as missing while avoiding `__bool__` evaluation; covered by new sync/async regression tests.
> 
> **Overview**
> Fixes `Index.query_namespaces()` and `AsyncIndex.query_namespaces()` validation to **stop boolean-coercing** the provided dense `vector`, checking explicitly for `None` or `len(vector)==0` instead.
> 
> Adds sync and async unit tests using a sequence-like vector with an *ambiguous truth value* to ensure the vector is accepted and forwarded through to `query()` unchanged, while preserving the existing empty-vector error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e94fb9459c37100e91938152b69b2227649c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->