### PR TITLE
Enable Dependabot version updates (PIN-4)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` enabling **weekly, grouped Dependabot version updates**.

Ecosystems covered: uv (python), cargo (rust), github-actions.

## Why
Part of standing up the security fast-patch process (**PIN-4**). Keeping dependencies close to their latest patched release shrinks the diff and time needed to ship a fix when a security advisory lands. Dependabot **security updates** (auto patch PRs on advisories) and **vulnerability alerts** are already enabled on this repo; this adds the routine version-update cadence.

Minor/patch updates are grouped into a single PR per ecosystem to keep review noise low; majors come as individual PRs.

## Review notes
Config only — no code changes. First run may open a batch of update PRs; that is expected. Adjust `open-pull-requests-limit` or `schedule` if the cadence is too noisy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/dependency automation config only; no application code or runtime behavior changes.
> 
> **Overview**
> Introduces **`.github/dependabot.yml`** to run **weekly** Dependabot **version updates** for **uv** (Python), **Cargo** (Rust), and **GitHub Actions**, complementing existing security alerts and advisory-driven updates (**PIN-4**).
> 
> For **uv** and **Cargo**, **minor** and **patch** bumps are **grouped** into one PR per ecosystem (cap **10** open update PRs each). **GitHub Actions** updates are grouped under a single weekly PR. **Major** version bumps are not grouped and should still arrive as separate PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e942467fc4585631d166ad6ab9f91d7aba6baa2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->