### PR TITLE
fix: validate is_in/not_in receive a list in the filter builder

### DIFF
--- a/pinecone/utils/filter_builder.py
+++ b/pinecone/utils/filter_builder.py
@@ -117,12 +117,20 @@ class Field:
 
     # -- set operators --------------------------------------------------------
 
+    def _require_list(self, op: str, values: Any) -> None:
+        if not isinstance(values, (list, tuple)):
+            raise TypeError(
+                f"{op} requires a list of values, got {type(values).__name__}"
+            )
+
     def is_in(self, values: list[str | int | float | bool]) -> Condition:
         """``$in`` — value is in the given list."""
+        self._require_list("is_in", values)
         return Condition({self._name: {"$in": values}})
 
     def not_in(self, values: list[str | int | float | bool]) -> Condition:
         """``$nin`` — value is not in the given list."""
+        self._require_list("not_in", values)
         return Condition({self._name: {"$nin": values}})
 
     # -- exists operator ------------------------------------------------------

--- a/tests/unit/utils/test_filter_builder.py
+++ b/tests/unit/utils/test_filter_builder.py
@@ -64,6 +64,18 @@ class TestFieldSetOperators:
         result = Field("tag").not_in(["spam"]).to_dict()
         assert result == {"tag": {"$nin": ["spam"]}}
 
+    def test_field_is_in_accepts_tuple(self) -> None:
+        result = Field("color").is_in(("red", "blue")).to_dict()
+        assert result == {"color": {"$in": ("red", "blue")}}
+
+    def test_is_in_requires_list(self) -> None:
+        with pytest.raises(TypeError, match="list"):
+            Field("genre").is_in("drama")  # type: ignore[arg-type]
+
+    def test_not_in_requires_list(self) -> None:
+        with pytest.raises(TypeError, match="list"):
+            Field("genre").not_in("drama")  # type: ignore[arg-type]
+
 
 class TestFieldExists:
     def test_field_exists(self) -> None:


### PR DESCRIPTION
## What

In the metadata filter builder, `Field.is_in()` / `Field.not_in()` accept any value without checking it's a list. A common mistake — passing a bare value instead of a list — is silently turned into an invalid filter:

```python
Field("genre").is_in("drama").to_dict()
# -> {"genre": {"$in": "drama"}}   ❌  (a bare string, not a list)
```

Because a string is iterable, nothing catches this client-side; the server rejects it later with an opaque `400 Invalid request`, which is hard to trace back to the filter.

This is inconsistent with the numeric operators in the same class — `gt` / `gte` / `lt` / `lte` already validate their argument via `_require_numeric` and raise a clear `TypeError`.

## Fix

Add a `_require_list` guard mirroring the existing `_require_numeric`, and call it from `is_in` / `not_in` (`pinecone/utils/filter_builder.py`). It accepts a `list` or `tuple` and raises a clear `TypeError` otherwise:

```python
Field("genre").is_in("drama")
# TypeError: is_in requires a list of values, got str
```

Valid `list`/`tuple` usage is unchanged.

## Testing

Added tests to `TestFieldSetOperators` in `tests/unit/utils/test_filter_builder.py`, mirroring the existing `test_numeric_only_*` cases (tuple accepted; `is_in`/`not_in` with a non-list raise `TypeError` matching "list"). Verified the behavior directly against the module — `filter_builder.py` is pure Python (list/tuple pass, `str`/`int` raise).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to filter-builder validation with no auth, data, or API contract changes beyond catching invalid client usage earlier.
> 
> **Overview**
> **`Field.is_in()` and `Field.not_in()`** now validate their argument client-side via a new **`_require_list`** helper (same pattern as **`_require_numeric`** on comparison operators).
> 
> Passing a bare scalar (e.g. `Field("genre").is_in("drama")`) no longer builds an invalid `{"$in": "drama"}` filter; it raises **`TypeError: is_in requires a list of values, got str`**. **`list`** and **`tuple`** inputs behave as before.
> 
> Unit tests cover tuple acceptance and **`TypeError`** for non-list values on both set operators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a999d418f2fb5307e025744ed89baa16a772ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->