### PR TITLE
fix: support legacy search query bodies

### DIFF
--- a/pinecone/_internal/data_plane_helpers.py
+++ b/pinecone/_internal/data_plane_helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from pinecone._internal.config import normalize_host
@@ -58,6 +58,87 @@ def _normalize_search_vector_dict(vector: Mapping[str, Any]) -> dict[str, Any]:
     if "sparse_values" in vector:
         result["sparse_values"] = list(vector["sparse_values"])
     return result
+
+
+def _legacy_search_query_to_dict(query: Any) -> dict[str, Any]:
+    if hasattr(query, "to_dict") and callable(query.to_dict):
+        raw = query.to_dict()
+    elif hasattr(query, "as_dict") and callable(query.as_dict):
+        raw = query.as_dict()
+    else:
+        raw = dict(query)
+    return dict(raw)
+
+
+def _build_search_records_body(
+    *,
+    top_k: int | None,
+    inputs: Mapping[str, Any] | None,
+    vector: Sequence[float] | Mapping[str, Any] | None,
+    id: str | None,
+    filter: Mapping[str, Any] | None,
+    fields: Sequence[str] | None,
+    rerank: Mapping[str, Any] | None,
+    match_terms: Mapping[str, Any] | None,
+    query: Any | None,
+    wrap_dense_vector: bool = True,
+) -> dict[str, Any]:
+    if rerank is not None:
+        if "model" not in rerank:
+            raise ValidationError("rerank requires 'model' to be specified")
+        if "rank_fields" not in rerank:
+            raise ValidationError("rerank requires 'rank_fields' to be specified")
+
+    if query is not None:
+        if any(value is not None for value in (top_k, inputs, vector, id, filter, match_terms)):
+            raise ValidationError(
+                "query cannot be combined with top_k, inputs, vector, id, filter, or match_terms"
+            )
+        query_body = _legacy_search_query_to_dict(query)
+        if "vector" in query_body and query_body["vector"] is not None:
+            query_vector = query_body["vector"]
+            if isinstance(query_vector, Mapping):
+                query_body["vector"] = _normalize_search_vector_dict(query_vector)
+            else:
+                values = list(query_vector)
+                query_body["vector"] = {"values": values} if wrap_dense_vector else values
+    else:
+        if top_k is None:
+            raise ValidationError("top_k is required unless query is provided")
+        query_body = {"top_k": top_k}
+        if inputs is not None:
+            query_body["inputs"] = inputs
+        if vector is not None:
+            if isinstance(vector, Mapping):
+                query_body["vector"] = _normalize_search_vector_dict(vector)
+            else:
+                values = list(vector)
+                query_body["vector"] = {"values": values} if wrap_dense_vector else values
+        if id is not None:
+            query_body["id"] = id
+        if filter is not None:
+            query_body["filter"] = filter
+        if match_terms is not None:
+            query_body["match_terms"] = match_terms
+
+    top_k_value = query_body.get("top_k")
+    if not isinstance(top_k_value, int) or top_k_value < 1:
+        raise ValidationError(f"top_k must be a positive integer, got {top_k_value}")
+    if (
+        query_body.get("inputs") is None
+        and query_body.get("vector") is None
+        and query_body.get("id") is None
+    ):
+        raise ValidationError(
+            "At least one of inputs, vector, or id must be provided as a query source"
+        )
+
+    body: dict[str, Any] = {"query": query_body}
+    if fields is not None:
+        body["fields"] = fields
+    if rerank is not None:
+        body["rerank"] = rerank
+    return body
 
 
 def _vector_to_dict(v: Vector) -> dict[str, Any]:

--- a/pinecone/async_client/async_index.py
+++ b/pinecone/async_client/async_index.py
@@ -18,7 +18,7 @@ from pinecone._internal.batching import validate_batch_size
 from pinecone._internal.config import PineconeConfig
 from pinecone._internal.constants import DATA_PLANE_API_VERSION
 from pinecone._internal.data_plane_helpers import (
-    _normalize_search_vector_dict,
+    _build_search_records_body,
     _validate_host,
     _vector_to_dict,
 )
@@ -40,7 +40,12 @@ from pinecone.models.vectors.responses import (
     UpsertRecordsResponse,
     UpsertResponse,
 )
-from pinecone.models.vectors.search import RerankConfig, SearchInputs, SearchRecordsResponse
+from pinecone.models.vectors.search import (
+    RerankConfig,
+    SearchInputs,
+    SearchQuery,
+    SearchRecordsResponse,
+)
 from pinecone.models.vectors.sparse import SparseValues
 from pinecone.models.vectors.vector import Vector
 
@@ -926,7 +931,7 @@ class AsyncIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -934,6 +939,7 @@ class AsyncIndex:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Search records by text, vector, or ID with optional reranking.
@@ -967,6 +973,9 @@ class AsyncIndex:
                 ``"all"``) and ``"terms"`` (list of strings). Only supported
                 for sparse indexes using ``pinecone-sparse-english-v0``.
                 ``None`` disables term matching.
+            query (dict[str, Any] | None): Legacy query body containing
+                ``top_k`` plus one of ``inputs``, ``vector``, or ``id``. Prefer
+                passing these fields directly.
 
         Returns:
             :class:`SearchRecordsResponse` with hits and usage statistics.
@@ -995,40 +1004,19 @@ class AsyncIndex:
             raise ValidationError("namespace must be a string")
         if not namespace or not namespace.strip():
             raise ValidationError("namespace must be a non-empty string")
-        if top_k < 1:
-            raise ValidationError(f"top_k must be a positive integer, got {top_k}")
-        if rerank is not None:
-            if "model" not in rerank:
-                raise ValidationError("rerank requires 'model' to be specified")
-            if "rank_fields" not in rerank:
-                raise ValidationError("rerank requires 'rank_fields' to be specified")
-        if inputs is None and vector is None and id is None:
-            raise ValidationError(
-                "At least one of inputs, vector, or id must be provided as a query source"
-            )
+        body = _build_search_records_body(
+            top_k=top_k,
+            inputs=inputs,
+            vector=vector,
+            id=id,
+            filter=filter,
+            fields=fields,
+            rerank=rerank,
+            match_terms=match_terms,
+            query=query,
+        )
 
-        query_body: dict[str, Any] = {"top_k": top_k}
-        if inputs is not None:
-            query_body["inputs"] = inputs
-        if vector is not None:
-            if isinstance(vector, Mapping):
-                query_body["vector"] = _normalize_search_vector_dict(vector)
-            else:
-                query_body["vector"] = {"values": list(vector)}
-        if id is not None:
-            query_body["id"] = id
-        if filter is not None:
-            query_body["filter"] = filter
-        if match_terms is not None:
-            query_body["match_terms"] = match_terms
-
-        body: dict[str, Any] = {"query": query_body}
-        if fields is not None:
-            body["fields"] = fields
-        if rerank is not None:
-            body["rerank"] = rerank
-
-        logger.info("Searching namespace %r with top_k=%d", namespace, top_k)
+        logger.info("Searching namespace %r with top_k=%d", namespace, body["query"]["top_k"])
         response = await self._http.post(
             f"/records/namespaces/{namespace}/search", timeout=timeout, json=body
         )
@@ -1040,7 +1028,7 @@ class AsyncIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -1048,6 +1036,7 @@ class AsyncIndex:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Alias for :meth:`search`.
@@ -1063,6 +1052,7 @@ class AsyncIndex:
             fields=fields,
             rerank=rerank,
             match_terms=match_terms,
+            query=query,
             timeout=timeout,
         )
 

--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -17,7 +17,7 @@ from pinecone._internal.batch import batch_execute
 from pinecone._internal.batching import chunked, validate_batch_size, with_progress
 from pinecone._internal.config import PineconeConfig
 from pinecone._internal.constants import DATA_PLANE_API_VERSION
-from pinecone._internal.data_plane_helpers import _validate_host
+from pinecone._internal.data_plane_helpers import _build_search_records_body, _validate_host
 from pinecone._internal.validation import require_in_range
 from pinecone._internal.vector_factory import VectorFactory
 from pinecone.errors.exceptions import (
@@ -45,7 +45,12 @@ from pinecone.models.vectors.responses import (
     UpsertRecordsResponse,
     UpsertResponse,
 )
-from pinecone.models.vectors.search import RerankConfig, SearchInputs, SearchRecordsResponse
+from pinecone.models.vectors.search import (
+    RerankConfig,
+    SearchInputs,
+    SearchQuery,
+    SearchRecordsResponse,
+)
 from pinecone.models.vectors.sparse import SparseValues
 from pinecone.models.vectors.usage import Usage
 from pinecone.models.vectors.vector import ScoredVector, Vector
@@ -1196,14 +1201,15 @@ class GrpcIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
-        vector: Sequence[float] | None = None,
+        vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
         filter: Mapping[str, Any] | None = None,
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Search records by text, vector, or ID with optional reranking.
@@ -1234,6 +1240,9 @@ class GrpcIndex:
                 ``"all"``) and ``"terms"`` (list of strings). Only supported
                 for sparse indexes using ``pinecone-sparse-english-v0``.
                 ``None`` disables term matching.
+            query (dict[str, Any] | None): Legacy query body containing
+                ``top_k`` plus one of ``inputs``, ``vector``, or ``id``. Prefer
+                passing these fields directly.
 
         Returns:
             :class:`SearchRecordsResponse` with hits and usage statistics.
@@ -1284,37 +1293,24 @@ class GrpcIndex:
             raise ValidationError("namespace must be a string")
         if not namespace or not namespace.strip():
             raise ValidationError("namespace must be a non-empty string")
-        if top_k < 1:
-            raise ValidationError(f"top_k must be a positive integer, got {top_k}")
-        if rerank is not None:
-            if "model" not in rerank:
-                raise ValidationError("rerank requires 'model' to be specified")
-            if "rank_fields" not in rerank:
-                raise ValidationError("rerank requires 'rank_fields' to be specified")
-        if inputs is None and vector is None and id is None:
-            raise ValidationError(
-                "At least one of inputs, vector, or id must be provided as a query source"
-            )
+        body = _build_search_records_body(
+            top_k=top_k,
+            inputs=inputs,
+            vector=vector,
+            id=id,
+            filter=filter,
+            fields=fields,
+            rerank=rerank,
+            match_terms=match_terms,
+            query=query,
+            wrap_dense_vector=False,
+        )
 
-        query_body: dict[str, Any] = {"top_k": top_k}
-        if inputs is not None:
-            query_body["inputs"] = inputs
-        if vector is not None:
-            query_body["vector"] = vector
-        if id is not None:
-            query_body["id"] = id
-        if filter is not None:
-            query_body["filter"] = filter
-        if match_terms is not None:
-            query_body["match_terms"] = match_terms
-
-        body: dict[str, Any] = {"query": query_body}
-        if fields is not None:
-            body["fields"] = fields
-        if rerank is not None:
-            body["rerank"] = rerank
-
-        logger.info("Searching namespace %r with top_k=%d (via REST)", namespace, top_k)
+        logger.info(
+            "Searching namespace %r with top_k=%d (via REST)",
+            namespace,
+            body["query"]["top_k"],
+        )
         response = self._http.post(
             f"/records/namespaces/{namespace}/search", timeout=timeout, json=body
         )
@@ -1326,14 +1322,15 @@ class GrpcIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
-        vector: Sequence[float] | None = None,
+        vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
         filter: Mapping[str, Any] | None = None,
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Alias for :meth:`search`.
@@ -1350,6 +1347,7 @@ class GrpcIndex:
             fields=fields,
             rerank=rerank,
             match_terms=match_terms,
+            query=query,
             timeout=timeout,
         )
 

--- a/pinecone/index/__init__.py
+++ b/pinecone/index/__init__.py
@@ -18,7 +18,7 @@ from pinecone._internal.batching import validate_batch_size
 from pinecone._internal.config import PineconeConfig
 from pinecone._internal.constants import DATA_PLANE_API_VERSION
 from pinecone._internal.data_plane_helpers import (
-    _normalize_search_vector_dict,
+    _build_search_records_body,
     _validate_host,
     _vector_to_dict,
 )
@@ -40,7 +40,12 @@ from pinecone.models.vectors.responses import (
     UpsertRecordsResponse,
     UpsertResponse,
 )
-from pinecone.models.vectors.search import RerankConfig, SearchInputs, SearchRecordsResponse
+from pinecone.models.vectors.search import (
+    RerankConfig,
+    SearchInputs,
+    SearchQuery,
+    SearchRecordsResponse,
+)
 from pinecone.models.vectors.sparse import SparseValues
 from pinecone.models.vectors.vector import Vector
 
@@ -1092,7 +1097,7 @@ class Index:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -1100,6 +1105,7 @@ class Index:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Search records by text, vector, or ID with optional reranking.
@@ -1137,6 +1143,9 @@ class Index:
                 ``"all"``) and ``"terms"`` (list of strings). Only supported
                 for sparse indexes using ``pinecone-sparse-english-v0``.
                 ``None`` disables term matching.
+            query (dict[str, Any] | None): Legacy query body containing
+                ``top_k`` plus one of ``inputs``, ``vector``, or ``id``. Prefer
+                passing these fields directly.
 
         Returns:
             :class:`SearchRecordsResponse` with hits and usage statistics.
@@ -1184,40 +1193,19 @@ class Index:
             raise ValidationError("namespace must be a string")
         if not namespace or not namespace.strip():
             raise ValidationError("namespace must be a non-empty string")
-        if top_k < 1:
-            raise ValidationError(f"top_k must be a positive integer, got {top_k}")
-        if rerank is not None:
-            if "model" not in rerank:
-                raise ValidationError("rerank requires 'model' to be specified")
-            if "rank_fields" not in rerank:
-                raise ValidationError("rerank requires 'rank_fields' to be specified")
-        if inputs is None and vector is None and id is None:
-            raise ValidationError(
-                "At least one of inputs, vector, or id must be provided as a query source"
-            )
+        body = _build_search_records_body(
+            top_k=top_k,
+            inputs=inputs,
+            vector=vector,
+            id=id,
+            filter=filter,
+            fields=fields,
+            rerank=rerank,
+            match_terms=match_terms,
+            query=query,
+        )
 
-        query_body: dict[str, Any] = {"top_k": top_k}
-        if inputs is not None:
-            query_body["inputs"] = inputs
-        if vector is not None:
-            if isinstance(vector, Mapping):
-                query_body["vector"] = _normalize_search_vector_dict(vector)
-            else:
-                query_body["vector"] = {"values": list(vector)}
-        if id is not None:
-            query_body["id"] = id
-        if filter is not None:
-            query_body["filter"] = filter
-        if match_terms is not None:
-            query_body["match_terms"] = match_terms
-
-        body: dict[str, Any] = {"query": query_body}
-        if fields is not None:
-            body["fields"] = fields
-        if rerank is not None:
-            body["rerank"] = rerank
-
-        logger.info("Searching namespace %r with top_k=%d", namespace, top_k)
+        logger.info("Searching namespace %r with top_k=%d", namespace, body["query"]["top_k"])
         response = self._http.post(
             f"/records/namespaces/{namespace}/search", timeout=timeout, json=body
         )
@@ -1229,7 +1217,7 @@ class Index:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -1237,6 +1225,7 @@ class Index:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Alias for :meth:`search`.
@@ -1253,6 +1242,7 @@ class Index:
             fields=fields,
             rerank=rerank,
             match_terms=match_terms,
+            query=query,
             timeout=timeout,
         )
 

--- a/tests/unit/test_async_search.py
+++ b/tests/unit/test_async_search.py
@@ -115,6 +115,36 @@ class TestAsyncSearch:
 
     @respx.mock
     @pytest.mark.anyio
+    async def test_async_search_accepts_legacy_query_body(self) -> None:
+        route = respx.post(SEARCH_URL_NS).mock(
+            return_value=httpx.Response(200, json=SEARCH_RESPONSE),
+        )
+        idx = _make_async_index()
+        query = {
+            "inputs": {"text": "hello"},
+            "top_k": 10,
+            "filter": {"genre": {"$eq": "sci-fi"}},
+        }
+        await idx.search(namespace="test-ns", query=query, fields=["chunk_text", "title"])
+
+        import orjson
+
+        body = orjson.loads(route.calls.last.request.content)
+        assert body["query"] == query
+        assert body["fields"] == ["chunk_text", "title"]
+
+    @pytest.mark.anyio
+    async def test_async_search_query_body_cannot_mix_direct_query_params(self) -> None:
+        idx = _make_async_index()
+        with pytest.raises(ValidationError, match="query cannot be combined"):
+            await idx.search(
+                namespace="test-ns",
+                query={"inputs": {"text": "hello"}, "top_k": 10},
+                top_k=10,
+            )
+
+    @respx.mock
+    @pytest.mark.anyio
     async def test_async_search_with_rerank(self) -> None:
         route = respx.post(SEARCH_URL_NS).mock(
             return_value=httpx.Response(200, json=SEARCH_RESPONSE),

--- a/tests/unit/test_async_search_records_alias.py
+++ b/tests/unit/test_async_search_records_alias.py
@@ -28,6 +28,7 @@ async def test_search_records_delegates_to_search() -> None:
             fields=None,
             rerank=None,
             match_terms=None,
+            query=None,
             timeout=None,
         )
 
@@ -60,6 +61,7 @@ async def test_search_records_passes_all_params() -> None:
         "fields": ["title", "year"],
         "rerank": {"model": "bge-reranker-v2-m3", "rank_fields": ["text"]},
         "match_terms": {"strategy": "all", "terms": ["animal", "duck"]},
+        "query": None,
         "timeout": None,
     }
 

--- a/tests/unit/test_grpc_index.py
+++ b/tests/unit/test_grpc_index.py
@@ -1212,6 +1212,21 @@ class TestGrpcIndexSearch:
         assert "fields" not in body["query"]
 
     @respx.mock
+    def test_search_accepts_legacy_query_body(self, mock_channel: MagicMock) -> None:
+        import orjson
+
+        route = respx.post(_SEARCH_URL).mock(
+            return_value=httpx.Response(200, json=_SEARCH_RESPONSE)
+        )
+        idx = _make_grpc_index(mock_channel, host=_INDEX_HOST)
+        query = {"inputs": {"text": "q"}, "top_k": 5, "filter": {"topic": {"$eq": "ai"}}}
+        idx.search(namespace="test-ns", query=query, fields=["text", "title"])
+
+        body = orjson.loads(route.calls.last.request.content)
+        assert body["query"] == query
+        assert body["fields"] == ["text", "title"]
+
+    @respx.mock
     def test_search_records_alias(self, mock_channel: MagicMock) -> None:
         """search_records() is an alias for search() and produces the same result."""
         respx.post(_SEARCH_URL).mock(return_value=httpx.Response(200, json=_SEARCH_RESPONSE))

--- a/tests/unit/test_index_search.py
+++ b/tests/unit/test_index_search.py
@@ -109,6 +109,34 @@ class TestSearch:
         assert body["fields"] == ["chunk_text", "title"]
 
     @respx.mock
+    def test_search_accepts_legacy_query_body(self) -> None:
+        route = respx.post(SEARCH_URL_NS).mock(
+            return_value=httpx.Response(200, json=SEARCH_RESPONSE),
+        )
+        idx = _make_index()
+        query = {
+            "inputs": {"text": "hello"},
+            "top_k": 10,
+            "filter": {"genre": {"$eq": "sci-fi"}},
+        }
+        idx.search(namespace="test-ns", query=query, fields=["chunk_text", "title"])
+
+        import orjson
+
+        body = orjson.loads(route.calls.last.request.content)
+        assert body["query"] == query
+        assert body["fields"] == ["chunk_text", "title"]
+
+    def test_search_query_body_cannot_mix_direct_query_params(self) -> None:
+        idx = _make_index()
+        with pytest.raises(ValidationError, match="query cannot be combined"):
+            idx.search(
+                namespace="test-ns",
+                query={"inputs": {"text": "hello"}, "top_k": 10},
+                top_k=10,
+            )
+
+    @respx.mock
     def test_search_with_rerank(self) -> None:
         route = respx.post(SEARCH_URL_NS).mock(
             return_value=httpx.Response(200, json=SEARCH_RESPONSE),

--- a/tests/unit/test_search_records_alias.py
+++ b/tests/unit/test_search_records_alias.py
@@ -46,6 +46,7 @@ class TestSearchRecordsAlias:
                 fields=None,
                 rerank=None,
                 match_terms=None,
+                query=None,
                 timeout=None,
             )
 
@@ -69,6 +70,7 @@ class TestSearchRecordsAlias:
             "fields": ["title", "genre"],
             "rerank": {"model": "bge-reranker", "rank_fields": ["text"]},
             "match_terms": {"strategy": "all", "terms": ["animal", "duck"]},
+            "query": None,
             "timeout": None,
         }
         with patch.object(idx, "search", return_value=expected) as mock_search:


### PR DESCRIPTION
## Summary
- add a legacy `query` request-body parameter to sync, async, and gRPC-backed `search()` / `search_records()`
- share search request-body validation while preserving existing dense-vector wire shapes
- add regression coverage for the reported `search(namespace=..., query={...}, fields=[...])` call shape

Fixes #661.

## Validation
- `uv sync --dev --no-install-project`
- `uv run --no-sync pytest tests/unit/test_index_search.py tests/unit/test_async_search.py tests/unit/test_grpc_index.py tests/unit/test_search_records_alias.py tests/unit/test_async_search_records_alias.py -q` (142 passed)
- `uv run --no-sync pytest tests/unit/test_client_timeout_parity.py tests/unit/test_backcompat_search_shims.py tests/unit/test_response_info_populated.py tests/unit/test_async_response_info.py -q` (75 passed)
- `uv run --no-sync ruff check pinecone/_internal/data_plane_helpers.py pinecone/index/__init__.py pinecone/async_client/async_index.py pinecone/grpc/__init__.py tests/unit/test_index_search.py tests/unit/test_async_search.py tests/unit/test_grpc_index.py tests/unit/test_search_records_alias.py tests/unit/test_async_search_records_alias.py`
- `uv run --no-sync ruff format --check pinecone/_internal/data_plane_helpers.py pinecone/index/__init__.py pinecone/async_client/async_index.py pinecone/grpc/__init__.py tests/unit/test_index_search.py tests/unit/test_async_search.py tests/unit/test_grpc_index.py tests/unit/test_search_records_alias.py tests/unit/test_async_search_records_alias.py`
- `uv run --no-sync mypy --strict pinecone/_internal/data_plane_helpers.py pinecone/index/__init__.py pinecone/async_client/async_index.py pinecone/grpc/__init__.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public `search()`/`search_records()` request building across sync, async, and gRPC clients, so regressions could affect search request shapes and validation. Risk is mitigated by added unit coverage for legacy `query` usage and param-mixing errors.
> 
> **Overview**
> Adds support for passing a legacy `query` request-body object to `search()`/`search_records()` across the sync `Index`, `AsyncIndex`, and REST-backed `GrpcIndex` search APIs.
> 
> Centralizes search request-body construction/validation in `_build_search_records_body`, including mutual-exclusion rules (`query` vs direct params), `top_k`/source validation, rerank required keys checks, and consistent normalization of dense vs sparse/hybrid vector shapes (with a gRPC-specific option to preserve the existing dense-vector wire format).
> 
> Extends unit tests to cover legacy `query` passthrough, rejection of mixed `query`+direct params, and updated alias forwarding to include the new `query` argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc0678153567badc889001f659a59af60a47cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->