### PR TITLE
security: stop logging raw request body in PINECONE_DEBUG_CURL (CodeQL #83)

### DIFF
--- a/pinecone/_internal/http_client.py
+++ b/pinecone/_internal/http_client.py
@@ -104,7 +104,14 @@ def _log_curl(
     headers: dict[str, str],
     body: bytes | None = None,
 ) -> None:
-    """Log a curl-equivalent command for debugging when PINECONE_DEBUG_CURL is set."""
+    """Log a curl-equivalent command for debugging when PINECONE_DEBUG_CURL is set.
+
+    Sensitive header values (see ``_SENSITIVE_HEADERS``) are redacted. The
+    request body is intentionally *not* logged verbatim: Pinecone request bodies
+    carry user vector and metadata payloads that may contain sensitive data
+    (e.g. PII embedded in metadata). Only the body size is emitted, and a
+    ``--data-binary @body.json`` placeholder shows where to supply it manually.
+    """
     if not os.environ.get("PINECONE_DEBUG_CURL"):
         return
     safe_headers = _redact_headers(headers)
@@ -112,7 +119,7 @@ def _log_curl(
     for key, value in safe_headers.items():
         parts.append(f"-H '{key}: {value}'")
     if body is not None:
-        parts.append(f"-d '{body.decode('utf-8', errors='replace')}'")
+        parts.append(f"--data-binary @body.json  # {len(body)} byte body omitted")
     curl_cmd = " ".join(parts)
     logger.debug("curl equivalent:\n%s", curl_cmd)
 

--- a/tests/unit/test_debug_logging.py
+++ b/tests/unit/test_debug_logging.py
@@ -82,9 +82,11 @@ class TestLogCurl:
         assert "my-secret-key-12345" not in caplog.text
         assert "Api-Key: ***" in caplog.text
 
-    def test_curl_logging_includes_body(
+    def test_curl_logging_omits_body_contents(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
+        # The raw request body must never be logged: it can carry user vector
+        # and metadata payloads (potentially PII). Only the byte count is shown.
         monkeypatch.setenv("PINECONE_DEBUG_CURL", "1")
         body = b'{"vectors": [{"id": "v1"}]}'
         with caplog.at_level(logging.DEBUG, logger="pinecone._internal.http_client"):
@@ -94,8 +96,8 @@ class TestLogCurl:
                 {"Api-Key": "test-key", "Content-Type": "application/json"},
                 body=body,
             )
-        assert "-d " in caplog.text
-        assert '{"vectors": [{"id": "v1"}]}' in caplog.text
+        assert '{"vectors": [{"id": "v1"}]}' not in caplog.text
+        assert f"{len(body)} byte body omitted" in caplog.text
 
     def test_curl_logging_includes_all_headers(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
@@ -144,7 +146,9 @@ class TestHTTPClientCurlLogging:
             finally:
                 client.close()
         assert "curl -X POST" in caplog.text
-        assert "-d " in caplog.text
+        assert "byte body omitted" in caplog.text
+        # Raw request payload must not appear in logs.
+        assert '"id": "v1"' not in caplog.text
 
     @respx.mock
     def test_no_curl_output_when_disabled(


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert **#83** `py/clear-text-logging-sensitive-data` (error/high) at `pinecone/_internal/http_client.py` `_log_curl`.

The `PINECONE_DEBUG_CURL` debug logger previously emitted the raw request body as `-d '<body>'`. CodeQL flags the `body.decode(...)` expression as clear-text logging of sensitive data.

## Change

Stop logging the request body verbatim. Pinecone request bodies carry user vector and metadata payloads that may contain sensitive data (e.g. PII embedded in metadata), so even under the explicit `PINECONE_DEBUG_CURL` opt-in the body is now replaced with:

```
--data-binary @body.json  # <N> byte body omitted
```

This records the payload size and shows where to supply the body manually, while removing the clear-text path to the logger entirely. Sensitive headers (`Api-Key`, `Authorization`, `Proxy-Authorization`) remain redacted as before.

This **removes the finding at the source** rather than dismissing it — no code-scanning `security_events` scope needed.

## Testing

Updated the two tests that asserted raw body content; added assertions that the body contents are absent and the byte-count placeholder is present.

```
uv run pytest tests/unit/test_debug_logging.py tests/unit/_internal/test_http_client_curl_debug.py tests/unit/test_http_client.py -k "curl or log_curl or redact or body"
28 passed, 69 deselected
```

Resolves PIN-27 (child of PIN-16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only, opt-in logging path with no change to request behavior; reduces exposure of user data in logs.
> 
> **Overview**
> **Stops logging raw HTTP request bodies** when `PINECONE_DEBUG_CURL` is enabled, addressing CodeQL clear-text logging of sensitive data in `_log_curl`.
> 
> Instead of emitting `-d '<decoded body>'`, the curl-equivalent debug line now uses `--data-binary @body.json  # <N> byte body omitted`, so payload size is visible without writing vectors/metadata (possible PII) to logs. **Sensitive header redaction is unchanged.**
> 
> Unit tests were updated to assert bodies are absent from logs and the byte-count placeholder is present, including for `HTTPClient.post` integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93062ed04ff273412b689e549c02b9e3179063f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->