### PR TITLE
fix: omit request body from PINECONE_DEBUG_CURL output (CodeQL)

### DIFF
--- a/pinecone/_internal/http_client.py
+++ b/pinecone/_internal/http_client.py
@@ -113,7 +113,9 @@ def _log_curl(
     for key, value in safe_headers.items():
         parts.append(f"-H '{key}: {value}'")
     if body is not None:
-        parts.append(f"-d '{body.decode('utf-8', errors='replace')}'")
+        # Emit body size only; the raw payload may contain vector data that
+        # CodeQL flags as cleartext-logging of potentially sensitive content.
+        parts.append(f"-d '<{len(body)} bytes>'")
     curl_cmd = " ".join(parts)
     logger.debug("curl equivalent:\n%s", curl_cmd)
 

--- a/tests/unit/test_debug_logging.py
+++ b/tests/unit/test_debug_logging.py
@@ -82,7 +82,7 @@ class TestLogCurl:
         assert "my-secret-key-12345" not in caplog.text
         assert "Api-Key: ***" in caplog.text
 
-    def test_curl_logging_includes_body(
+    def test_curl_logging_omits_body_content(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
         monkeypatch.setenv("PINECONE_DEBUG_CURL", "1")
@@ -94,8 +94,12 @@ class TestLogCurl:
                 {"Api-Key": "test-key", "Content-Type": "application/json"},
                 body=body,
             )
+        # The request body may carry vector data / user content, so the debug
+        # curl output logs only its size, never the raw payload (CodeQL
+        # cleartext-logging remediation — see _log_curl).
         assert "-d " in caplog.text
-        assert '{"vectors": [{"id": "v1"}]}' in caplog.text
+        assert f"<{len(body)} bytes>" in caplog.text
+        assert '{"vectors": [{"id": "v1"}]}' not in caplog.text
 
     def test_curl_logging_includes_all_headers(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Summary
Resolves CodeQL `py/clear-text-logging-sensitive-data` alert #83 at `pinecone/_internal/http_client.py:118`.

## Problem
`_log_curl` logs a curl-equivalent command for debugging (only when `PINECONE_DEBUG_CURL` is set). It included the raw request body via `body.decode()`, which CodeQL flags as cleartext logging of sensitive data. The body contains request payloads (vectors, query parameters, etc.).

## Fix
Replace the raw body with `'<N bytes>'` in the curl output. This:
- Removes the taint source, resolving the CodeQL alert.
- Preserves the body length for debugging context.
- Keeps full diagnostic value for the method, URL, and (already-redacted) headers.

The API key is already redacted by `_redact_headers` — this change covers the body.

## Verification
No behavior change to production code paths — `_log_curl` only executes when `PINECONE_DEBUG_CURL` is set and logs at `DEBUG` level.

Part of PIN-16 / PIN-27 (security tail), child of PIN-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to optional DEBUG curl logging behind an env var; no production request or API behavior changes.
> 
> **Overview**
> When **`PINECONE_DEBUG_CURL`** is enabled, **`_log_curl`** no longer writes the decoded request body into the debug curl line. It logs **`<N bytes>`** instead, so vector payloads and other request data are not written to logs while method, URL, and redacted headers stay useful for debugging.
> 
> Unit coverage is updated so the curl output asserts on byte length and confirms the JSON body is **not** present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22719d793082de815ddaeb5faaee09e17a98b528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->