### PR TITLE
security: clear 6 high Dependabot alerts (pyo3 0.24→0.29, tornado, soupsieve)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,12 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,15 +419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,15 +478,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -686,37 +662,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -724,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -736,13 +707,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -1250,12 +1220,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,7 +8,7 @@ name = "pinecone_grpc"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.24", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"] }
 tonic = { version = "0.13", features = ["tls-ring", "tls-native-roots"] }
 prost = "0.13"
 prost-types = "0.13"

--- a/rust/src/transport.rs
+++ b/rust/src/transport.rs
@@ -186,7 +186,7 @@ fn status_to_py_err(status: tonic::Status) -> PyErr {
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let errors_mod = match py.import("pinecone.errors") {
             Ok(m) => m,
             Err(_) => return PyRuntimeError::new_err(msg),
@@ -353,7 +353,7 @@ fn struct_to_py_dict(py: Python<'_>, s: &prost_types::Struct) -> PyResult<Py<PyD
 }
 
 /// Convert a `prost_types::Value` to a Python object.
-fn prost_value_to_py(py: Python<'_>, value: &prost_types::Value) -> PyResult<PyObject> {
+fn prost_value_to_py(py: Python<'_>, value: &prost_types::Value) -> PyResult<Py<PyAny>> {
     use prost_types::value::Kind;
     match &value.kind {
         Some(Kind::NullValue(_)) => Ok(py.None()),
@@ -362,7 +362,7 @@ fn prost_value_to_py(py: Python<'_>, value: &prost_types::Value) -> PyResult<PyO
         Some(Kind::BoolValue(b)) => Ok(b.into_pyobject(py)?.to_owned().into_any().unbind()),
         Some(Kind::StructValue(s)) => Ok(struct_to_py_dict(py, s)?.into_any()),
         Some(Kind::ListValue(list)) => {
-            let items: Vec<PyObject> = list
+            let items: Vec<Py<PyAny>> = list
                 .values
                 .iter()
                 .map(|v| prost_value_to_py(py, v))
@@ -397,12 +397,12 @@ fn py_to_prost_value(obj: &Bound<'_, pyo3::PyAny>) -> PyResult<prost_types::Valu
             kind: Some(Kind::StringValue(s)),
         });
     }
-    if let Ok(dict) = obj.downcast::<PyDict>() {
+    if let Ok(dict) = obj.cast::<PyDict>() {
         return Ok(prost_types::Value {
             kind: Some(Kind::StructValue(py_dict_to_struct(dict)?)),
         });
     }
-    if let Ok(list) = obj.downcast::<pyo3::types::PyList>() {
+    if let Ok(list) = obj.cast::<pyo3::types::PyList>() {
         let values: Vec<prost_types::Value> = list
             .iter()
             .map(|item| py_to_prost_value(&item))
@@ -413,7 +413,7 @@ fn py_to_prost_value(obj: &Bound<'_, pyo3::PyAny>) -> PyResult<prost_types::Valu
     }
 
     let type_name = obj.get_type().name()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         Err(pinecone_value_error(
             py,
             &format!("Unsupported metadata value type: {type_name}"),
@@ -522,11 +522,11 @@ fn py_dict_to_metadata_schema(dict: &Bound<'_, PyDict>) -> PyResult<proto::Metad
     let fields_obj = dict
         .get_item("fields")?
         .ok_or_else(|| response_parsing_error(py, "schema missing 'fields'"))?;
-    let fields_dict = fields_obj.downcast::<PyDict>()?;
+    let fields_dict = fields_obj.cast::<PyDict>()?;
     let mut fields = std::collections::HashMap::new();
     for (key, value) in fields_dict.iter() {
         let key_str: String = key.extract()?;
-        let props_dict = value.downcast::<PyDict>()?;
+        let props_dict = value.cast::<PyDict>()?;
         let filterable: bool = props_dict
             .get_item("filterable")?
             .ok_or_else(|| response_parsing_error(py, "field properties missing 'filterable'"))?
@@ -636,7 +636,7 @@ impl GrpcChannel {
         let host = parse_host_from_endpoint(endpoint).unwrap_or_else(|| endpoint.to_string());
         let on_throttle_cb: Option<ThrottleCallback> = on_throttle.map(|py_cb| {
             let cb: ThrottleCallback = Arc::new(move |h: String| {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     if let Err(e) = py_cb.call1(py, (h,)) {
                         tracing::debug!("on_throttle callback raised, ignoring: {:?}", e);
                     }
@@ -687,11 +687,11 @@ impl GrpcChannel {
                 .ok_or_else(|| response_parsing_error(py, "vector missing 'values'"))?
                 .extract()?;
             let sparse_values = match v.get_item("sparse_values")? {
-                Some(sv) => Some(py_dict_to_sparse_values(&sv.downcast_into::<PyDict>()?)?),
+                Some(sv) => Some(py_dict_to_sparse_values(&sv.cast_into::<PyDict>()?)?),
                 None => None,
             };
             let metadata = match v.get_item("metadata")? {
-                Some(md) => Some(py_dict_to_struct(&md.downcast_into::<PyDict>()?)?),
+                Some(md) => Some(py_dict_to_struct(&md.cast_into::<PyDict>()?)?),
                 None => None,
             };
             proto_vectors.push(proto::Vector {
@@ -714,7 +714,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -798,7 +798,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -859,7 +859,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -924,7 +924,7 @@ impl GrpcChannel {
         let client = self.client.clone();
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
-        py.allow_threads(|| {
+        py.detach(|| {
             self.runtime.block_on(retry_on_transient(&retry_config, || {
                 let mut c = client.clone();
                 let r = request.clone();
@@ -989,7 +989,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -1047,7 +1047,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -1118,7 +1118,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -1196,7 +1196,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -1255,7 +1255,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -1299,7 +1299,7 @@ impl GrpcChannel {
         let client = self.client.clone();
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
-        py.allow_threads(|| {
+        py.detach(|| {
             self.runtime.block_on(retry_on_transient(&retry_config, || {
                 let mut c = client.clone();
                 let r = request.clone();
@@ -1350,7 +1350,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();
@@ -1405,7 +1405,7 @@ impl GrpcChannel {
         let retry_config = self.retry_config.clone();
         #[allow(clippy::result_large_err)]
         let response = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(retry_on_transient(&retry_config, || {
                     let mut c = client.clone();
                     let r = request.clone();

--- a/uv.lock
+++ b/uv.lock
@@ -1225,7 +1225,7 @@ wheels = [
 
 [[package]]
 name = "pinecone"
-version = "9.0.1"
+version = "9.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -1738,11 +1738,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -2007,19 +2007,19 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.5"
+version = "6.5.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
-    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
-    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
-    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Security fast-track (PIN-6)

Clears all **6 high** Dependabot alerts on the Python SDK. Highest-blast-radius SDK after go-pinecone; `pyo3` is a **runtime** dependency (the gRPC extension module), the rest are transitive dev/test deps.

### Runtime dependency
- **pyo3 `0.24` → `0.29`** (`rust/Cargo.toml`, `Cargo.lock`) — fixes *out-of-bounds read in `nth`/`nth_back` for `PyList`/`PyTuple` iterators*.
  - Migrated the extension to the pyo3 0.29 API — all pure renames, no behavioral change:
    - `Python::with_gil` → `Python::attach`
    - `Python::allow_threads` → `Python::detach`
    - `Bound::downcast` / `downcast_into` → `cast` / `cast_into`
    - removed `PyObject` prelude alias → `Py<PyAny>`

### Transitive (dev/test) deps — `uv.lock`
- **tornado `6.5.5` → `6.5.7`** — auth header forwarded across cross-origin redirects + gzip-bomb (2 high)
- **soupsieve `2.8.3` → `2.8.4`** — ReDoS + memory exhaustion in the selector parser (2 high)

### Verification
- `cargo check` + `cargo clippy` clean against pyo3 0.29 ✅
- `maturin develop` builds the abi3 wheel and it imports ✅
- **279 grpc unit tests pass** (18 skipped) — exercises the migrated prost↔Python conversion and error-mapping code paths ✅
- Full integration + smoke suites run in CI.

_Part of the fleet-wide security fast-track. One PR per repo._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> pyo3 is a runtime dependency for the gRPC extension; the changes are mechanical API migrations but touch every Python↔Rust boundary and blocking RPC path, so regressions would affect all gRPC client operations.
> 
> **Overview**
> **Security / dependency bumps** to clear high Dependabot alerts: runtime **pyo3 `0.24` → `0.29`** in `rust/Cargo.toml` with matching `Cargo.lock` updates (drops transitive crates like `indoc`, `memoffset`, `unindent`).
> 
> The gRPC extension in **`transport.rs`** is updated for pyo3 0.29 with **API renames only**—`Python::with_gil` → `Python::attach`, `allow_threads` → `detach`, `downcast`/`downcast_into` → `cast`/`cast_into`, and `PyObject` → `Py<PyAny>` in prost↔Python conversion—across error mapping, metadata handling, throttle callbacks, and all async RPC paths.
> 
> **`uv.lock`** bumps the editable package to **9.1.0** and transitive dev/test deps **tornado `6.5.5` → `6.5.7`** and **soupsieve `2.8.3` → `2.8.4`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 778dce2e20ecac825a519f62d05548a7bce6147e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->