### PR TITLE
Validate dry_run update mode

### DIFF
--- a/pinecone/async_client/async_index.py
+++ b/pinecone/async_client/async_index.py
@@ -910,7 +910,8 @@ class AsyncIndex:
             namespace (str): Namespace to target. Defaults to the default namespace.
             filter (dict[str, Any] | None): Metadata filter expression selecting vectors to update.
             dry_run (bool): If True, return the count of records that would be
-                affected without applying changes.
+                affected without applying changes. Only applies to filter-based
+                updates.
 
         Returns:
             :class:`UpdateResponse` with matched_records count (when available).
@@ -942,6 +943,8 @@ class AsyncIndex:
             raise ValidationError("Exactly one of id or filter must be provided, not both")
         if not has_id and not has_filter:
             raise ValidationError("Exactly one of id or filter must be provided, got neither")
+        if dry_run and has_id:
+            raise ValidationError("dry_run is only supported for filter-based updates")
 
         body: dict[str, Any] = {"namespace": namespace}
         if id is not None:

--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -765,7 +765,8 @@ class GrpcIndex:
             namespace (str): Namespace to target. Defaults to the default namespace.
             filter (dict[str, Any] | None): Metadata filter expression selecting vectors to update.
             dry_run (bool): If True, return the count of records that would be
-                affected without applying changes.
+                affected without applying changes. Only applies to filter-based
+                updates.
             timeout (float | None): Per-call timeout in seconds. None uses the client-level default.
 
         Returns:
@@ -795,6 +796,8 @@ class GrpcIndex:
             raise ValidationError("Exactly one of id or filter must be provided, not both")
         if not has_id and not has_filter:
             raise ValidationError("Exactly one of id or filter must be provided, got neither")
+        if dry_run and has_id:
+            raise ValidationError("dry_run is only supported for filter-based updates")
 
         # Convert SparseValues model to dict for GrpcChannel
         sv_dict: Mapping[str, Any] | None = None

--- a/pinecone/index/__init__.py
+++ b/pinecone/index/__init__.py
@@ -1018,6 +1018,8 @@ class Index:
             raise ValidationError("Exactly one of id or filter must be provided, not both")
         if not has_id and not has_filter:
             raise ValidationError("Exactly one of id or filter must be provided, got neither")
+        if dry_run and has_id:
+            raise ValidationError("dry_run is only supported for filter-based updates")
 
         body: dict[str, Any] = {"namespace": namespace}
         if id is not None:

--- a/tests/unit/test_async_index_operations.py
+++ b/tests/unit/test_async_index_operations.py
@@ -426,6 +426,12 @@ class TestAsyncUpdate:
         with pytest.raises(ValidationError, match="not both"):
             await idx.update(id="vec1", filter={"x": 1})
 
+    @pytest.mark.asyncio
+    async def test_update_dry_run_with_id_raises(self) -> None:
+        idx = _make_async_index()
+        with pytest.raises(ValidationError, match="dry_run is only supported"):
+            await idx.update(id="vec1", set_metadata={"genre": "comedy"}, dry_run=True)
+
     @respx.mock
     @pytest.mark.asyncio
     async def test_update_dry_run(self) -> None:

--- a/tests/unit/test_grpc_index.py
+++ b/tests/unit/test_grpc_index.py
@@ -500,6 +500,10 @@ class TestUpdate:
         with pytest.raises(ValidationError, match="got neither"):
             grpc_index.update(values=[0.1])
 
+    def test_update_validates_dry_run_with_id(self, grpc_index: GrpcIndex) -> None:
+        with pytest.raises(ValidationError, match="dry_run is only supported"):
+            grpc_index.update(id="v1", set_metadata={"key": "new_val"}, dry_run=True)
+
     def test_update_by_filter_with_dry_run(
         self, grpc_index: GrpcIndex, mock_channel: MagicMock
     ) -> None:

--- a/tests/unit/test_index_update.py
+++ b/tests/unit/test_index_update.py
@@ -168,6 +168,11 @@ class TestUpdateValidation:
         with pytest.raises(ValidationError, match="got neither"):
             idx.update(values=[0.1])
 
+    def test_dry_run_with_id_raises(self) -> None:
+        idx = _make_index()
+        with pytest.raises(ValidationError, match="dry_run is only supported"):
+            idx.update(id="vec1", set_metadata={"genre": "comedy"}, dry_run=True)
+
     @respx.mock
     def test_dry_run_not_in_body_when_false(self) -> None:
         route = respx.post(UPDATE_URL).mock(


### PR DESCRIPTION
This fixes `dry_run=True` being sent with ID-based vector updates.

What changed:
- Reject `dry_run=True` when `id` is used in sync REST, async REST, and gRPC update paths.
- Clarify the update docstrings so `dry_run` is described as filter-only.
- Add unit coverage for sync, async, and gRPC validation.

Why:
The update proto documents `dry_run` as returning the count of records that match the `filter`. ID-based updates do not have supported dry-run semantics, so the SDK should fail before sending that request.

Checked:
- On current `origin/main`, `idx.update(id="vec1", set_metadata={...}, dry_run=True)` sends `{"id": "vec1", ..., "dryRun": true}` instead of raising.
- On this branch, the same call raises `ValidationError` before any API call.
- `PROTOC=$PWD/.venv/bin/protoc .venv/bin/python -m pytest tests/unit/test_index_update.py tests/unit/test_async_index_operations.py tests/unit/test_grpc_index.py -q` (`143 passed`)
- `.venv/bin/ruff check .` (`All checks passed!`)
- `PROTOC=$PWD/.venv/bin/protoc .venv/bin/python -m pytest tests/unit -q -k "not test_async_transport_calls_module_level_compute_backoff and not test_linux_keepalive_params and not test_darwin_keepalive_params"` (`4601 passed, 30 skipped, 3 deselected, 1 xfailed`)

Note: a full local `tests/unit` run on macOS/Python 3.12 still has unrelated failures in `test_socket_options` for missing `socket.TCP_KEEPIDLE`; the same socket checks fail on current `origin/main` in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, consistent input validation across three update entry points; filter-based dry-run is unchanged and tests were added.
> 
> **Overview**
> **`update()` now rejects `dry_run=True` when an `id` is used**, across sync REST (`Index`), async REST (`AsyncIndex`), and gRPC (`GrpcIndex`). The SDK raises `ValidationError` with *"dry_run is only supported for filter-based updates"* before any request is sent, instead of posting payloads like `{"id": "...", "dryRun": true}`.
> 
> Docstrings for **`dry_run`** now state it applies only to **filter-based** updates. Unit tests cover the new validation on sync, async, and gRPC paths; filter-based dry-run behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cfc474d45ddf84ee11fa478dc0ed0d7d8467196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->