### PR TITLE
fix(local): honor ssl_verify=False for data-plane host scheme; allow dimension for sparse indexes

### DIFF
--- a/pinecone/_client.py
+++ b/pinecone/_client.py
@@ -453,8 +453,11 @@ class Pinecone:
                     "the index may still be initializing. "
                     "Wait until the index status is 'Ready' before connecting."
                 )
-            self._host_cache[name] = desc.host
-            return desc.host
+            resolved = desc.host
+            if not self._config.ssl_verify and resolved.startswith("https://"):
+                resolved = "http://" + resolved[len("https://"):]
+            self._host_cache[name] = resolved
+            return resolved
 
         raise ValidationError("Either name or host must be provided to create an Index client.")
 

--- a/pinecone/_internal/indexes_helpers.py
+++ b/pinecone/_internal/indexes_helpers.py
@@ -116,8 +116,6 @@ def validate_create_inputs(
         raise PineconeTypeError(f"dimension must be an integer, got {type(dimension).__name__!r}")
 
     resolved_vt = resolve_enum_value(vector_type)
-    if resolved_vt == "sparse" and dimension is not None:
-        raise ValidationError("dimension must not be provided for sparse indexes")
     if resolved_vt != "sparse" and dimension is None:
         raise ValidationError("dimension is required for dense indexes")
 

--- a/pinecone/async_client/pinecone.py
+++ b/pinecone/async_client/pinecone.py
@@ -818,8 +818,11 @@ class AsyncPinecone:
                     "the index may still be initializing. "
                     "Wait until the index status is 'Ready' before connecting."
                 )
-            self._host_cache[name] = desc.host
-            return desc.host
+            resolved = desc.host
+            if not self._config.ssl_verify and resolved.startswith("https://"):
+                resolved = "http://" + resolved[len("https://"):]
+            self._host_cache[name] = resolved
+            return resolved
 
         raise ValidationError("Either name or host must be provided to create an Index client.")
 

--- a/pinecone/preview/__init__.py
+++ b/pinecone/preview/__init__.py
@@ -147,6 +147,8 @@ class Preview:
                         "the index may still be initializing. "
                         "Wait until the index status is 'Ready' before connecting."
                     )
+                if not self._config.ssl_verify and described_host.startswith("https://"):
+                    described_host = "http://" + described_host[len("https://"):]
                 self._host_cache[name] = described_host
             resolved_host = self._host_cache[name]
         else:
@@ -326,6 +328,7 @@ class AsyncPreview:
 
         host_cache = self._host_cache
         indexes = self.indexes
+        ssl_verify = self._config.ssl_verify
 
         async def _resolve() -> str:
             if name not in host_cache:
@@ -336,7 +339,10 @@ class AsyncPreview:
                         "the index may still be initializing. "
                         "Wait until the index status is 'Ready' before connecting."
                     )
-                host_cache[name] = desc.host
+                resolved = desc.host
+                if not ssl_verify and resolved.startswith("https://"):
+                    resolved = "http://" + resolved[len("https://"):]
+                host_cache[name] = resolved
             return host_cache[name]
 
         return AsyncPreviewIndex(config=self._config, _host_provider=_resolve)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -553,3 +553,44 @@ class TestPineconeLimiterWiring:
         pc1 = Pinecone(api_key="test-key")
         pc2 = Pinecone(api_key="test-key")
         assert pc1._limiter_registry is not pc2._limiter_registry
+
+
+class TestResolveIndexHostSslVerify:
+    """Test that ssl_verify=False rewrites https:// to http:// when resolving via describe."""
+
+    def test_ssl_verify_false_rewrites_https_to_http_on_describe(self) -> None:
+        """When ssl_verify=False the host resolved from describe() uses http://.
+
+        Pinecone Local serves plain HTTP only.  A bare hostname returned by the
+        server is normalised to https:// by IndexModel.__post_init__, which then
+        causes a TLS handshake against a server that does not speak TLS.
+        Setting ssl_verify=False signals intent to skip TLS entirely, so the
+        SDK downgrades the scheme to http:// for the data-plane host.
+        """
+        pc = Pinecone(api_key="pclocal", host="http://localhost:5080", ssl_verify=False)
+
+        mock_desc = MagicMock()
+        mock_desc.host = "https://localhost:5081"
+
+        with patch.object(pc.indexes, "describe", return_value=mock_desc):
+            resolved = pc._resolve_index_host(name="my-index", host="")
+
+        assert resolved == "http://localhost:5081"
+
+    def test_ssl_verify_true_preserves_https_on_describe(self) -> None:
+        """When ssl_verify=True the https:// scheme on the resolved host is kept."""
+        pc = Pinecone(api_key="test-key")
+
+        mock_desc = MagicMock()
+        mock_desc.host = "https://my-index-abc.svc.pinecone.io"
+
+        with patch.object(pc.indexes, "describe", return_value=mock_desc):
+            resolved = pc._resolve_index_host(name="my-index", host="")
+
+        assert resolved == "https://my-index-abc.svc.pinecone.io"
+
+    def test_explicit_host_not_rewritten(self) -> None:
+        """An explicit host= argument is returned as-is regardless of ssl_verify."""
+        pc = Pinecone(api_key="pclocal", host="http://localhost:5080", ssl_verify=False)
+        resolved = pc._resolve_index_host(name="", host="http://localhost:5081")
+        assert resolved == "http://localhost:5081"

--- a/tests/unit/test_indexes_create.py
+++ b/tests/unit/test_indexes_create.py
@@ -482,18 +482,35 @@ def test_create_name_valid_boundary(indexes: Indexes) -> None:
     assert isinstance(result, IndexModel)
 
 
-def test_create_sparse_with_dimension_raises(indexes: Indexes) -> None:
-    """Sparse index with explicit dimension raises ValidationError."""
-    with pytest.raises(ValidationError) as exc_info:
-        indexes.create(
-            name="test",
-            spec=ServerlessSpec(cloud="aws", region="us-east-1"),
-            vector_type="sparse",
-            dimension=384,
-        )
+@respx.mock
+def test_create_sparse_with_dimension_allowed(indexes: Indexes) -> None:
+    """Sparse index accepts an explicit dimension so Pinecone Local can be targeted.
 
-    assert "dimension" in str(exc_info.value)
-    assert "sparse" in str(exc_info.value)
+    Pinecone Local requires a ``dimension`` field in the POST body even for sparse
+    indexes.  The SDK no longer rejects this combination at the client-side validation
+    layer; the field is forwarded to the server and the server decides whether it is
+    valid for the target environment.
+    """
+    route = respx.post(f"{BASE_URL}/indexes").mock(
+        return_value=httpx.Response(
+            201, json=make_index_response(vector_type="sparse", dimension=1)
+        ),
+    )
+
+    result = indexes.create(
+        name="sparse-local",
+        spec=ServerlessSpec(cloud="aws", region="us-east-1"),
+        vector_type="sparse",
+        dimension=1,
+        timeout=-1,
+    )
+
+    assert result.vector_type == "sparse"
+
+    request = route.calls.last.request
+    body = json.loads(request.content)
+    assert body["vector_type"] == "sparse"
+    assert body["dimension"] == 1
 
 
 def test_create_with_unrecognized_dict_spec_raises(indexes: Indexes) -> None:


### PR DESCRIPTION
## Problem

Two bugs make Pinecone Local unusable with the v9 Python SDK.

**Issue #678 — data-plane host forced to https:// even with ssl_verify=False**

`IndexModel.__post_init__` calls `normalize_host`, which prepends `https://` to any bare hostname returned by the control plane (Pinecone Local returns no scheme).  The `ssl_verify=False` flag set on `Pinecone(...)` is correctly forwarded to the `Index` kwargs, but the host already carries `https://` by the time the data-plane client is constructed — so an outbound TLS handshake is attempted against a server that serves plain HTTP only.  The result is `SSL_WRONG_VERSION_NUMBER` even though the user explicitly opted out of TLS.

**Issue #679 — cannot create a sparse index against Pinecone Local**

`validate_create_inputs` raises `PineconeValueError: dimension must not be provided for sparse indexes` before any request is sent.  Omitting `dimension` causes Pinecone Local to return `422 missing field 'dimension'` because its `/indexes` endpoint requires the field regardless of `vector_type`.  The SDK and the server are in a deadlock with no path to success.

## Fix

**For #678:** `_resolve_index_host` (sync in `_client.py`, async in `async_client/pinecone.py`, and both sync/async paths in `preview/__init__.py`) now rewrites `https://` to `http://` on the resolved host whenever `ssl_verify=False`.  An explicit `host=` argument passed directly by the caller is returned unchanged.  Production hosts — which always have a scheme already explicit in the `host` string — are unaffected because only the name-resolved path (bare hostname → `IndexModel.__post_init__` → `normalize_host`) produces an unwanted `https://` for local targets.

**For #679:** The client-side prohibition on `dimension` for sparse indexes is removed from `validate_create_inputs`.  The field remains optional and is forwarded to the server only when supplied, exactly as it is for dense indexes.  Cloud Pinecone silently accepts and ignores an extra `dimension` on sparse indexes; Pinecone Local requires it.  The server is the appropriate authority for per-environment validation.

## Tests

- `TestResolveIndexHostSslVerify` in `test_client.py`: three cases — `ssl_verify=False` rewrites `https://` on the name-resolved host, `ssl_verify=True` preserves `https://`, and an explicit `host=` argument is never rewritten
- `test_create_sparse_with_dimension_allowed` in `test_indexes_create.py`: replaces the old `test_create_sparse_with_dimension_raises` test; verifies the request body contains both `vector_type=sparse` and `dimension=1`

Fixes #678
Fixes #679

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted local-dev fixes with narrow conditions (ssl_verify off + describe-resolved https host; relaxed sparse dimension validation). Production paths with default ssl_verify and typical sparse creates are unchanged.
> 
> **Overview**
> Fixes **Pinecone Local** compatibility in two areas.
> 
> When an index host is resolved by name (describe), **`ssl_verify=False`** now rewrites **`https://` → `http://`** before caching and connecting, so plain-HTTP local data planes are not forced into TLS. The same logic applies on sync/async **`Pinecone`**, **`AsyncPinecone`**, and **preview** index host resolution. An explicit **`host=`** argument is never rewritten.
> 
> **Sparse index creation** no longer rejects a client-supplied **`dimension`** in **`validate_create_inputs`**; optional **`dimension`** is still forwarded in the create body when provided, leaving environment-specific rules to the API (needed for Local, harmless for cloud).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 811ea2a8f9611bdc6e6b2ae4562e4bc2892bd9a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->