### PR TITLE
Document bulk import integration_id option

### DIFF
--- a/docs/how-to/vectors/bulk-import.md
+++ b/docs/how-to/vectors/bulk-import.md
@@ -52,6 +52,21 @@ response = index.start_import(
 ```
 
 
+## Use a storage integration
+
+If your project uses a configured storage integration for the import source, pass the
+integration ID with `integration_id`:
+
+```python
+response = index.start_import(
+    uri="s3://my-bucket/embeddings/",
+    integration_id="integration-id",
+)
+```
+
+You can combine integration_id with error_mode when needed.
+
+
 ## Check import status
 
 {meth}`~pinecone.Index.describe_import` returns an {class}`~pinecone.models.ImportModel`


### PR DESCRIPTION
Adds the supported integration_id argument to the bulk import guide. The SDK signature, request body, unit tests, and smoke-test README already cover this option, but the how-to guide currently only documents uri and error_mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> The bulk import how-to guide now documents **`integration_id`** on **`start_import`**, for projects that use a configured storage integration when reading from S3/GCS/Azure.
> 
> A new **Use a storage integration** section shows passing `integration_id` alongside `uri`, and notes it can be combined with **`error_mode`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3963077fed73ed82421a8e81e97e16c024e449a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->