### PR TITLE
fix: honor IndexAsyncio config overrides

### DIFF
--- a/pinecone/_client.py
+++ b/pinecone/_client.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any, cast
 
 from pinecone._internal.config import PineconeConfig, RetryConfig
 from pinecone._internal.constants import CONTROL_PLANE_API_VERSION, DEFAULT_BASE_URL
-from pinecone._internal.indexes_helpers import _LegacyIndexKwargs, poll_index_until_ready
+from pinecone._internal.indexes_helpers import (
+    IndexKwargs,
+    _LegacyIndexKwargs,
+    apply_index_kwargs_overrides,
+    poll_index_until_ready,
+)
 from pinecone._internal.validation import require_non_empty
 from pinecone.errors.exceptions import ValidationError
 
@@ -874,7 +879,7 @@ class Pinecone:
         """
         from pinecone.async_client.async_index import AsyncIndex as _AsyncIndex
 
-        return _AsyncIndex(
+        index_kwargs = IndexKwargs(
             host=host,
             api_key=self._config.api_key,
             additional_headers=dict(self._config.additional_headers),
@@ -886,6 +891,10 @@ class Pinecone:
             source_tag=self._config.source_tag,
             connection_pool_maxsize=self._config.connection_pool_maxsize,
         )
+        index_kwargs = apply_index_kwargs_overrides(
+            index_kwargs, kwargs, caller="Pinecone.IndexAsyncio()"
+        )
+        return _AsyncIndex(**index_kwargs)
 
     def close(self) -> None:
         """Close all open HTTP connections.

--- a/pinecone/_internal/indexes_helpers.py
+++ b/pinecone/_internal/indexes_helpers.py
@@ -60,6 +60,34 @@ class _LegacyIndexKwargs(IndexKwargs):
     pool_threads: NotRequired[int]
 
 
+_INDEX_KWARG_KEYS = frozenset(IndexKwargs.__annotations__)
+
+
+def apply_index_kwargs_overrides(
+    base: IndexKwargs, overrides: Mapping[str, Any], *, caller: str
+) -> IndexKwargs:
+    """Apply explicit data-plane client kwargs to factory defaults."""
+    allowed = _INDEX_KWARG_KEYS - {"host"}
+    unexpected = sorted(set(overrides) - allowed)
+    if unexpected:
+        raise TypeError(f"{caller} got unexpected keyword arguments: {unexpected!r}")
+
+    return IndexKwargs(
+        host=base["host"],
+        api_key=overrides.get("api_key", base["api_key"]),
+        additional_headers=dict(overrides.get("additional_headers", base["additional_headers"])),
+        timeout=overrides.get("timeout", base["timeout"]),
+        proxy_url=overrides.get("proxy_url", base["proxy_url"]),
+        proxy_headers=dict(overrides.get("proxy_headers", base["proxy_headers"])),
+        ssl_ca_certs=overrides.get("ssl_ca_certs", base["ssl_ca_certs"]),
+        ssl_verify=overrides.get("ssl_verify", base["ssl_verify"]),
+        source_tag=overrides.get("source_tag", base["source_tag"]),
+        connection_pool_maxsize=overrides.get(
+            "connection_pool_maxsize", base["connection_pool_maxsize"]
+        ),
+    )
+
+
 def resolve_enum_value(value: Any) -> Any:
     """Extract ``.value`` from enum-like objects, pass through otherwise."""
     return value.value if hasattr(value, "value") else value

--- a/pinecone/async_client/pinecone.py
+++ b/pinecone/async_client/pinecone.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 
 from pinecone._internal.config import PineconeConfig, RetryConfig
 from pinecone._internal.constants import CONTROL_PLANE_API_VERSION, DEFAULT_BASE_URL
-from pinecone._internal.indexes_helpers import IndexKwargs, async_poll_index_until_ready
+from pinecone._internal.indexes_helpers import (
+    IndexKwargs,
+    apply_index_kwargs_overrides,
+    async_poll_index_until_ready,
+)
 from pinecone._internal.validation import require_non_empty
 from pinecone.errors.exceptions import ValidationError
 
@@ -750,7 +754,7 @@ class AsyncPinecone:
         """
         from pinecone.async_client.async_index import AsyncIndex as _AsyncIndex
 
-        return _AsyncIndex(
+        index_kwargs = IndexKwargs(
             host=host,
             api_key=self._config.api_key,
             additional_headers=dict(self._config.additional_headers),
@@ -762,6 +766,10 @@ class AsyncPinecone:
             source_tag=self._config.source_tag,
             connection_pool_maxsize=self._config.connection_pool_maxsize,
         )
+        index_kwargs = apply_index_kwargs_overrides(
+            index_kwargs, kwargs, caller="AsyncPinecone.IndexAsyncio()"
+        )
+        return _AsyncIndex(**index_kwargs)
 
     def _build_index_kwargs(self, host: str) -> IndexKwargs:
         """Return the kwargs dict for constructing an AsyncIndex."""

--- a/tests/unit/test_async_pinecone_backcompat.py
+++ b/tests/unit/test_async_pinecone_backcompat.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from pinecone.async_client.pinecone import AsyncPinecone
 from pinecone.inference.models.index_embed import IndexEmbed
 from pinecone.models.enums import CloudProvider
@@ -331,6 +333,22 @@ def test_async_index_asyncio_delegate_returns_async_index() -> None:
     pc = AsyncPinecone(api_key="test-key")
     idx = pc.IndexAsyncio(host="my-index.svc.pinecone.io")
     assert isinstance(idx, AsyncIndex)
+
+
+def test_async_index_asyncio_delegate_forwards_explicit_ssl_verify() -> None:
+    from unittest.mock import patch
+
+    pc = AsyncPinecone(api_key="test-key", ssl_verify=True)
+    with patch("pinecone.async_client.async_index.AsyncIndex") as mock_async_index:
+        pc.IndexAsyncio(host="my-index.svc.pinecone.io", ssl_verify=False)
+    _, kwargs = mock_async_index.call_args
+    assert kwargs["ssl_verify"] is False
+
+
+def test_async_index_asyncio_delegate_rejects_unknown_kwargs() -> None:
+    pc = AsyncPinecone(api_key="test-key")
+    with pytest.raises(TypeError, match="unexpected keyword arguments"):
+        pc.IndexAsyncio(host="my-index.svc.pinecone.io", bogus=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pinecone_class.py
+++ b/tests/unit/test_pinecone_class.py
@@ -470,6 +470,18 @@ class TestPineconeIndexAsyncioDelegate:
         _, kwargs = mock_async_index.call_args
         assert kwargs["host"] == "my-index.svc.pinecone.io"
 
+    def test_forwards_explicit_ssl_verify(self) -> None:
+        pc = Pinecone(api_key="test-key", ssl_verify=True)
+        with patch("pinecone.async_client.async_index.AsyncIndex") as mock_async_index:
+            pc.IndexAsyncio(host="my-index.svc.pinecone.io", ssl_verify=False)
+        _, kwargs = mock_async_index.call_args
+        assert kwargs["ssl_verify"] is False
+
+    def test_rejects_unknown_kwargs(self) -> None:
+        pc = Pinecone(api_key="test-key")
+        with pytest.raises(TypeError, match="unexpected keyword arguments"):
+            pc.IndexAsyncio(host="my-index.svc.pinecone.io", bogus=True)
+
 
 # ---------------------------------------------------------------------------
 # Lazy namespace property first-access and caching


### PR DESCRIPTION
## Root cause

`Pinecone.IndexAsyncio(...)` and `AsyncPinecone.IndexAsyncio(...)` accepted `**kwargs`, but the compatibility factories ignored those values when constructing `AsyncIndex`. As a result, calls such as `pc.IndexAsyncio(host=..., ssl_verify=False)` still used the parent client's default `ssl_verify=True`, which blocks proxy/local setups that need certificate verification disabled.

## Change

- Build the AsyncIndex constructor kwargs from the parent client defaults and overlay explicit supported data-plane kwargs.
- Reject unknown kwargs instead of silently ignoring them.
- Add regression coverage for both sync and async compatibility factories forwarding `ssl_verify=False`.

## Validation

- `uv sync --group dev --no-install-project`
- `PYTHONPATH=. .venv/bin/python -m pytest tests/unit/test_pinecone_class.py::TestPineconeIndexAsyncioDelegate tests/unit/test_async_pinecone_backcompat.py -q` (35 passed, 1 pytest config warning because `pytest-timeout` was not installed by the no-project source-tree run)
- `PYTHONPATH=. .venv/bin/python -m ruff check pinecone/_internal/indexes_helpers.py pinecone/_client.py pinecone/async_client/pinecone.py tests/unit/test_pinecone_class.py tests/unit/test_async_pinecone_backcompat.py`
- `PYTHONPATH=. .venv/bin/python -m ruff format --check pinecone/_internal/indexes_helpers.py pinecone/_client.py pinecone/async_client/pinecone.py tests/unit/test_pinecone_class.py tests/unit/test_async_pinecone_backcompat.py`
- `PYTHONPATH=. .venv/bin/python -m mypy --strict pinecone/_internal/indexes_helpers.py pinecone/_client.py pinecone/async_client/pinecone.py`

Note: I initially tried `uv run pytest ...`, but stopped it after it spent roughly 12 minutes compiling the native Rust extension through maturin before reaching pytest. The final checks above run from the source tree to keep validation focused on this Python-only compatibility change.

Fixes #465.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior of the `IndexAsyncio` backcompat factories to apply/validate kwargs, which could break callers that previously passed (and had ignored) unsupported parameters. Limited to client construction-time configuration, with added unit coverage for the new semantics.
> 
> **Overview**
> Fixes the backcompat `IndexAsyncio` factories on both `Pinecone` and `AsyncPinecone` to **actually honor explicit data-plane overrides** (e.g. `ssl_verify=False`) instead of always using parent-client defaults.
> 
> Introduces `apply_index_kwargs_overrides()` in `indexes_helpers` to merge supported overrides and **raise `TypeError` on unknown kwargs** (rather than silently ignoring them), and adds regression tests covering override forwarding and unknown-kwarg rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86bee16d3b5ba4bea72a0d2ff43672636034da77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->