### PR TITLE
fix(models): teach the id/score aliases when Hit is accessed with wire keys

### DIFF
--- a/pinecone/models/vectors/search.py
+++ b/pinecone/models/vectors/search.py
@@ -83,6 +83,9 @@ class SearchUsage(StructDictMixin, Struct, kw_only=True):
     rerank_units: int | None = None
 
 
+_WIRE_KEY_ALIASES = {"_id": "id", "_score": "score"}
+
+
 class Hit(StructDictMixin, Struct, kw_only=True, rename={"id_": "_id", "score_": "_score"}):
     """A single search result hit.
 
@@ -117,7 +120,15 @@ class Hit(StructDictMixin, Struct, kw_only=True, rename={"id_": "_id", "score_":
         if key == "score":
             return self.score_
         if key not in self.__struct_fields__:
-            raise KeyError(key)
+            alias = _WIRE_KEY_ALIASES.get(key)
+            if alias is not None:
+                raise KeyError(
+                    f"{key!r} is the wire name for this field; use hit[{alias!r}] or hit.{alias}"
+                )
+            raise KeyError(
+                f"{key!r}; available keys are 'id', 'score', and 'fields' "
+                "(record fields live in hit['fields'])"
+            )
         return getattr(self, key)
 
     def __contains__(self, key: object) -> bool:

--- a/tests/unit/test_search_models.py
+++ b/tests/unit/test_search_models.py
@@ -35,6 +35,29 @@ class TestHit:
         with pytest.raises(KeyError, match="nonexistent"):
             hit["nonexistent"]
 
+    def test_hit_bracket_missing_key_lists_available_keys(self) -> None:
+        hit = Hit(id_="r1", score_=0.5)
+        with pytest.raises(KeyError) as excinfo:
+            hit["nonexistent"]
+        assert "available keys" in str(excinfo.value)
+
+    def test_hit_bracket_wire_name_id_teaches_alias(self) -> None:
+        """The wire format calls the field '_id'; the error must point at hit['id']."""
+        hit = Hit(id_="r1", score_=0.5)
+        with pytest.raises(KeyError) as excinfo:
+            hit["_id"]
+        message = str(excinfo.value)
+        assert "wire name" in message
+        assert "hit['id']" in message
+
+    def test_hit_bracket_wire_name_score_teaches_alias(self) -> None:
+        hit = Hit(id_="r1", score_=0.5)
+        with pytest.raises(KeyError) as excinfo:
+            hit["_score"]
+        message = str(excinfo.value)
+        assert "wire name" in message
+        assert "hit['score']" in message
+
 
 class TestSearchUsage:
     def test_search_usage_required_only(self) -> None:


### PR DESCRIPTION
## Problem

The search wire format names the hit fields `_id` and `_score` — that's what upserted records and raw REST examples show — so `hit["_id"]` is the natural first guess. It raised a bare `KeyError: '_id'` even though the value exists under the renamed attribute.

## Fix

`Hit.__getitem__` now teaches:

- `hit["_id"]` → `KeyError: '_id' is the wire name for this field; use hit['id'] or hit.id` (same for `_score` → `score`).
- Other unknown keys → `KeyError: 'x'; available keys are 'id', 'score', and 'fields' (record fields live in hit['fields'])`.

Read semantics are unchanged — the wire keys are still not accepted as aliases (the error steers to the canonical names). If maintainers would rather accept `_id`/`_score` as read aliases outright, happy to follow up; this is the smaller change.

## Testing

- New unit tests for both wire-name errors and the available-keys message; existing `match="nonexistent"` test unaffected.
- `uv run pytest tests/unit`: 4602 passed (socket_options linux/darwin failures are pre-existing on macOS main, untouched).
- `ruff check`, `ruff format --check`, `mypy --strict` clean on touched files.

Fixes #692

Found by a cold-agent audit: 2/2 SDK-path agents wrote `hit["_id"]` and had to read `models/vectors/search.py` to discover `.id`/`.score`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-message-only change on invalid key paths; no change to successful access or serialization.
> 
> **Overview**
> **`Hit.__getitem__`** now raises guided **`KeyError`**s instead of bare missing-key errors when bracket access uses API wire names or unknown keys.
> 
> Indexing with **`_id`** or **`_score`** still does not return values; the error explains they are wire names and points to **`hit['id']`**, **`hit.id`**, **`hit['score']`**, or **`hit.score`**. Other invalid keys get a message listing **`id`**, **`score`**, and **`fields`**, with a note that record payload lives under **`hit['fields']`**.
> 
> Unit tests cover the wire-name hints and the available-keys message; successful **`id`** / **`score`** / **`fields`** access is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0430d2464af0299f593d9a853f714170275fcede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->