### PR TITLE
fix(index): teach the keyword-only call shape when upsert_records gets positional args

### DIFF
--- a/pinecone/_internal/validation.py
+++ b/pinecone/_internal/validation.py
@@ -2,10 +2,54 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, overload
+import functools
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, ParamSpec, TypeVar, cast, overload
 
-from pinecone.errors.exceptions import ValidationError
+from pinecone.errors.exceptions import PineconeTypeError, ValidationError
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def reject_positional_args(example: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
+    """Give a keyword-only instance method a teaching error on positional misuse.
+
+    The interpreter's own failure ("takes 1 positional argument but N were
+    given") names neither the parameters nor the fix. This guard raises
+    :class:`PineconeTypeError` (a ``TypeError`` subclass) carrying *example*,
+    the exact call shape to use instead. ``inspect.signature`` still reports
+    the wrapped method's real keyword-only signature via ``__wrapped__``.
+    The bound ``self`` is the only positional argument allowed through.
+    """
+
+    def decorate(fn: Callable[_P, _R]) -> Callable[_P, _R]:
+        message = (
+            f"{fn.__name__}() accepts keyword arguments only: {example}. "
+            "Positional arguments are rejected because the parameter order "
+            "changed across SDK generations."
+        )
+        if inspect.iscoroutinefunction(fn):
+            async_fn = cast("Callable[_P, Awaitable[_R]]", fn)
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+                if len(args) > 1:
+                    raise PineconeTypeError(message)
+                return await async_fn(*args, **kwargs)
+
+            return cast("Callable[_P, _R]", async_wrapper)
+
+        @functools.wraps(fn)
+        def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            if len(args) > 1:
+                raise PineconeTypeError(message)
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorate
 
 
 @overload

--- a/pinecone/_internal/validation.py
+++ b/pinecone/_internal/validation.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import functools
 import inspect
-from collections.abc import Awaitable, Callable, Sequence
-from typing import Any, ParamSpec, TypeVar, cast, overload
+import sys
+from collections.abc import Callable, Sequence
+from typing import Any, ParamSpec, TypeVar, overload
 
 from pinecone.errors.exceptions import PineconeTypeError, ValidationError
 
@@ -19,9 +20,14 @@ def reject_positional_args(example: str) -> Callable[[Callable[_P, _R]], Callabl
     The interpreter's own failure ("takes 1 positional argument but N were
     given") names neither the parameters nor the fix. This guard raises
     :class:`PineconeTypeError` (a ``TypeError`` subclass) carrying *example*,
-    the exact call shape to use instead. ``inspect.signature`` still reports
-    the wrapped method's real keyword-only signature via ``__wrapped__``.
-    The bound ``self`` is the only positional argument allowed through.
+    the exact call shape to use instead. The wrapper is a plain function even
+    for async methods, so the check runs at call time — before the coroutine
+    is created — matching native keyword-only binding rather than deferring
+    the error to await. ``inspect.signature`` still reports the wrapped
+    method's real keyword-only signature via ``__wrapped__``; on Python 3.12+
+    an async method's wrapper is also marked for
+    ``inspect.iscoroutinefunction``. The bound ``self`` is the only
+    positional argument allowed through.
     """
 
     def decorate(fn: Callable[_P, _R]) -> Callable[_P, _R]:
@@ -30,16 +36,6 @@ def reject_positional_args(example: str) -> Callable[[Callable[_P, _R]], Callabl
             "Positional arguments are rejected because the parameter order "
             "changed across SDK generations."
         )
-        if inspect.iscoroutinefunction(fn):
-            async_fn = cast("Callable[_P, Awaitable[_R]]", fn)
-
-            @functools.wraps(fn)
-            async def async_wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-                if len(args) > 1:
-                    raise PineconeTypeError(message)
-                return await async_fn(*args, **kwargs)
-
-            return cast("Callable[_P, _R]", async_wrapper)
 
         @functools.wraps(fn)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
@@ -47,6 +43,8 @@ def reject_positional_args(example: str) -> Callable[[Callable[_P, _R]], Callabl
                 raise PineconeTypeError(message)
             return fn(*args, **kwargs)
 
+        if sys.version_info >= (3, 12) and inspect.iscoroutinefunction(fn):
+            inspect.markcoroutinefunction(wrapper)
         return wrapper
 
     return decorate

--- a/pinecone/async_client/async_index.py
+++ b/pinecone/async_client/async_index.py
@@ -23,7 +23,11 @@ from pinecone._internal.data_plane_helpers import (
     _validate_host,
     _vector_to_dict,
 )
-from pinecone._internal.validation import require_in_range, require_positive
+from pinecone._internal.validation import (
+    reject_positional_args,
+    require_in_range,
+    require_positive,
+)
 from pinecone._internal.vector_factory import VectorFactory
 from pinecone.errors.exceptions import PineconeValueError, ValidationError
 from pinecone.models.imports.list import ImportList
@@ -138,6 +142,7 @@ class AsyncIndex:
         """The data plane host URL for this index."""
         return self._host
 
+    @reject_positional_args('upsert_records(namespace="...", records=[...])')
     async def upsert_records(
         self,
         *,

--- a/pinecone/grpc/__init__.py
+++ b/pinecone/grpc/__init__.py
@@ -19,7 +19,11 @@ from pinecone._internal.batching import chunked, validate_batch_size, with_progr
 from pinecone._internal.config import PineconeConfig
 from pinecone._internal.constants import DATA_PLANE_API_VERSION
 from pinecone._internal.data_plane_helpers import _build_search_records_body, _validate_host
-from pinecone._internal.validation import require_in_range, require_positive
+from pinecone._internal.validation import (
+    reject_positional_args,
+    require_in_range,
+    require_positive,
+)
 from pinecone._internal.vector_factory import VectorFactory
 from pinecone.errors.exceptions import (
     PineconeValueError,
@@ -1312,6 +1316,7 @@ class GrpcIndex:
             )
         )
 
+    @reject_positional_args('upsert_records(namespace="...", records=[...])')
     def upsert_records(
         self,
         *,

--- a/pinecone/index/__init__.py
+++ b/pinecone/index/__init__.py
@@ -22,7 +22,11 @@ from pinecone._internal.data_plane_helpers import (
     _validate_host,
     _vector_to_dict,
 )
-from pinecone._internal.validation import require_in_range, require_positive
+from pinecone._internal.validation import (
+    reject_positional_args,
+    require_in_range,
+    require_positive,
+)
 from pinecone._internal.vector_factory import VectorFactory
 from pinecone.errors.exceptions import PineconeValueError, ValidationError
 from pinecone.models.imports.list import ImportList
@@ -465,6 +469,7 @@ class Index:
             timeout=timeout,
         )
 
+    @reject_positional_args('upsert_records(namespace="...", records=[...])')
     def upsert_records(
         self,
         *,

--- a/tests/unit/test_async_upsert_records.py
+++ b/tests/unit/test_async_upsert_records.py
@@ -150,3 +150,13 @@ class TestAsyncUpsertRecords:
         message = str(excinfo.value)
         assert "keyword arguments only" in message
         assert 'upsert_records(namespace="...", records=[...])' in message
+
+    def test_async_upsert_records_positional_error_raises_at_call_time(self) -> None:
+        """The guard fires at the call, before any coroutine is created.
+
+        A deferred (await-time) error would hand back a coroutine and a
+        'never awaited' warning instead of the teaching message.
+        """
+        idx = _make_async_index()
+        with pytest.raises(PineconeTypeError):
+            idx.upsert_records("test-ns", [{"_id": "r1"}])  # type: ignore[misc]

--- a/tests/unit/test_async_upsert_records.py
+++ b/tests/unit/test_async_upsert_records.py
@@ -9,7 +9,7 @@ import pytest
 import respx
 
 from pinecone.async_client.async_index import AsyncIndex
-from pinecone.errors.exceptions import ValidationError
+from pinecone.errors.exceptions import PineconeTypeError, ValidationError
 from pinecone.models.vectors.responses import UpsertRecordsResponse
 
 INDEX_HOST = "my-index-abc123.svc.pinecone.io"
@@ -140,3 +140,13 @@ class TestAsyncUpsertRecords:
                 namespace="test-ns",
                 records=[{"_id": 123, "text": "hello"}],
             )
+
+    @pytest.mark.anyio
+    async def test_async_upsert_records_positional_args_raise_teaching_error(self) -> None:
+        """Positional misuse names the keyword-only call shape, not a bare TypeError."""
+        idx = _make_async_index()
+        with pytest.raises(PineconeTypeError) as excinfo:
+            await idx.upsert_records("test-ns", [{"_id": "r1", "text": "hello"}])  # type: ignore[misc]
+        message = str(excinfo.value)
+        assert "keyword arguments only" in message
+        assert 'upsert_records(namespace="...", records=[...])' in message

--- a/tests/unit/test_grpc_index.py
+++ b/tests/unit/test_grpc_index.py
@@ -18,6 +18,7 @@ from pinecone.errors.exceptions import (
     NotFoundError,
     PineconeConnectionError,
     PineconeTimeoutError,
+    PineconeTypeError,
     ServiceError,
     UnauthorizedError,
     ValidationError,
@@ -985,6 +986,17 @@ _SEARCH_RESPONSE: dict[str, object] = {
 
 class TestGrpcIndexUpsertRecords:
     """GrpcIndex.upsert_records() delegates to REST (NDJSON) endpoint."""
+
+    def test_upsert_records_positional_args_raise_teaching_error(
+        self, mock_channel: MagicMock
+    ) -> None:
+        """Positional misuse names the keyword-only call shape, not a bare TypeError."""
+        idx = _make_grpc_index(mock_channel, host=_INDEX_HOST)
+        with pytest.raises(PineconeTypeError) as excinfo:
+            idx.upsert_records("test-ns", [{"_id": "r1", "text": "hello"}])  # type: ignore[misc]
+        message = str(excinfo.value)
+        assert "keyword arguments only" in message
+        assert 'upsert_records(namespace="...", records=[...])' in message
 
     @respx.mock
     def test_upsert_records_basic(self, mock_channel: MagicMock) -> None:

--- a/tests/unit/test_upsert_records.py
+++ b/tests/unit/test_upsert_records.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 
 import httpx
@@ -9,7 +10,7 @@ import pytest
 import respx
 
 from pinecone import Index
-from pinecone.errors.exceptions import ValidationError
+from pinecone.errors.exceptions import PineconeTypeError, ValidationError
 from pinecone.models.vectors.responses import UpsertRecordsResponse
 
 INDEX_HOST = "my-index-abc123.svc.pinecone.io"
@@ -168,6 +169,20 @@ class TestUpsertRecords:
         idx = _make_index()
         with pytest.raises(TypeError):
             idx.upsert_records([{"_id": "r1"}], "test-ns")  # type: ignore[misc]
+
+    def test_upsert_records_positional_args_raise_teaching_error(self) -> None:
+        """Positional misuse names the keyword-only call shape, not a bare TypeError."""
+        idx = _make_index()
+        with pytest.raises(PineconeTypeError) as excinfo:
+            idx.upsert_records("test-ns", [{"_id": "r1", "text": "hello"}])  # type: ignore[misc]
+        message = str(excinfo.value)
+        assert "keyword arguments only" in message
+        assert 'upsert_records(namespace="...", records=[...])' in message
+
+    def test_upsert_records_signature_reports_keyword_only_params(self) -> None:
+        params = inspect.signature(Index.upsert_records).parameters
+        assert params["records"].kind is inspect.Parameter.KEYWORD_ONLY
+        assert params["namespace"].kind is inspect.Parameter.KEYWORD_ONLY
 
     @respx.mock
     def test_upsert_records_preserves_metadata_fields(self) -> None:


### PR DESCRIPTION
## Problem

`index.upsert_records("ns", records)` fails with the interpreter's bare `TypeError: Index.upsert_records() takes 1 positional argument but 3 were given` — naming neither the parameters nor the fix. The keyword-only contract is deliberate and stays (parameter order changed across SDK generations, so accepting positionals would silently mis-bind old-style calls); the failure just needs to say so.

## Fix

New `reject_positional_args(example)` guard in `_internal/validation.py`, applied to the sync, async, and gRPC `upsert_records`:

```
PineconeTypeError: upsert_records() accepts keyword arguments only: upsert_records(namespace="...", records=[...]). Positional arguments are rejected because the parameter order changed across SDK generations.
```

- `PineconeTypeError` subclasses `TypeError`, so existing `except TypeError` handlers (and the existing `test_upsert_records_keyword_only` test) keep working unchanged.
- `functools.wraps` preserves `__wrapped__`, so `inspect.signature()` still reports the real keyword-only signature — verified by a new test.
- The guard is reusable for other keyword-only methods if the pattern proves useful.

## Testing

- New unit tests for sync/async/gRPC positional misuse (message content) + signature introspection.
- `uv run pytest tests/unit`: 4603 passed (socket_options linux/darwin failures are pre-existing on macOS main, untouched).
- `ruff check`, `ruff format --check`, `mypy --strict` clean on all touched files.

Fixes #691

Found by a cold-agent audit: 2/2 SDK-path agents guessed the positional form and burned 3–4 turns on the bare TypeError; one read the SDK source to find the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to error messaging for invalid call sites; successful keyword-only calls are unchanged and `PineconeTypeError` remains a `TypeError` subclass for existing handlers.
> 
> **Overview**
> Adds a reusable **`reject_positional_args`** decorator in `pinecone/_internal/validation.py` and applies it to **`upsert_records`** on sync `Index`, `AsyncIndex`, and `GrpcIndex`.
> 
> When callers pass extra positional arguments (e.g. `upsert_records("ns", records)`), the SDK now raises **`PineconeTypeError`** with the correct keyword-only example and a note that parameter order changed across SDK generations—instead of Python’s generic “takes 1 positional argument but N were given.” The wrapper still allows only `self` positionally, preserves **`inspect.signature`** via `functools.wraps`, and for async methods fails at **call time** (before a coroutine is created); on Python 3.12+ async wrappers are marked for `inspect.iscoroutinefunction`.
> 
> Unit tests cover message content for sync/async/gRPC, async call-time behavior, and keyword-only signature introspection on `Index.upsert_records`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac800ea8b30b9bf1332d81883d7da8c3c1305c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->