### PR TITLE
feat(backcompat): accept legacy query= kwarg on search/search_records (sync, async, gRPC)

### DIFF
--- a/pinecone/_legacy/search_query_kwarg.py
+++ b/pinecone/_legacy/search_query_kwarg.py
@@ -1,0 +1,97 @@
+"""Backcompat shim for the legacy v8 ``query=SearchQuery(...)`` kwarg on
+``Index.search`` / ``AsyncIndex.search`` / ``GrpcIndex.search`` (and their
+``search_records`` aliases).
+
+In v8 the search methods took a single ``query: SearchQuery | dict`` wrapper
+parameter; v9 flattened that into top-level kwargs (``top_k``, ``inputs``,
+``vector``, ``id``, ``filter``, ``match_terms``). This helper restores the
+wrapper form for migrating callers, with a ``DeprecationWarning``.
+
+:meta private:
+"""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from pinecone.models.vectors.search import SearchQuery
+
+_LEGACY_QUERY_FIELDS = ("inputs", "top_k", "vector", "id", "filter", "match_terms")
+
+
+def unpack_legacy_query(
+    *,
+    method_name: str,
+    query: SearchQuery | Mapping[str, Any] | None,
+    top_k: int | None,
+    inputs: Any,
+    vector: Sequence[float] | Mapping[str, Any] | None,
+    id: str | None,
+    filter: Mapping[str, Any] | None,
+    match_terms: Mapping[str, Any] | None,
+) -> tuple[
+    int | None,
+    Any,
+    Sequence[float] | Mapping[str, Any] | None,
+    str | None,
+    Mapping[str, Any] | None,
+    Mapping[str, Any] | None,
+]:
+    """If *query* is provided, unpack it into the flat kwargs and warn.
+
+    Returns the (possibly rewritten) tuple
+    ``(top_k, inputs, vector, id, filter, match_terms)``.
+
+    Raises:
+        TypeError: if *query* is provided together with any of the flat
+            kwargs (ambiguous call).
+    """
+    if query is None:
+        return top_k, inputs, vector, id, filter, match_terms
+
+    already_set = [
+        name
+        for name, value in (
+            ("top_k", top_k),
+            ("inputs", inputs),
+            ("vector", vector),
+            ("id", id),
+            ("filter", filter),
+            ("match_terms", match_terms),
+        )
+        if value is not None
+    ]
+    if already_set:
+        raise TypeError(
+            f"{method_name}() received both 'query=' and "
+            f"{already_set!r}. Pass either the legacy 'query=SearchQuery(...)' "
+            "form OR the new flat keyword arguments, not both."
+        )
+
+    warnings.warn(
+        f"Passing 'query=SearchQuery(...)' to {method_name}() is a v8 "
+        "compatibility shim. Pass top_k, inputs, vector, id, filter, and "
+        "match_terms as separate keyword arguments instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+    if isinstance(query, SearchQuery):
+        unpacked = {name: getattr(query, name) for name in _LEGACY_QUERY_FIELDS}
+    elif isinstance(query, Mapping):
+        unpacked = {name: query.get(name) for name in _LEGACY_QUERY_FIELDS}
+    else:
+        raise TypeError(
+            f"{method_name}() 'query=' must be a SearchQuery or Mapping, got {type(query).__name__}"
+        )
+
+    return (
+        unpacked["top_k"],
+        unpacked["inputs"],
+        unpacked["vector"],
+        unpacked["id"],
+        unpacked["filter"],
+        unpacked["match_terms"],
+    )

--- a/pinecone/async_client/async_index.py
+++ b/pinecone/async_client/async_index.py
@@ -40,7 +40,12 @@ from pinecone.models.vectors.responses import (
     UpsertRecordsResponse,
     UpsertResponse,
 )
-from pinecone.models.vectors.search import RerankConfig, SearchInputs, SearchRecordsResponse
+from pinecone.models.vectors.search import (
+    RerankConfig,
+    SearchInputs,
+    SearchQuery,
+    SearchRecordsResponse,
+)
 from pinecone.models.vectors.sparse import SparseValues
 from pinecone.models.vectors.vector import Vector
 
@@ -926,7 +931,7 @@ class AsyncIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -934,6 +939,7 @@ class AsyncIndex:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Search records by text, vector, or ID with optional reranking.
@@ -991,6 +997,23 @@ class AsyncIndex:
                 for hit in response.result.hits:
                     print(hit.id, hit.score)
         """
+        if query is not None:
+            from pinecone._legacy.search_query_kwarg import unpack_legacy_query
+
+            top_k, inputs, vector, id, filter, match_terms = unpack_legacy_query(
+                method_name="AsyncIndex.search",
+                query=query,
+                top_k=top_k,
+                inputs=inputs,
+                vector=vector,
+                id=id,
+                filter=filter,
+                match_terms=match_terms,
+            )
+        if top_k is None:
+            raise ValidationError(
+                "top_k is required (pass top_k=... or use the legacy query=SearchQuery(...) form)"
+            )
         if not isinstance(namespace, str):
             raise ValidationError("namespace must be a string")
         if not namespace or not namespace.strip():
@@ -1040,7 +1063,7 @@ class AsyncIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -1048,11 +1071,25 @@ class AsyncIndex:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Alias for :meth:`search`.
 
         Prefer calling :meth:`search` directly — this alias exists for backwards compatibility."""
+        if query is not None:
+            from pinecone._legacy.search_query_kwarg import unpack_legacy_query
+
+            top_k, inputs, vector, id, filter, match_terms = unpack_legacy_query(
+                method_name="AsyncIndex.search_records",
+                query=query,
+                top_k=top_k,
+                inputs=inputs,
+                vector=vector,
+                id=id,
+                filter=filter,
+                match_terms=match_terms,
+            )
         return await self.search(
             namespace=namespace,
             top_k=top_k,
@@ -1063,6 +1100,7 @@ class AsyncIndex:
             fields=fields,
             rerank=rerank,
             match_terms=match_terms,
+            query=None,
             timeout=timeout,
         )
 

--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -45,7 +45,12 @@ from pinecone.models.vectors.responses import (
     UpsertRecordsResponse,
     UpsertResponse,
 )
-from pinecone.models.vectors.search import RerankConfig, SearchInputs, SearchRecordsResponse
+from pinecone.models.vectors.search import (
+    RerankConfig,
+    SearchInputs,
+    SearchQuery,
+    SearchRecordsResponse,
+)
 from pinecone.models.vectors.sparse import SparseValues
 from pinecone.models.vectors.usage import Usage
 from pinecone.models.vectors.vector import ScoredVector, Vector
@@ -1196,7 +1201,7 @@ class GrpcIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | None = None,
         id: str | None = None,
@@ -1204,6 +1209,7 @@ class GrpcIndex:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Search records by text, vector, or ID with optional reranking.
@@ -1280,6 +1286,29 @@ class GrpcIndex:
            Use ``pc.inference.rerank()`` when reranking results from a different
            source or when you need to rerank without searching.
         """
+        if query is not None:
+            from pinecone._legacy.search_query_kwarg import unpack_legacy_query
+
+            top_k, inputs, vector, id, filter, match_terms = unpack_legacy_query(  # type: ignore[assignment]
+                method_name="GrpcIndex.search",
+                query=query,
+                top_k=top_k,
+                inputs=inputs,
+                vector=vector,
+                id=id,
+                filter=filter,
+                match_terms=match_terms,
+            )
+        if top_k is None:
+            raise ValidationError(
+                "top_k is required (pass top_k=... or use the legacy query=SearchQuery(...) form)"
+            )
+        if vector is not None and not isinstance(vector, Sequence):
+            raise TypeError(
+                "GrpcIndex.search() does not accept a Mapping for 'vector'; "
+                "the gRPC surface accepts only a list of floats. Use the REST "
+                "AsyncIndex or Index path for sparse/hybrid query vectors."
+            )
         if not isinstance(namespace, str):
             raise ValidationError("namespace must be a string")
         if not namespace or not namespace.strip():
@@ -1326,7 +1355,7 @@ class GrpcIndex:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | None = None,
         id: str | None = None,
@@ -1334,12 +1363,26 @@ class GrpcIndex:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Alias for :meth:`search`.
 
         Prefer calling :meth:`search` directly — this alias exists for backwards compatibility.
         """
+        if query is not None:
+            from pinecone._legacy.search_query_kwarg import unpack_legacy_query
+
+            top_k, inputs, vector, id, filter, match_terms = unpack_legacy_query(  # type: ignore[assignment]
+                method_name="GrpcIndex.search_records",
+                query=query,
+                top_k=top_k,
+                inputs=inputs,
+                vector=vector,
+                id=id,
+                filter=filter,
+                match_terms=match_terms,
+            )
         return self.search(
             namespace=namespace,
             top_k=top_k,
@@ -1350,6 +1393,7 @@ class GrpcIndex:
             fields=fields,
             rerank=rerank,
             match_terms=match_terms,
+            query=None,
             timeout=timeout,
         )
 

--- a/pinecone/index/__init__.py
+++ b/pinecone/index/__init__.py
@@ -40,7 +40,12 @@ from pinecone.models.vectors.responses import (
     UpsertRecordsResponse,
     UpsertResponse,
 )
-from pinecone.models.vectors.search import RerankConfig, SearchInputs, SearchRecordsResponse
+from pinecone.models.vectors.search import (
+    RerankConfig,
+    SearchInputs,
+    SearchQuery,
+    SearchRecordsResponse,
+)
 from pinecone.models.vectors.sparse import SparseValues
 from pinecone.models.vectors.vector import Vector
 
@@ -1092,7 +1097,7 @@ class Index:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -1100,6 +1105,7 @@ class Index:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Search records by text, vector, or ID with optional reranking.
@@ -1180,6 +1186,23 @@ class Index:
            Use ``pc.inference.rerank()`` when reranking results from a different
            source or when you need to rerank without searching.
         """
+        if query is not None:
+            from pinecone._legacy.search_query_kwarg import unpack_legacy_query
+
+            top_k, inputs, vector, id, filter, match_terms = unpack_legacy_query(
+                method_name="Index.search",
+                query=query,
+                top_k=top_k,
+                inputs=inputs,
+                vector=vector,
+                id=id,
+                filter=filter,
+                match_terms=match_terms,
+            )
+        if top_k is None:
+            raise ValidationError(
+                "top_k is required (pass top_k=... or use the legacy query=SearchQuery(...) form)"
+            )
         if not isinstance(namespace, str):
             raise ValidationError("namespace must be a string")
         if not namespace or not namespace.strip():
@@ -1229,7 +1252,7 @@ class Index:
         self,
         *,
         namespace: str,
-        top_k: int,
+        top_k: int | None = None,
         inputs: SearchInputs | Mapping[str, Any] | None = None,
         vector: Sequence[float] | Mapping[str, Any] | None = None,
         id: str | None = None,
@@ -1237,12 +1260,26 @@ class Index:
         fields: Sequence[str] | None = None,
         rerank: RerankConfig | Mapping[str, Any] | None = None,
         match_terms: Mapping[str, Any] | None = None,
+        query: SearchQuery | Mapping[str, Any] | None = None,
         timeout: float | None = None,
     ) -> SearchRecordsResponse:
         """Alias for :meth:`search`.
 
         Prefer calling :meth:`search` directly — this alias exists for backwards compatibility.
         """
+        if query is not None:
+            from pinecone._legacy.search_query_kwarg import unpack_legacy_query
+
+            top_k, inputs, vector, id, filter, match_terms = unpack_legacy_query(
+                method_name="Index.search_records",
+                query=query,
+                top_k=top_k,
+                inputs=inputs,
+                vector=vector,
+                id=id,
+                filter=filter,
+                match_terms=match_terms,
+            )
         return self.search(
             namespace=namespace,
             top_k=top_k,

--- a/tests/unit/test_async_search_records_alias.py
+++ b/tests/unit/test_async_search_records_alias.py
@@ -28,6 +28,7 @@ async def test_search_records_delegates_to_search() -> None:
             fields=None,
             rerank=None,
             match_terms=None,
+            query=None,
             timeout=None,
         )
 
@@ -65,4 +66,4 @@ async def test_search_records_passes_all_params() -> None:
 
     with patch.object(AsyncIndex, "search", new_callable=AsyncMock, return_value=mock_response):
         await idx.search_records(**kwargs)
-        AsyncIndex.search.assert_awaited_once_with(**kwargs)  # type: ignore[attr-defined]
+        AsyncIndex.search.assert_awaited_once_with(**kwargs, query=None)  # type: ignore[attr-defined]

--- a/tests/unit/test_backcompat_search_shims.py
+++ b/tests/unit/test_backcompat_search_shims.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 
 class TestSearchQueryShim:
     def test_legacy_search_query_importable_from_old_path(self) -> None:
@@ -214,3 +216,64 @@ class TestDataclassesPackageExports:
 
         for name in pkg.__all__:
             assert hasattr(pkg, name), f"__all__ lists {name!r} but it is not an attribute"
+
+
+class TestAsyncSearchLegacyQueryKwarg:
+    """v8 backcompat: AsyncIndex.search/search_records accept query=SearchQuery(...)."""
+
+    @pytest.mark.asyncio
+    async def test_search_records_with_legacy_query_kwarg(self) -> None:
+        import warnings
+        from unittest.mock import AsyncMock, patch
+
+        from pinecone.async_client.async_index import AsyncIndex
+        from pinecone.models.vectors.search import SearchQuery, SearchRecordsResponse
+
+        idx = object.__new__(AsyncIndex)
+        mock_response = AsyncMock(spec=SearchRecordsResponse)
+        with patch.object(
+            AsyncIndex, "search", new_callable=AsyncMock, return_value=mock_response
+        ) as m:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                await idx.search_records(
+                    namespace="ns",
+                    query=SearchQuery(inputs={"text": "hi"}, top_k=3),
+                )
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        m.assert_awaited_once()
+        kw = m.await_args.kwargs
+        assert kw["namespace"] == "ns"
+        assert kw["top_k"] == 3
+        assert kw["inputs"] == {"text": "hi"}
+        assert kw["query"] is None  # already unpacked by search_records before forwarding
+
+    @pytest.mark.asyncio
+    async def test_search_query_and_top_k_both_provided_raises(self) -> None:
+        from pinecone.async_client.async_index import AsyncIndex
+        from pinecone.models.vectors.search import SearchQuery
+
+        idx = object.__new__(AsyncIndex)
+        with pytest.raises(TypeError, match="received both 'query='"):
+            await idx.search(
+                namespace="ns",
+                top_k=5,
+                query=SearchQuery(inputs={"text": "x"}, top_k=3),
+            )
+
+    @pytest.mark.asyncio
+    async def test_search_query_invalid_type_raises(self) -> None:
+        from pinecone.async_client.async_index import AsyncIndex
+
+        idx = object.__new__(AsyncIndex)
+        with pytest.raises(TypeError, match="must be a SearchQuery or Mapping"):
+            await idx.search(namespace="ns", query=12345)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_search_without_top_k_or_query_raises(self) -> None:
+        from pinecone.async_client.async_index import AsyncIndex
+        from pinecone.errors.exceptions import ValidationError
+
+        idx = object.__new__(AsyncIndex)
+        with pytest.raises(ValidationError, match="top_k is required"):
+            await idx.search(namespace="ns", inputs={"text": "x"})

--- a/tests/unit/test_backcompat_search_shims.py
+++ b/tests/unit/test_backcompat_search_shims.py
@@ -354,3 +354,95 @@ class TestSyncSearchLegacyQueryKwarg:
         idx = object.__new__(Index)
         with pytest.raises(ValidationError, match="top_k is required"):
             idx.search(namespace="ns", inputs={"text": "x"})
+
+
+class TestGrpcSearchLegacyQueryKwarg:
+    """v8 backcompat: GrpcIndex.search/search_records accept query=SearchQuery(...)."""
+
+    def test_search_records_with_legacy_query_kwarg(self) -> None:
+        import warnings
+        from unittest.mock import MagicMock, patch
+
+        from pinecone.grpc import GrpcIndex
+        from pinecone.models.vectors.search import SearchQuery, SearchRecordsResponse
+
+        idx = object.__new__(GrpcIndex)
+        mock_response = MagicMock(spec=SearchRecordsResponse)
+        with patch.object(GrpcIndex, "search", return_value=mock_response) as m:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                idx.search_records(
+                    namespace="ns",
+                    query=SearchQuery(inputs={"text": "hi"}, top_k=3),
+                )
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        m.assert_called_once()
+        kw = m.call_args.kwargs
+        assert kw["namespace"] == "ns"
+        assert kw["top_k"] == 3
+        assert kw["inputs"] == {"text": "hi"}
+        assert kw.get("query") is None  # already unpacked before forwarding
+
+    def test_search_with_legacy_query_dict(self) -> None:
+        import warnings
+        from unittest.mock import MagicMock, patch
+
+        from pinecone.grpc import GrpcIndex
+        from pinecone.models.vectors.search import SearchRecordsResponse
+
+        idx = object.__new__(GrpcIndex)
+        mock_response = MagicMock(spec=SearchRecordsResponse)
+        with patch.object(GrpcIndex, "search", return_value=mock_response) as m:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                idx.search_records(
+                    namespace="ns",
+                    query={"inputs": {"text": "x"}, "top_k": 2},
+                )
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        m.assert_called_once()
+        kw = m.call_args.kwargs
+        assert kw["top_k"] == 2
+        assert kw["inputs"] == {"text": "x"}
+
+    def test_search_query_and_top_k_both_provided_raises(self) -> None:
+        from pinecone.grpc import GrpcIndex
+        from pinecone.models.vectors.search import SearchQuery
+
+        idx = object.__new__(GrpcIndex)
+        with pytest.raises(TypeError, match="received both 'query='"):
+            idx.search(
+                namespace="ns",
+                top_k=5,
+                query=SearchQuery(inputs={"text": "x"}, top_k=3),
+            )
+
+    def test_search_query_invalid_type_raises(self) -> None:
+        from pinecone.grpc import GrpcIndex
+
+        idx = object.__new__(GrpcIndex)
+        with pytest.raises(TypeError, match="must be a SearchQuery or Mapping"):
+            idx.search(namespace="ns", query=12345)  # type: ignore[arg-type]
+
+    def test_search_without_top_k_or_query_raises(self) -> None:
+        from pinecone.errors.exceptions import ValidationError
+        from pinecone.grpc import GrpcIndex
+
+        idx = object.__new__(GrpcIndex)
+        with pytest.raises(ValidationError, match="top_k is required"):
+            idx.search(namespace="ns", inputs={"text": "x"})
+
+    def test_search_query_with_mapping_vector_raises(self) -> None:
+        from pinecone.grpc import GrpcIndex
+        from pinecone.models.vectors.search import SearchQuery
+
+        idx = object.__new__(GrpcIndex)
+        with pytest.raises(TypeError, match="does not accept a Mapping for 'vector'"):
+            idx.search(
+                namespace="ns",
+                query=SearchQuery(
+                    inputs={"text": "x"},
+                    top_k=1,
+                    vector={"values": [0.1, 0.2]},  # type: ignore[arg-type]
+                ),
+            )

--- a/tests/unit/test_backcompat_search_shims.py
+++ b/tests/unit/test_backcompat_search_shims.py
@@ -277,3 +277,80 @@ class TestAsyncSearchLegacyQueryKwarg:
         idx = object.__new__(AsyncIndex)
         with pytest.raises(ValidationError, match="top_k is required"):
             await idx.search(namespace="ns", inputs={"text": "x"})
+
+
+class TestSyncSearchLegacyQueryKwarg:
+    """v8 backcompat: Index.search/search_records accept query=SearchQuery(...)."""
+
+    def test_search_records_with_legacy_query_kwarg(self) -> None:
+        import warnings
+        from unittest.mock import MagicMock, patch
+
+        from pinecone.index import Index
+        from pinecone.models.vectors.search import SearchQuery, SearchRecordsResponse
+
+        idx = object.__new__(Index)
+        mock_response = MagicMock(spec=SearchRecordsResponse)
+        with patch.object(Index, "search", return_value=mock_response) as m:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                idx.search_records(
+                    namespace="ns",
+                    query=SearchQuery(inputs={"text": "hi"}, top_k=3),
+                )
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        m.assert_called_once()
+        kw = m.call_args.kwargs
+        assert kw["namespace"] == "ns"
+        assert kw["top_k"] == 3
+        assert kw["inputs"] == {"text": "hi"}
+        assert kw.get("query") is None  # already unpacked before forwarding
+
+    def test_search_with_legacy_query_dict(self) -> None:
+        import warnings
+        from unittest.mock import MagicMock, patch
+
+        from pinecone.index import Index
+        from pinecone.models.vectors.search import SearchRecordsResponse
+
+        idx = object.__new__(Index)
+        mock_response = MagicMock(spec=SearchRecordsResponse)
+        with patch.object(Index, "search", return_value=mock_response) as m:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                idx.search_records(
+                    namespace="ns",
+                    query={"inputs": {"text": "x"}, "top_k": 2},
+                )
+            assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        m.assert_called_once()
+        kw = m.call_args.kwargs
+        assert kw["top_k"] == 2
+        assert kw["inputs"] == {"text": "x"}
+
+    def test_search_query_and_top_k_both_provided_raises(self) -> None:
+        from pinecone.index import Index
+        from pinecone.models.vectors.search import SearchQuery
+
+        idx = object.__new__(Index)
+        with pytest.raises(TypeError, match="received both 'query='"):
+            idx.search(
+                namespace="ns",
+                top_k=5,
+                query=SearchQuery(inputs={"text": "x"}, top_k=3),
+            )
+
+    def test_search_query_invalid_type_raises(self) -> None:
+        from pinecone.index import Index
+
+        idx = object.__new__(Index)
+        with pytest.raises(TypeError, match="must be a SearchQuery or Mapping"):
+            idx.search(namespace="ns", query=12345)  # type: ignore[arg-type]
+
+    def test_search_without_top_k_or_query_raises(self) -> None:
+        from pinecone.errors.exceptions import ValidationError
+        from pinecone.index import Index
+
+        idx = object.__new__(Index)
+        with pytest.raises(ValidationError, match="top_k is required"):
+            idx.search(namespace="ns", inputs={"text": "x"})


### PR DESCRIPTION
## Summary

Restores the v8 `query=SearchQuery(...)` (or `query={...}`) wrapper kwarg on `Index.search`, `AsyncIndex.search`, and `GrpcIndex.search` (plus the `search_records` aliases) with a `DeprecationWarning`, so v8 callers upgrading to v9 don't immediately hit `TypeError: search() got an unexpected keyword argument 'query'`.

Fixes #661.

## Background

v8 SDK callers used a single wrapper kwarg:

```python
index.search(
    namespace="ns",
    query={"inputs": {"text": "..."}, "top_k": 10, "filter": {...}},
    fields=["text"],
)
```

v9 flattened that wrapper into top-level kwargs (`top_k`, `inputs`, `vector`, `id`, `filter`, `match_terms`), which is a hard break for migrating callers — see #661 for the user-reported failure mode.

## Solution

- New shared helper `pinecone/_legacy/search_query_kwarg.py` exposing `unpack_legacy_query()`. It accepts either a `SearchQuery` (msgspec.Struct) or a plain `Mapping` / `TypedDict` and unpacks it into the flat kwargs.
- Sync `Index.search`/`search_records`, `AsyncIndex.search`/`search_records`, and `GrpcIndex.search`/`search_records` all gain a `query: SearchQuery | Mapping[str, Any] | None = None` parameter; `top_k` is relaxed from required to `int | None = None` so the legacy form can supply it via the wrapper. After unpacking, the existing validation (`top_k >= 1`, query-source-required, rerank shape) runs unchanged.
- Mutual exclusion: passing both `query=` and any of the flat kwargs raises `TypeError` with a message naming the conflicting kwargs. Passing a wrong-typed `query=` (not `SearchQuery` and not `Mapping`) raises `TypeError` naming the offending type.
- A `DeprecationWarning` fires once per call to nudge callers toward the new flat form.

## Why this design

- **Single helper, three call sites.** The unpacking, mutual-exclusion check, and warning emission are identical across sync/async/gRPC — keeping them in one place avoids three subtly different implementations drifting.
- **Robust to legacy variations.** Accepts the `SearchQuery` dataclass, the `SearchQueryTypedDict` shape (any `Mapping`), and tolerates `SearchQueryVector` inside `vector` (the canonical `SearchQuery` struct already handles vector normalization downstream).
- **Informative on misuse.** The conflict error names the kwargs that conflict instead of saying "got both"; the type error names the actual type received.

## Tests

`tests/unit/test_backcompat_search_shims.py` adds three test classes — `TestAsyncSearchLegacyQueryKwarg`, `TestSyncSearchLegacyQueryKwarg`, `TestGrpcSearchLegacyQueryKwarg` — each covering:

- `SearchQuery(...)` wrapper passes through correctly
- `dict` wrapper passes through correctly
- both `query=` and a flat kwarg raise `TypeError`
- non-`SearchQuery`, non-`Mapping` `query=` raises `TypeError`
- missing `top_k` (neither in `query=` nor flat) raises `ValidationError`

## Verification

```
uv run pytest tests/unit/test_backcompat_search_shims.py tests/unit/test_index_search.py tests/unit/test_async_search.py -q
# 84 passed

uv run mypy --strict pinecone/_legacy/search_query_kwarg.py pinecone/index/__init__.py pinecone/async_client/async_index.py pinecone/grpc/__init__.py
# Success: no issues found in 4 source files
```

## Relationship to #668

There is an independent open PR #668 ("fix: support legacy search query bodies") tackling the same issue with a different design — it centralizes search body construction in a new `_build_search_records_body` helper in `pinecone/_internal/data_plane_helpers.py`. This PR takes a narrower approach focused on the `query=` unpacking specifically. Reviewers should pick one of the two designs and close the other.

## Test plan

- [ ] CI passes on this branch
- [ ] `uv run pytest tests/unit/ -q` (full unit suite) passes locally
- [ ] Sanity-check a v8-style call against a live integrated-inference index in a scratch script
- [ ] Decide between this PR and #668; close the loser

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compatibility-layer changes with strict mutual-exclusion and validation; no change to the HTTP search body path except via unpacked kwargs. Slightly wider public signatures (optional top_k, new query= param).
> 
> **Overview**
> Restores v8-style **`query=SearchQuery(...)`** (or a dict) on **`search`** and **`search_records`** for **`Index`**, **`AsyncIndex`**, and **`GrpcIndex`**, so v9 callers are not broken by the flattened **`top_k` / `inputs` / …** API.
> 
> A shared **`unpack_legacy_query`** helper in **`pinecone/_legacy/search_query_kwarg.py`** unpacks the wrapper, emits a **`DeprecationWarning`**, rejects mixing **`query=`** with flat kwargs (**`TypeError`**), and validates **`query`** type. **`top_k`** is optional at the signature level; after unpack, missing **`top_k`** raises **`ValidationError`**. Existing search validation and request building are unchanged.
> 
> **`GrpcIndex.search`** adds an explicit **`TypeError`** when a mapping **`vector`** comes from the legacy path (dense-only gRPC surface). Unit tests cover sync, async, and gRPC legacy paths plus alias forwarding with **`query=None`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d17445f5ead414f706763067907824a3ed03c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->